### PR TITLE
Pending notes for cron-fired emails

### DIFF
--- a/apps/next/app/api/email/cron-schedules/route.ts
+++ b/apps/next/app/api/email/cron-schedules/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from 'next/server'
+import { auth } from '../../../../utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+// vercel.json is the authoritative cron list right now (DB-driven EventBridge
+// system isn't live yet). Imported via resolveJsonModule so the file is
+// bundled into the serverless function — no runtime fs read.
+import vercelConfig from '../../../../vercel.json'
+
+interface VercelCron {
+  path: string
+  schedule: string
+}
+
+interface ScheduledEmail {
+  reason: string
+  cronExpression: string
+  nextFiringUtcMs: number
+}
+
+const REASON_FROM_PATH = /^\/api\/email\/([a-z-]+)$/
+
+// Parse a single field of a cron expression that may be "*", a single int,
+// or a comma-separated list. Returns null for unsupported forms (ranges,
+// step values, etc.) so we can fall back gracefully.
+function parseCronField(field: string, min: number, max: number): number[] | null {
+  if (field === '*') {
+    const out: number[] = []
+    for (let i = min; i <= max; i++) out.push(i)
+    return out
+  }
+  const values: number[] = []
+  for (const part of field.split(',')) {
+    const n = Number(part)
+    if (!Number.isInteger(n) || n < min || n > max) return null
+    values.push(n)
+  }
+  return values
+}
+
+// Compute the next firing time (UTC ms) for a cron expression. Vercel cron
+// always runs in UTC.
+function nextFiringUtcMs(expression: string, fromMs = Date.now()): number | null {
+  const parts = expression.trim().split(/\s+/)
+  if (parts.length !== 5) return null
+  const [m, h, dom, mon, dow] = parts
+
+  // We only support paths that fire on day-of-week (the only shape used in
+  // vercel.json today). day-of-month and month must be wildcards.
+  if (dom !== '*' || mon !== '*') return null
+
+  const minutes = parseCronField(m, 0, 59)
+  const hours = parseCronField(h, 0, 23)
+  const daysOfWeek = parseCronField(dow, 0, 6)
+  if (!minutes || !hours || !daysOfWeek) return null
+
+  // Walk forward up to 7 days looking for the next matching slot
+  const from = new Date(fromMs)
+  for (let dayOffset = 0; dayOffset < 8; dayOffset++) {
+    const candidate = new Date(Date.UTC(
+      from.getUTCFullYear(),
+      from.getUTCMonth(),
+      from.getUTCDate() + dayOffset
+    ))
+    if (!daysOfWeek.includes(candidate.getUTCDay())) continue
+    for (const hour of hours) {
+      for (const minute of minutes) {
+        const slot = Date.UTC(
+          candidate.getUTCFullYear(),
+          candidate.getUTCMonth(),
+          candidate.getUTCDate(),
+          hour,
+          minute
+        )
+        if (slot > fromMs) return slot
+      }
+    }
+  }
+  return null
+}
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
+  const userRole = session.user.role
+  if (!userRole || ![ROLES.OWNER, ROLES.ADMIN].includes(userRole)) {
+    return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 })
+  }
+
+  const crons = ((vercelConfig as { crons?: VercelCron[] }).crons) ?? []
+  const now = Date.now()
+  const schedules: ScheduledEmail[] = crons
+    .map((c): ScheduledEmail | null => {
+      const reasonMatch = REASON_FROM_PATH.exec(c.path)
+      if (!reasonMatch) return null
+      const next = nextFiringUtcMs(c.schedule, now)
+      if (next == null) return null
+      return {
+        reason: reasonMatch[1],
+        cronExpression: c.schedule,
+        nextFiringUtcMs: next,
+      }
+    })
+    .filter((s): s is ScheduledEmail => s !== null)
+    .sort((a, b) => a.nextFiringUtcMs - b.nextFiringUtcMs)
+
+  return NextResponse.json({ schedules })
+}

--- a/apps/next/app/api/email/pending-note/route.ts
+++ b/apps/next/app/api/email/pending-note/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '../../../../utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+import { pendingEmailNoteRepository } from '@my/app/provider/dynamodb/repositories/pending-email-note-repository'
+import type { EmailReasonType } from '@my/app/types'
+
+const ALLOWED_REASONS: EmailReasonType[] = [
+  'newsletter',
+  'recap',
+  'bible-class',
+  'sunday-school',
+]
+
+const MAX_NOTE_LENGTH = 500
+
+export async function POST(request: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
+  const userRole = session.user.role
+  if (!userRole || ![ROLES.OWNER, ROLES.ADMIN].includes(userRole)) {
+    return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 })
+  }
+
+  let body: { reason?: string; note?: string; clear?: boolean }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const { reason, note, clear } = body
+  if (!reason || !ALLOWED_REASONS.includes(reason as EmailReasonType)) {
+    return NextResponse.json(
+      { error: `reason must be one of: ${ALLOWED_REASONS.join(', ')}` },
+      { status: 400 }
+    )
+  }
+
+  const typedReason = reason as EmailReasonType
+
+  if (clear) {
+    await pendingEmailNoteRepository.clearNote(typedReason)
+    return NextResponse.json({ ok: true, cleared: true, reason: typedReason })
+  }
+
+  const trimmed = (note ?? '').trim()
+  if (!trimmed) {
+    return NextResponse.json({ error: 'note is required' }, { status: 400 })
+  }
+  if (trimmed.length > MAX_NOTE_LENGTH) {
+    return NextResponse.json(
+      { error: `note exceeds ${MAX_NOTE_LENGTH} characters` },
+      { status: 400 }
+    )
+  }
+
+  await pendingEmailNoteRepository.saveNote(typedReason, trimmed, session.user.email)
+
+  return NextResponse.json({ ok: true, reason: typedReason, note: trimmed })
+}
+
+export async function GET(request: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
+  const userRole = session.user.role
+  if (!userRole || ![ROLES.OWNER, ROLES.ADMIN].includes(userRole)) {
+    return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 })
+  }
+
+  const reason = request.nextUrl.searchParams.get('reason') as EmailReasonType | null
+  if (!reason || !ALLOWED_REASONS.includes(reason)) {
+    return NextResponse.json(
+      { error: `reason must be one of: ${ALLOWED_REASONS.join(', ')}` },
+      { status: 400 }
+    )
+  }
+
+  const note = await pendingEmailNoteRepository.getNote(reason)
+  return NextResponse.json({ reason, note: note ?? null })
+}

--- a/apps/next/pages/api/email/[reason].ts
+++ b/apps/next/pages/api/email/[reason].ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { emailReasons, emailSend } from 'next-app/utils/email/email-send'
 import { getEmailContent } from 'next-app/utils/email/get-email-content'
+import { pendingEmailNoteRepository } from '@my/app/provider/dynamodb/repositories/pending-email-note-repository'
 
 export const config = {
   maxDuration: 60, // 60 seconds
@@ -19,8 +20,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(404).json({ failed: 'Json Data Not Found' })
   }
   const isTest = !!req.query.test
-  const note = typeof req.query.note === 'string' ? req.query.note : undefined
+  const queryNote = typeof req.query.note === 'string' ? req.query.note.trim() : ''
   const reason = req.query.reason as emailReasons
+
+  // If no note in query, fall back to a pending note saved for this reason
+  // (e.g. via the "Save for next scheduled send" UI). Consumed on success.
+  let note: string | undefined = queryNote || undefined
+  let consumePendingNote = false
+  if (!note) {
+    try {
+      const pending = await pendingEmailNoteRepository.getNote(reason)
+      if (pending) {
+        note = pending
+        consumePendingNote = true
+      }
+    } catch (err) {
+      console.error('[email/reason] failed to read pending note:', err)
+    }
+  }
 
   // For custom emails, we need additional parameters from the request body
   let customHtmlContent: string | undefined
@@ -97,6 +114,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       customSubject: generatedSubject || customSubject, // Use generated subject if available
     })
     console.log('result from AWS.SES', result)
+    // Only consume pending notes on live sends — a test send should preview
+    // the queued note without deleting it.
+    if (consumePendingNote && !isTest) {
+      try {
+        await pendingEmailNoteRepository.clearNote(reason)
+      } catch (err) {
+        console.error('[email/reason] failed to clear pending note:', err)
+      }
+    }
     return res.status(200).json(result)
   } catch (e) {
     console.log('email[reason] failed with error:', e)

--- a/packages/app/features/email-sender/index.tsx
+++ b/packages/app/features/email-sender/index.tsx
@@ -2,10 +2,13 @@
 
 import React, { useState, useEffect } from 'react'
 import {
+  Adapt,
   Button,
   Checkbox,
   Heading,
   Paragraph,
+  Select,
+  Sheet,
   Text,
   TextArea,
   XStack,
@@ -19,10 +22,53 @@ import { Section } from '@my/app/features/newsletter/Section'
 import { LogInUser } from '@my/app/provider/auth/log-in-user'
 import { ROLES } from '@my/app/provider/auth/auth-roles'
 import { Check, Send, Mail, AlertCircle, Edit3 } from '@tamagui/lucide-icons'
-import { sendEmail, getContactsList } from '../../provider/get-data'
+import { sendEmail, getContactsList, savePendingNote } from '../../provider/get-data'
 import { CustomEmailCreator } from '../custom-email-creator'
 import { EmailListTypeKeys, EmailReasonType, AuthSession, AuthStatus } from '@my/app/types'
 import { Event } from '@my/app/types/events'
+
+interface CronScheduledEmail {
+  reason: string
+  cronExpression: string
+  nextFiringUtcMs: number
+}
+
+// "manual" is a UX-only target meaning "include with the next manual click below" —
+// it does not persist to the pending-notes table.
+type PendingNoteTargetValue = 'manual' | string
+
+interface PendingNoteTargetOption {
+  value: PendingNoteTargetValue
+  label: string
+  reason?: EmailReasonType
+  nextFiringAt?: number // ms epoch, for sort + display
+}
+
+const DISPLAY_TIMEZONE = 'America/Toronto'
+
+const REASON_LABEL: Record<string, string> = {
+  newsletter: 'Newsletter',
+  recap: 'Memorial recap',
+  'bible-class': 'Bible Class',
+  'sunday-school': 'Sunday School',
+}
+
+function formatCronFiringLabel(reason: string, firingUtcMs: number): string {
+  const typeLabel = REASON_LABEL[reason] ?? reason
+  const date = new Date(firingUtcMs)
+  const dayLabel = date.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    timeZone: DISPLAY_TIMEZONE,
+  })
+  const timeLabel = date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: DISPLAY_TIMEZONE,
+  })
+  return `${typeLabel} — ${dayLabel} at ${timeLabel}`
+}
 
 // Confirmation dialog state type
 interface ConfirmDialogState {
@@ -49,6 +95,14 @@ export const EmailSender: React.FC<EmailSenderProps> = ({ session, status = 'aut
   const [test, setTest] = useState<boolean>(true) // Default to test mode for safety
   const [sending, setSending] = useState<boolean>(false)
   const [note, setNote] = useState<string>('')
+  const [pendingTarget, setPendingTarget] = useState<PendingNoteTargetValue>('manual')
+  const [scheduleOptions, setScheduleOptions] = useState<PendingNoteTargetOption[]>([])
+  const [savingPending, setSavingPending] = useState<boolean>(false)
+  const [pendingSaveStatus, setPendingSaveStatus] = useState<
+    | { kind: 'success'; label: string }
+    | { kind: 'error'; label: string; message: string }
+    | null
+  >(null)
   const [availableLists, setAvailableLists] = useState<{ key: EmailListTypeKeys; label: string }[]>([])
   const [activeTab, setActiveTab] = useState<string>('templates')
   const [recentEvents, setRecentEvents] = useState<Event[]>([])
@@ -80,6 +134,38 @@ export const EmailSender: React.FC<EmailSenderProps> = ({ session, status = 'aut
       }
     }
     loadLists()
+  }, [])
+
+  // Load the active Vercel cron-fired emails (sourced from vercel.json on the
+  // server) so the "Attach this note to:" Select can list upcoming scheduled
+  // sends in chronological order. The DB-driven EventBridge system isn't live
+  // yet, so vercel.json is the authoritative source.
+  useEffect(() => {
+    const loadSchedules = async () => {
+      try {
+        const response = await fetch('/api/email/cron-schedules', { cache: 'no-store' })
+        if (!response.ok) return
+        const data: { schedules?: CronScheduledEmail[] } = await response.json()
+        const options: PendingNoteTargetOption[] = (data.schedules ?? []).map((s) => ({
+          value: `${s.reason}#${s.cronExpression}`,
+          label: formatCronFiringLabel(s.reason, s.nextFiringUtcMs),
+          reason: s.reason as EmailReasonType,
+          nextFiringAt: s.nextFiringUtcMs,
+        }))
+        console.info(
+          '[EmailSender] cron schedule options:',
+          options.map((o) => ({
+            value: o.value,
+            label: o.label,
+            firesAt: o.nextFiringAt ? new Date(o.nextFiringAt).toISOString() : null,
+          }))
+        )
+        setScheduleOptions(options)
+      } catch (error) {
+        console.error('[EmailSender] Failed to load cron schedules:', error)
+      }
+    }
+    loadSchedules()
   }, [])
 
   // Load recent funeral/baptism events (created within 2 weeks)
@@ -219,6 +305,59 @@ export const EmailSender: React.FC<EmailSenderProps> = ({ session, status = 'aut
     } finally {
       setSending(false)
       setReason(null)
+    }
+  }
+
+  const selectedTargetOption =
+    pendingTarget === 'manual'
+      ? { value: 'manual' as const, label: 'Next manual send (default)' }
+      : scheduleOptions.find((opt) => opt.value === pendingTarget) ?? null
+
+  // Save the textarea note. For "manual" we just confirm — the textarea content
+  // is already what gets sent when an email card is clicked. For a scheduled
+  // target we persist a pending note that the cron picks up on its next firing.
+  const handleSavePendingNote = async () => {
+    if (!note.trim()) return
+    setPendingSaveStatus(null)
+
+    if (pendingTarget === 'manual') {
+      setPendingSaveStatus({
+        kind: 'success',
+        label: 'Next manual send',
+      })
+      return
+    }
+
+    const option = scheduleOptions.find((opt) => opt.value === pendingTarget)
+    if (!option || !option.reason) {
+      setPendingSaveStatus({
+        kind: 'error',
+        label: 'Selected target',
+        message: 'Could not resolve the selected schedule.',
+      })
+      return
+    }
+
+    setSavingPending(true)
+    try {
+      const result = await savePendingNote(option.reason, note)
+      if (result.ok) {
+        setPendingSaveStatus({ kind: 'success', label: option.label })
+      } else {
+        setPendingSaveStatus({
+          kind: 'error',
+          label: option.label,
+          message: result.error || 'Failed to save note',
+        })
+      }
+    } catch (error) {
+      setPendingSaveStatus({
+        kind: 'error',
+        label: option.label,
+        message: error instanceof Error ? error.message : 'Failed to save note',
+      })
+    } finally {
+      setSavingPending(false)
     }
   }
 
@@ -462,6 +601,98 @@ export const EmailSender: React.FC<EmailSenderProps> = ({ session, status = 'aut
                       Clear Note
                     </Button> : null}
                 </XStack>
+
+                <Separator />
+
+                <YStack gap="$2">
+                  <Text fontSize="$3" fontWeight="600">
+                    Attach this note to:
+                  </Text>
+                  <XStack gap="$2" alignItems="center" flexWrap="wrap">
+                    <Select
+                      value={pendingTarget}
+                      onValueChange={(value) => {
+                        setPendingTarget(value as PendingNoteTargetValue)
+                        setPendingSaveStatus(null)
+                      }}
+                    >
+                      <Select.Trigger minWidth={280} iconAfter={null}>
+                        <Select.Value placeholder="Select a send..." />
+                      </Select.Trigger>
+
+                      <Adapt when="sm" platform="touch">
+                        <Sheet native modal dismissOnSnapToBottom>
+                          <Sheet.Frame>
+                            <Sheet.ScrollView>
+                              <Adapt.Contents />
+                            </Sheet.ScrollView>
+                          </Sheet.Frame>
+                          <Sheet.Overlay
+                            animation="lazy"
+                            enterStyle={{ opacity: 0 }}
+                            exitStyle={{ opacity: 0 }}
+                          />
+                        </Sheet>
+                      </Adapt>
+
+                      <Select.Content zIndex={200000 as any}>
+                        <Select.ScrollUpButton />
+                        <Select.Viewport>
+                          <Select.Group>
+                            <Select.Item index={0} value="manual">
+                              <Select.ItemText>Next manual send (default)</Select.ItemText>
+                              <Select.ItemIndicator>
+                                <Check size={16} />
+                              </Select.ItemIndicator>
+                            </Select.Item>
+                            {scheduleOptions.map((opt, idx) => (
+                              <Select.Item key={opt.value} index={idx + 1} value={opt.value}>
+                                <Select.ItemText>{opt.label}</Select.ItemText>
+                                <Select.ItemIndicator>
+                                  <Check size={16} />
+                                </Select.ItemIndicator>
+                              </Select.Item>
+                            ))}
+                          </Select.Group>
+                        </Select.Viewport>
+                        <Select.ScrollDownButton />
+                      </Select.Content>
+                    </Select>
+
+                    <Button
+                      size="$3"
+                      theme="active"
+                      disabled={!note.trim() || savingPending}
+                      opacity={!note.trim() ? 0.5 : 1}
+                      onPress={handleSavePendingNote}
+                    >
+                      {savingPending ? 'Saving…' : 'Save'}
+                    </Button>
+                  </XStack>
+
+                  {pendingTarget === 'manual' ? (
+                    <Text fontSize="$2" color="$gray11">
+                      Default behaviour — your note is included with whichever email you click below.
+                    </Text>
+                  ) : (
+                    <Text fontSize="$2" color="$gray11">
+                      Saves this note to the next {selectedTargetOption?.label ?? 'scheduled'} send. The note is consumed once that email is delivered live.
+                    </Text>
+                  )}
+
+                  {pendingSaveStatus?.kind === 'success' ? (
+                    <Text fontSize="$2" color="$green10">
+                      ✅ {pendingTarget === 'manual'
+                        ? 'Ready — click an email below to send it.'
+                        : `Saved — will be included on the next ${pendingSaveStatus.label}.`}
+                    </Text>
+                  ) : null}
+                  {pendingSaveStatus?.kind === 'error' ? (
+                    <Text fontSize="$2" color="$red10">
+                      Failed to save for {pendingSaveStatus.label}: {pendingSaveStatus.message}
+                    </Text>
+                  ) : null}
+                </YStack>
               </YStack>
             </Card>
 

--- a/packages/app/provider/dynamodb/repositories/pending-email-note-repository.ts
+++ b/packages/app/provider/dynamodb/repositories/pending-email-note-repository.ts
@@ -1,0 +1,45 @@
+import { BaseRepository } from './base-repository'
+import type { EmailReasonType } from '../../../types'
+
+const PK = 'PENDING_EMAIL_NOTE'
+
+interface PendingEmailNoteItem {
+  pkey: string
+  skey: EmailReasonType
+  note: string
+  createdAt: string
+  createdBy?: string
+  lastUpdated?: string
+  version?: number
+}
+
+class PendingEmailNoteRepository extends BaseRepository<PendingEmailNoteItem> {
+  constructor() {
+    super('admin', false)
+  }
+
+  protected buildSheetPK(): string {
+    return PK
+  }
+
+  async getNote(reason: EmailReasonType): Promise<string | undefined> {
+    const item = await this.get(PK, reason)
+    return item?.note
+  }
+
+  async saveNote(reason: EmailReasonType, note: string, createdBy?: string): Promise<void> {
+    await this.put({
+      pkey: PK,
+      skey: reason,
+      note,
+      createdAt: new Date().toISOString(),
+      ...(createdBy ? { createdBy } : {}),
+    } as PendingEmailNoteItem)
+  }
+
+  async clearNote(reason: EmailReasonType): Promise<void> {
+    await this.delete(PK, reason)
+  }
+}
+
+export const pendingEmailNoteRepository = new PendingEmailNoteRepository()

--- a/packages/app/provider/get-data.ts
+++ b/packages/app/provider/get-data.ts
@@ -80,6 +80,49 @@ export const sendEmail = async (
 }
 
 /**
+ * Save a brief note that will be attached to the next scheduled email of the
+ * given reason (consumed once it sends successfully). Used for cron-triggered
+ * sends like the Saturday Memorial recap or the weekly newsletter.
+ */
+export const savePendingNote = async (
+  reason: emailReasons,
+  note: string
+): Promise<{ ok: boolean; error?: string }> => {
+  const url = `${API_PATH}api/email/pending-note`
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ reason, note }),
+    cache: 'no-store',
+  })
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok) {
+    return { ok: false, error: data.error || `Request failed (${response.status})` }
+  }
+  return { ok: true }
+}
+
+/**
+ * Clear any pending note for a reason without sending.
+ */
+export const clearPendingNote = async (
+  reason: emailReasons
+): Promise<{ ok: boolean; error?: string }> => {
+  const url = `${API_PATH}api/email/pending-note`
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ reason, clear: true }),
+    cache: 'no-store',
+  })
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok) {
+    return { ok: false, error: data.error || `Request failed (${response.status})` }
+  }
+  return { ok: true }
+}
+
+/**
  * Get a list of all Subscriber Lists.
  */
 export const getContactsList = async (): Promise<SimplifiedContactListType> => {


### PR DESCRIPTION
## Summary
- Admins can now save a brief note that gets attached to the **next scheduled (cron) email**, not just manual sends. Needed today to include a Don Valley Parkway closure notice on the Memorial recap.
- New per-reason `PENDING_EMAIL_NOTE` row in `tee-admin`, written via a new auth-gated `POST /api/email/pending-note` and consumed on the next **live** send.
- The "Include a Brief Note (Optional)" card on the email sender now has a Select listing **"Next manual send"** plus every Vercel-cron-fired email in chronological order, and a single **Save** button.

## How it works
- `apps/next/app/api/email/cron-schedules/route.ts` reads `vercel.json` server-side (no fs at runtime — bundled via `resolveJsonModule`), parses each `M H * * D` cron expression in UTC, returns `{ reason, cronExpression, nextFiringUtcMs }[]` sorted ascending.
- `pages/api/email/[reason].ts` falls back to the stored pending note when no `?note=` query is present (so cron firings pick it up). Test sends preview the note but **do not** delete it.
- `packages/app/provider/dynamodb/repositories/pending-email-note-repository.ts` — `getNote / saveNote / clearNote`, single record per reason in `tee-admin`.

## Test plan
- [ ] Load `/admin/email/sender`, confirm console logs `[EmailSender] cron schedule options` showing `recap` and `bible-class` in chronological order.
- [ ] Type a note, pick a cron entry, click Save → green confirmation.
- [ ] With **TEST MODE on**, click the matching email card; the yellow "Note:" box renders the saved note (URL auto-linked) and the pending note is **not** cleared.
- [ ] Confirm typecheck (`yarn workspace next-app typecheck`) and shared-package build (`yarn build`) — both green locally.

## Out of scope / follow-ups
- Source for the dropdown is `vercel.json` (Vercel cron is the active scheduler today). When the EventBridge / DynamoDB-driven schedule system goes live, swap the source endpoint.
- "Next manual send" is currently a UX-only sentinel: the textarea content drives manual sends as today, no DB persistence on that path.