### PR TITLE
Multi-brand sender router for outbound mail

### DIFF
--- a/apps/next/app/api/email/test-thursday/route.ts
+++ b/apps/next/app/api/email/test-thursday/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getEmailContent } from '@/utils/email/get-email-content'
 import { emailSend } from '@/utils/email/email-send'
+import { getTenantFromHeaders, resolveTenantFromEnv } from '@my/app/config/tenants'
 
 /**
  * Thursday 9:30pm Test Email
@@ -29,12 +30,14 @@ export async function GET(req: NextRequest) {
       throw new Error('Failed to generate email content')
     }
 
+    const tenant = getTenantFromHeaders(req.headers) ?? resolveTenantFromEnv()
     // Send via SES in TEST MODE
     const result = await emailSend({
       reason: 'newsletter',
       emailHtml,
       emailText,
       test: true, // Always send to test list for safety
+      tenant,
     })
 
     if (result instanceof Error) {

--- a/apps/next/pages/api/email/[reason].ts
+++ b/apps/next/pages/api/email/[reason].ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { emailReasons, emailSend } from 'next-app/utils/email/email-send'
 import { getEmailContent } from 'next-app/utils/email/get-email-content'
 import { pendingEmailNoteRepository } from '@my/app/provider/dynamodb/repositories/pending-email-note-repository'
+import { getTenantFromHeaders, resolveTenantFromEnv } from '@my/app/config/tenants'
 
 export const config = {
   maxDuration: 60, // 60 seconds
@@ -105,6 +106,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(500).json({ failed: 'Email template for ' + reason + ' not found' })
     }
     console.log('IS sending as TEST: ', { isTest, hasNote: !!note, generatedSubject })
+    const tenant = getTenantFromHeaders(req.headers) ?? resolveTenantFromEnv()
     const result = await emailSend({
       reason,
       emailHtml,
@@ -112,6 +114,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       test: isTest,
       customList,
       customSubject: generatedSubject || customSubject, // Use generated subject if available
+      tenant,
     })
     console.log('result from AWS.SES', result)
     // Only consume pending notes on live sends — a test send should preview

--- a/apps/next/utils/email/email-send.tsx
+++ b/apps/next/utils/email/email-send.tsx
@@ -7,8 +7,7 @@ import { chunkArray } from '../chunkArray'
 import { generateEcclesiaUpdateUrl } from './ecclesia-token'
 import { addUtmParameters } from './utm-links'
 import { sendRecordRepository } from '@my/app/provider/dynamodb/repositories/send-record-repository'
-
-const adminMailDomain = '@tee-admin.com'
+import { resolveTenantFromEnv, type TenantConfig } from '@my/app/config/tenants'
 
 const SES_RATE_LIMIT = 14
 
@@ -17,64 +16,60 @@ export { type EmailReasonType as emailReasons } from '@my/app/types'
 import { type EmailReasonType, type EmailSubReason } from '@my/app/types'
 type emailReasons = EmailReasonType // Local alias for use in this file
 
-// All outbound mail uses a single From: address to concentrate sender reputation,
-// and a single Reply-To routing every reply to the Recording Brother.
-const SENDER_EMAIL = 'communications'
+// Each tenant has ONE local-part for bulk mail (concentrates sender
+// reputation per brand-domain — see feedback_multi_brand_email_senders.md).
+// The domain part comes from the resolved tenant.
+const SENDER_LOCAL_PART = 'communications'
 const REPLY_TO = 'teerecbro@gmail.com'
 
+// Per-reason display-name overrides per tenant. Anything not listed
+// falls back to the tenant's default senderDisplayName.
+function senderDisplayName(reason: emailReasons, tenant: TenantConfig): string {
+  if (tenant.id === 'tee' && reason === 'sunday-school') {
+    return 'Toronto East Sunday School'
+  }
+  return tenant.senderDisplayName
+}
+
+// Reason-specific config — sender name and domain come from the
+// resolved tenant, so this no longer carries `name` or `email`.
 const senders = {
   'sunday-school': {
-    name: 'Toronto East Sunday School',
-    email: SENDER_EMAIL,
     subject: 'Sunday School Tomorrow',
     contactList: 'sundaySchool',
     replyTo: REPLY_TO,
   },
   newsletter: {
-    name: 'Toronto East Ecclesia',
-    email: SENDER_EMAIL,
     subject: 'Toronto East Christadelphian Ecclesia Newsletter',
     contactList: 'newsletter',
     replyTo: REPLY_TO,
   },
   'bible-class': {
-    name: 'Toronto East Ecclesia',
-    email: SENDER_EMAIL,
     subject: 'Bible Class Tonight!',
     contactList: 'bibleClass',
     replyTo: REPLY_TO,
   },
   recap: {
-    name: 'Toronto East Ecclesia',
-    email: SENDER_EMAIL,
     subject: 'Memorial Service Tomorrow',
     contactList: 'memorial',
     replyTo: REPLY_TO,
   },
   'business-meeting': {
-    name: 'Toronto East Ecclesia',
-    email: SENDER_EMAIL,
     subject: 'Business Meeting Details',
     contactList: 'members',
     replyTo: REPLY_TO,
   },
   custom: {
-    name: 'Toronto East Ecclesia',
-    email: SENDER_EMAIL,
     subject: 'Toronto East Communications',
     contactList: 'testList', // Safe default - will be overridden by customList parameter
     replyTo: REPLY_TO,
   },
   'event-announcement': {
-    name: 'Toronto East Ecclesia',
-    email: SENDER_EMAIL,
     subject: 'Event Announcement',
     contactList: 'newsletter', // Default - will be overridden by customList parameter
     replyTo: REPLY_TO,
   },
   'inter-ecclesia': {
-    name: 'Toronto East Ecclesia',
-    email: SENDER_EMAIL,
     subject: 'Inter-Ecclesia Announcement',
     contactList: 'interEcclesia',
     replyTo: REPLY_TO,
@@ -91,6 +86,13 @@ export type emailSendProps = {
   subReason?: EmailSubReason // Categorization for per-send tracking
   description?: string // Free-text description for the send record
   sentBy?: string // Email of the user who triggered the send
+  /**
+   * Tenant context for the From-address. When omitted, falls back to
+   * `resolveTenantFromEnv()` which reads `DEPLOYMENT_NAME` (defaulting
+   * to 'tee'). Pass explicitly from API routes that have request
+   * headers — e.g. `getTenantFromHeaders(req.headers) ?? resolveTenantFromEnv()`.
+   */
+  tenant?: TenantConfig
 }
 
 type Sends = { sends: string[]; skips: string[] }
@@ -124,11 +126,13 @@ export const emailSend = async function ({
   subReason = 'general',
   description,
   sentBy,
+  tenant,
 }: emailSendProps): Promise<SendResult | Error> {
   if (Object.keys(senders).findIndex((r) => r === reason) === -1) {
     throw new Error(`${reason} is not a valid email type`)
   }
 
+  const resolvedTenant = tenant ?? resolveTenantFromEnv()
   const campaignId = randomUUID()
 
   if (!emailsEnabled()) {
@@ -156,7 +160,7 @@ export const emailSend = async function ({
     // Format date in Toronto timezone to avoid UTC date issues when sending in evening EST
     const today = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Toronto' })
 
-    const from = `"${senders[reason].name}" <${senders[reason].email}${adminMailDomain}>`
+    const from = `"${senderDisplayName(reason, resolvedTenant)}" <${SENDER_LOCAL_PART}@${resolvedTenant.senderDomain}>`
     // For custom emails, use the provided subject, otherwise use the default
     const defaultSubject = customSubject || senders[reason].subject
     const subject = `${test ? '[TEST] ' : ''}${defaultSubject} ${today}`

--- a/apps/next/utils/email/sesClient.ts
+++ b/apps/next/utils/email/sesClient.ts
@@ -1,5 +1,6 @@
 import { SESv2Client, SESv2ClientConfig, SendEmailCommand } from '@aws-sdk/client-sesv2'
 import { DynamoDBClientConfig } from '@aws-sdk/client-dynamodb'
+import { resolveTenantFromEnv, type TenantConfig } from '@my/app/config/tenants'
 
 export class GlobalRef<T> {
   private readonly sym: symbol
@@ -55,9 +56,14 @@ export interface SendEmailProps {
   subject: string
   body: string
   textBody?: string
+  /**
+   * Tenant context for the From-address. When omitted, falls back to
+   * `resolveTenantFromEnv()` (DEPLOYMENT_NAME → 'tee' default).
+   */
+  tenant?: TenantConfig
 }
 
-export async function sendEmail({ to, subject, body, textBody }: SendEmailProps): Promise<void> {
+export async function sendEmail({ to, subject, body, textBody, tenant }: SendEmailProps): Promise<void> {
   if (!emailsEnabled()) {
     console.log(
       `[sendEmail] Skipped — EMAILS_ENABLED=false (deployment=${process.env.DEPLOYMENT_NAME ?? 'unknown'}, to=${to})`
@@ -65,10 +71,11 @@ export async function sendEmail({ to, subject, body, textBody }: SendEmailProps)
     return
   }
 
+  const resolvedTenant = tenant ?? resolveTenantFromEnv()
   const sesClient = getSesClient()
 
   const emailCmd = new SendEmailCommand({
-    FromEmailAddress: '"TEE Admin" <noreply@tee-admin.com>',
+    FromEmailAddress: `"${resolvedTenant.senderDisplayName}" <noreply@${resolvedTenant.senderDomain}>`,
     Destination: {
       ToAddresses: [to],
     },

--- a/packages/app/config/tenants.ts
+++ b/packages/app/config/tenants.ts
@@ -61,6 +61,20 @@ export function getTenantById(id: TenantId): TenantConfig {
 }
 
 /**
+ * Resolve the tenant for the current deployment from server-side env
+ * vars. Used as a fallback when no request context is available
+ * (e.g. background jobs entered without an HTTP request frame).
+ * Reads DEPLOYMENT_NAME — set per-Vercel-project. Defaults to 'tee'
+ * when unset, matching the legacy single-tenant behavior of
+ * tee-admin deploys that pre-date this env var.
+ */
+export function resolveTenantFromEnv(): TenantConfig {
+  const id = process.env.DEPLOYMENT_NAME as TenantId | undefined
+  if (id === 'echadhub') return TENANTS.echadhub
+  return TENANTS.tee
+}
+
+/**
  * Resolve a TenantConfig from headers (request or response Headers,
  * Pages-Router-style plain object, or anything with a `.get()` /
  * indexable shape). Reads `x-tenant-id` first (set by middleware),


### PR DESCRIPTION
## Summary
Outbound mail's From-address (display name + domain) is now resolved per-tenant at send time, ending the hardcoded TEE / tee-admin.com defaults. tee-admin keeps its existing behavior; echadhub starts sending as `"Echad Hub" <communications@echadhub.org>` (and `<noreply@echadhub.org>` for transactional).

## Resolution chain
API routes resolve tenant in this order:
1. **`getTenantFromHeaders(req.headers)`** — reads `x-tenant-id` set by the hostname middleware (PR #37), falls back to host-based lookup
2. **`resolveTenantFromEnv()`** — fallback for callers without request context (background jobs); reads `DEPLOYMENT_NAME`, defaults to `tee`

Defaulting to `tee` means any caller that doesn't pass tenant gets identical behavior to today — backwards compatible.

## Files touched
- `packages/app/config/tenants.ts` — adds `resolveTenantFromEnv()` (DEPLOYMENT_NAME → tenant, default `tee`)
- `apps/next/utils/email/email-send.tsx` — drops `adminMailDomain` constant, drops per-reason `name` field, adds `senderDisplayName(reason, tenant)` helper, threads `tenant` through `emailSendProps`
- `apps/next/utils/email/sesClient.ts` — `sendEmail()` accepts optional `tenant`, builds From-address from it
- `apps/next/pages/api/email/[reason].ts` — resolves tenant from `req.headers`, passes to `emailSend`
- `apps/next/app/api/email/test-thursday/route.ts` — same

> Note: Replaces closed PR #38 (closed because GitHub auto-closes PRs when the base branch is deleted; #38's base was `feat/hostname-tenant-resolver` which was deleted on merge of #37).

## Test plan
- [x] tee-admin Vercel build: green
- [x] echadhub Vercel build: green
- [ ] Sanity check after merge: send a test from each tenant and confirm From-address