### PR TITLE
Hostname-to-tenant resolver middleware

### DIFF
--- a/apps/next/middleware.ts
+++ b/apps/next/middleware.ts
@@ -1,11 +1,23 @@
 import { auth } from './utils/auth'
 import { NextResponse } from 'next/server'
 import type { NextAuthRequest } from 'next-auth/lib'
+import { getTenantByHost } from '@my/app/config/tenants'
 
 const ANALYTICS_KEY = process.env.ANALYTICS_INTERNAL_KEY
 
 export default auth((req: NextAuthRequest) => {
   const { pathname } = req.nextUrl
+
+  // Resolve tenant from Host header and forward as `x-tenant-id` so
+  // downstream API routes don't need to redo the lookup. tee-admin.com
+  // → 'tee', echadhub.org / .com → 'echadhub'. Unknown hosts get no
+  // header set; consumers decide their own fallback strategy.
+  const tenant = getTenantByHost(req.headers.get('host'))
+  const forwardedHeaders = new Headers(req.headers)
+  if (tenant) {
+    forwardedHeaders.set('x-tenant-id', tenant.id)
+  }
+  const passthrough = () => NextResponse.next({ request: { headers: forwardedHeaders } })
 
   // Check if user is trying to access profile page
   if (pathname.startsWith('/profile')) {
@@ -17,7 +29,7 @@ export default auth((req: NextAuthRequest) => {
     if (!req.auth) {
       if (isFromAuth) {
         // Allow the request through - the page itself will handle auth checking
-        return NextResponse.next()
+        return passthrough()
       } else {
         return NextResponse.redirect(new URL('/auth/signin', req.url))
       }
@@ -59,7 +71,7 @@ export default auth((req: NextAuthRequest) => {
     })
   }
 
-  return NextResponse.next()
+  return passthrough()
 })
 
 export const config = {

--- a/packages/app/config/tenants.ts
+++ b/packages/app/config/tenants.ts
@@ -1,0 +1,86 @@
+// Tenant identity per request. Resolves the incoming Host header to
+// a TenantConfig that downstream code uses to decide outbound-mail
+// sender, brand, etc. Must stay Edge-safe (no Node imports) so the
+// Next.js middleware can import it.
+
+export type TenantId = 'tee' | 'echadhub'
+
+export interface TenantConfig {
+  id: TenantId
+  /** Bare-domain part of the canonical sender address (no `@`) */
+  senderDomain: string
+  /** Display name used as the From-name on outbound mail */
+  senderDisplayName: string
+}
+
+const TENANTS: Record<TenantId, TenantConfig> = {
+  tee: {
+    id: 'tee',
+    senderDomain: 'tee-admin.com',
+    senderDisplayName: 'Toronto East Ecclesia',
+  },
+  echadhub: {
+    id: 'echadhub',
+    senderDomain: 'echadhub.org',
+    senderDisplayName: 'Echad Hub',
+  },
+}
+
+const HOST_TO_TENANT: Record<string, TenantId> = {
+  'tee-admin.com': 'tee',
+  'www.tee-admin.com': 'tee',
+  'echadhub.org': 'echadhub',
+  'www.echadhub.org': 'echadhub',
+  'echadhub.com': 'echadhub',
+  'www.echadhub.com': 'echadhub',
+}
+
+/**
+ * Resolve a Host header value to a TenantConfig. Returns null when
+ * the host is unknown — callers decide whether to fall back to a
+ * deployment-scoped default or refuse to proceed (e.g. email send
+ * should refuse rather than silently default to TEE).
+ *
+ * Handles port suffixes (`localhost:3000`) and casing.
+ */
+export function getTenantByHost(host: string | null | undefined): TenantConfig | null {
+  if (!host) return null
+  const cleanHost = host.split(':')[0]?.toLowerCase()
+  if (!cleanHost) return null
+  const tenantId = HOST_TO_TENANT[cleanHost]
+  return tenantId ? TENANTS[tenantId] : null
+}
+
+/**
+ * Look up a TenantConfig by its TenantId. Used when the deployment
+ * is identified by env var (e.g. cron jobs without a request context)
+ * rather than by Host header.
+ */
+export function getTenantById(id: TenantId): TenantConfig {
+  return TENANTS[id]
+}
+
+/**
+ * Resolve a TenantConfig from headers (request or response Headers,
+ * Pages-Router-style plain object, or anything with a `.get()` /
+ * indexable shape). Reads `x-tenant-id` first (set by middleware),
+ * falls back to host-based resolution.
+ */
+export function getTenantFromHeaders(
+  headers: { get(name: string): string | null } | Record<string, string | string[] | undefined>
+): TenantConfig | null {
+  const get = (name: string): string | null => {
+    if (typeof (headers as { get?: unknown }).get === 'function') {
+      return (headers as { get(n: string): string | null }).get(name)
+    }
+    const v = (headers as Record<string, string | string[] | undefined>)[name]
+    if (Array.isArray(v)) return v[0] ?? null
+    return v ?? null
+  }
+
+  const tenantId = get('x-tenant-id')
+  if (tenantId && (tenantId === 'tee' || tenantId === 'echadhub')) {
+    return TENANTS[tenantId]
+  }
+  return getTenantByHost(get('host'))
+}


### PR DESCRIPTION
## Summary
Adds an Edge-safe tenant resolver and integrates it into the existing Next.js middleware. Foundation for per-request, per-tenant behavior — the next PR will use this to pick outbound-mail sender domain.

## What changes

**New: `packages/app/config/tenants.ts`**
- `TenantId = 'tee' | 'echadhub'`
- `TenantConfig` carries `senderDomain` + `senderDisplayName` (per the multi-brand sender model)
- Static `HOST_TO_TENANT` map: `tee-admin.com` + `www.tee-admin.com` → `tee`; `echadhub.org/.com` + `www.echadhub.org/.com` → `echadhub`
- Helpers: `getTenantByHost(host)`, `getTenantById(id)`, `getTenantFromHeaders(headers)` — works for both Web Headers objects and Pages-Router-style plain objects

**Modified: `apps/next/middleware.ts`**
- Resolves tenant from `Host` once at the top, sets `x-tenant-id` on the forwarded request headers via `NextResponse.next({ request: { headers } })`
- Existing NextAuth + analytics behavior unchanged
- Unknown hosts get no header — consumers pick their fallback strategy

## Why
- Today: each Vercel project serves one branded domain, so deployment-level env vars (`DEPLOYMENT_NAME`, `NEXT_PUBLIC_BRAND`) are sufficient.
- Soon: as multi-domain serving expands (e.g. one Vercel project hosting multiple ecclesia domains), we need per-request tenant resolution. This middleware is the foundation.
- Edge-safe: no Node-only imports, so it works in Next.js Edge runtime where middleware runs.

## Test plan
- [x] `yarn workspace next-app typecheck` passes
- [x] `cd apps/next && yarn build` succeeds (middleware compiles, 163kB)
- [ ] After merge: confirm `x-tenant-id: tee` appears on tee-admin requests, `x-tenant-id: echadhub` on echadhub requests
- [ ] Confirm preview deploys still work for branches (middleware doesn't break ungated paths)

## Why no fallback to "TEE" for unknown hosts
Per the memory note `project_multi_domain_tenant_resolution.md`: "Fallback for unrecognized hosts: show a landing/unknown-tenant page, do NOT silently default to Toronto East." The middleware leaves unknown hosts untagged so downstream code can pick the right behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)