### PR TITLE
Gate all SES sends behind EMAILS_ENABLED env var

### DIFF
--- a/apps/next/utils/email/email-send.tsx
+++ b/apps/next/utils/email/email-send.tsx
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto'
 import { ListContactsResponse, SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2'
 // import { getSesClient, SendEmailCommand } from './MockSesSendEmail'
-import { getSesClient } from './sesClient'
+import { emailsEnabled, getSesClient } from './sesClient'
 import { getContacts } from './contact'
 import { chunkArray } from '../chunkArray'
 import { generateEcclesiaUpdateUrl } from './ecclesia-token'
@@ -130,6 +130,13 @@ export const emailSend = async function ({
   }
 
   const campaignId = randomUUID()
+
+  if (!emailsEnabled()) {
+    console.log(
+      `[emailSend] Skipped — EMAILS_ENABLED=false (deployment=${process.env.DEPLOYMENT_NAME ?? 'unknown'}, reason=${reason}, test=${test})`
+    )
+    return { sends: [], skips: [], campaignId }
+  }
 
   try {
     // For custom emails, use the provided list, otherwise use the default for that reason

--- a/apps/next/utils/email/sesClient.ts
+++ b/apps/next/utils/email/sesClient.ts
@@ -42,6 +42,14 @@ export function getSesClient(): SESv2Client {
   return sesConnection.value as SESv2Client
 }
 
+// Deployment-scoped email kill switch. Set EMAILS_ENABLED=false on
+// non-production deployments (e.g. echadhub pre-prod) to prevent any
+// outbound mail — both bulk sends (emailSend) and transactional sends
+// (sendEmail). Default behaviour is enabled.
+export function emailsEnabled(): boolean {
+  return process.env.EMAILS_ENABLED !== 'false'
+}
+
 export interface SendEmailProps {
   to: string
   subject: string
@@ -50,8 +58,15 @@ export interface SendEmailProps {
 }
 
 export async function sendEmail({ to, subject, body, textBody }: SendEmailProps): Promise<void> {
+  if (!emailsEnabled()) {
+    console.log(
+      `[sendEmail] Skipped — EMAILS_ENABLED=false (deployment=${process.env.DEPLOYMENT_NAME ?? 'unknown'}, to=${to})`
+    )
+    return
+  }
+
   const sesClient = getSesClient()
-  
+
   const emailCmd = new SendEmailCommand({
     FromEmailAddress: '"TEE Admin" <noreply@tee-admin.com>',
     Destination: {


### PR DESCRIPTION
## Summary
- Adds `emailsEnabled()` helper in `sesClient.ts` reading `process.env.EMAILS_ENABLED`
- Gates `emailSend()` (bulk: newsletter, bible-class, recap, business-meeting, inter-ecclesia, custom, event-announcement) — returns empty `SendResult` when disabled
- Gates `sendEmail()` (transactional: OTP, verification, RB confirmation, connection, email-change) — returns early when disabled
- Default unset = enabled. tee-admin's production behaviour is unchanged

## Why
Setting up a parallel Vercel project (`echadhub`) that shares this repo, same DynamoDB tables, and same SES account. Both projects will register the same Vercel crons (defined in `apps/next/vercel.json`), which means without a kill switch, echadhub's first cron tick would email real members from a non-production deployment. This gate lets `EMAILS_ENABLED=false` on echadhub disable every outbound path in two chokepoints — no risk of missing one.

## Test plan
- [x] `yarn workspace next-app typecheck` passes
- [ ] Verify on echadhub deploy: cron fires, log shows `[emailSend] Skipped — EMAILS_ENABLED=false`, no SES bill
- [ ] Verify tee-admin Thursday cron continues to send (unset env var = enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)