### PR TITLE
News Manager (Issue #41)

### DIFF
--- a/apps/email-builder/emails/NewsAlert.tsx
+++ b/apps/email-builder/emails/NewsAlert.tsx
@@ -1,0 +1,60 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components'
+import React from 'react'
+import {
+  container,
+  defaultText,
+  globalCss,
+  header,
+  main,
+} from '../styles'
+import { Footer } from '../components/Footer'
+import { AutoLinkText } from '../components/AutoLinkText'
+
+export type NewsAlertProps = {
+  title: string
+  body: string
+}
+
+const NewsAlert: React.FC<NewsAlertProps> = ({ title, body }) => {
+  return (
+    <Html lang="en">
+      <Head>
+        <style>{globalCss}</style>
+      </Head>
+      <Preview>{title}</Preview>
+      <Body style={main}>
+        <Section style={header}>
+          <Heading>Toronto East Communications</Heading>
+        </Section>
+
+        <Container style={{ ...container, marginTop: '24px' }} className="container">
+          <Heading as="h2" style={{ margin: '0 0 16px 0' }}>
+            {title}
+          </Heading>
+
+          <Section>
+            <Text style={{ ...defaultText, whiteSpace: 'pre-wrap' }}>
+              <AutoLinkText text={body} />
+            </Text>
+          </Section>
+        </Container>
+
+        <Container>
+          <Text>&nbsp;</Text>
+        </Container>
+        <Footer />
+      </Body>
+    </Html>
+  )
+}
+
+export default NewsAlert

--- a/apps/email-builder/emails/Newsletter.tsx
+++ b/apps/email-builder/emails/Newsletter.tsx
@@ -15,6 +15,7 @@ import { columnAlignTop, container, defaultText, globalCss, header, link, main, 
 import React from 'react'
 import { BibleClassType, MemorialServiceType, ProgramsTypes, SundaySchoolType } from '@my/app/types'
 import { Event } from '@my/app/types/events'
+import type { NewsItem } from '@my/app/types/news'
 import { Footer } from '../components/Footer'
 import { AutoLinkText } from '../components/AutoLinkText'
 import { ReplacementEventCard, findReplacementEvent } from '../components/ReplacementEventCard'
@@ -679,6 +680,8 @@ interface EmailNewsletterProps {
   upcomingEvents?: Event[]
   readings?: any[]
   note?: string
+  /** Active news items (Issue #41) — rendered before events, dateless, no section heading */
+  newsItems?: NewsItem[]
   /** Per-ecclesia service times — replaces hardcoded "9:30am" / "11:00am" */
   serviceTimes?: {
     sundaySchool?: ServiceTimeDisplay
@@ -692,6 +695,7 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
   upcomingEvents = [],
   readings = [],
   note,
+  newsItems = [],
   serviceTimes,
 }) => {
   const todaysDate = new Date().toLocaleDateString('en-US', {
@@ -1299,7 +1303,7 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
               return getEventDate(b).getTime() - getEventDate(a).getTime()
             })
 
-          if (specialEvents.length === 0) return null
+          if (specialEvents.length === 0 && newsItems.length === 0) return null
 
           return (
             <Container style={container} className="container">
@@ -1748,6 +1752,28 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
                       >
                         View Details →
                       </Link>
+                    </Text>
+                  </Section>
+                </React.Fragment>
+              ))}
+              {/* News items (Issue #41) — appended to Announcements, no extra heading, dateless */}
+              {newsItems.map((item, index) => (
+                <React.Fragment key={item.id}>
+                  {(index > 0 || specialEvents.length > 0) && (
+                    <hr
+                      style={{
+                        borderWidth: '0',
+                        background: '#000',
+                        color: '#000',
+                        height: '2px',
+                        margin: '16px 0',
+                      }}
+                    />
+                  )}
+                  <Section style={program}>
+                    <Heading style={defaultText}>{item.title}</Heading>
+                    <Text style={{ ...defaultText, margin: 0 }}>
+                      <TextWithLineBreaks text={item.body} />
                     </Text>
                   </Section>
                 </React.Fragment>

--- a/apps/next/app/(public)/news/[newsId]/page.tsx
+++ b/apps/next/app/(public)/news/[newsId]/page.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { Button, H1, Paragraph, Spinner, YStack } from '@my/ui'
+import { ArrowLeft } from '@tamagui/lucide-icons'
+import { useHydrated } from '@my/app/hooks/use-hydrated'
+import type { NewsItem } from '@my/app/types/news'
+
+export default function NewsDetailPage() {
+  const isHydrated = useHydrated()
+  const router = useRouter()
+  const params = useParams<{ newsId: string }>()
+  const newsId = params?.newsId
+  const [item, setItem] = useState<NewsItem | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!newsId) return
+    let cancelled = false
+    fetch(`/api/news/${newsId}`)
+      .then((r) => {
+        if (r.status === 404) throw new Error('News item not found')
+        if (!r.ok) throw new Error('Failed to load news')
+        return r.json()
+      })
+      .then((data) => {
+        if (!cancelled) setItem(data)
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [newsId])
+
+  if (!isHydrated || loading) {
+    return (
+      <YStack flex={1} justifyContent="center" alignItems="center" padding="$4">
+        <Spinner size="large" width={36} height={36} />
+      </YStack>
+    )
+  }
+
+  if (error || !item) {
+    return (
+      <YStack padding="$4" gap="$4" maxWidth={800} alignSelf="center" width="100%">
+        <Button
+          icon={<ArrowLeft size={16} />}
+          variant="outlined"
+          alignSelf="flex-start"
+          onPress={() => router.push('/news')}
+        >
+          Back to News
+        </Button>
+        <Paragraph color="$error">{error || 'News item not found'}</Paragraph>
+      </YStack>
+    )
+  }
+
+  return (
+    <YStack padding="$4" gap="$4" maxWidth={800} alignSelf="center" width="100%">
+      <Button
+        icon={<ArrowLeft size={16} />}
+        variant="outlined"
+        alignSelf="flex-start"
+        hoverStyle={{ borderColor: '$textSecondary' }}
+        onPress={() => router.push('/news')}
+      >
+        Back to News
+      </Button>
+
+      <H1>{item.title}</H1>
+
+      <Paragraph whiteSpace="pre-wrap" lineHeight="$6">
+        {item.body}
+      </Paragraph>
+    </YStack>
+  )
+}

--- a/apps/next/app/(public)/news/page.tsx
+++ b/apps/next/app/(public)/news/page.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { H1, Paragraph, Spinner, YStack } from '@my/ui'
+import { useHydrated } from '@my/app/hooks/use-hydrated'
+import { NewsPublicCard } from '@my/ui/src/news/news-public-card'
+import type { NewsItem } from '@my/app/types/news'
+
+export default function NewsListPage() {
+  const isHydrated = useHydrated()
+  const [items, setItems] = useState<NewsItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/news')
+      .then((r) => {
+        if (!r.ok) throw new Error('Failed to load news')
+        return r.json()
+      })
+      .then((data) => {
+        if (!cancelled) setItems(data)
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (!isHydrated) {
+    return (
+      <YStack flex={1} justifyContent="center" alignItems="center" padding="$4">
+        <Spinner size="large" width={36} height={36} />
+      </YStack>
+    )
+  }
+
+  return (
+    <YStack padding="$4" gap="$4" maxWidth={900} alignSelf="center" width="100%">
+      <H1>News</H1>
+
+      {loading ? (
+        <YStack alignItems="center" padding="$4">
+          <Spinner size="small" width={20} height={20} />
+        </YStack>
+      ) : error ? (
+        <Paragraph color="$error">{error}</Paragraph>
+      ) : items.length === 0 ? (
+        <Paragraph color="$textSecondary">No news at this time.</Paragraph>
+      ) : (
+        <YStack gap="$3">
+          {items.map((item) => (
+            <NewsPublicCard
+              key={item.id}
+              id={item.id}
+              title={item.title}
+              body={item.body}
+            />
+          ))}
+        </YStack>
+      )}
+    </YStack>
+  )
+}

--- a/apps/next/app/admin/(admin-plus)/news/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/news/page.tsx
@@ -1,0 +1,247 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { useAdminAccess } from '@/hooks/use-admin-access'
+import { useHydrated } from '@my/app/hooks/use-hydrated'
+import { Button, H1, Paragraph, Spinner, Text, XStack, YStack } from '@my/ui'
+import { Plus } from '@tamagui/lucide-icons'
+import { NewsCard } from '@my/ui/src/news/news-card'
+import {
+  NewsItemForm,
+  type NewsFormValues,
+} from '@my/ui/src/news/news-item-form'
+import type { NewsItem } from '@my/app/types/news'
+import { isNewsActive } from '@my/app/types/news'
+
+type Mode = { kind: 'list' } | { kind: 'new' } | { kind: 'edit'; item: NewsItem }
+
+export default function AdminNewsPage() {
+  const isHydrated = useHydrated()
+  const { hasAccess, isLoading } = useAdminAccess()
+  const [items, setItems] = useState<NewsItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [mode, setMode] = useState<Mode>({ kind: 'list' })
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (hasAccess) loadItems()
+  }, [hasAccess])
+
+  const loadItems = async () => {
+    try {
+      setLoading(true)
+      const res = await fetch('/api/admin/news')
+      if (!res.ok) throw new Error('Failed to fetch news')
+      const data = await res.json()
+      setItems(data)
+    } catch (e) {
+      console.error(e)
+      setErrorMessage('Could not load news items.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!isHydrated || isLoading || !hasAccess) {
+    return (
+      <YStack flex={1} justifyContent="center" alignItems="center" padding="$4">
+        <Spinner size="large" width={36} height={36} />
+        <Text marginTop="$4">Loading…</Text>
+      </YStack>
+    )
+  }
+
+  const handleSave = async (values: NewsFormValues) => {
+    setSaving(true)
+    setErrorMessage(null)
+    try {
+      const payload = {
+        title: values.title,
+        body: values.body,
+        category: values.category || undefined,
+        durationWeeks: Number(values.durationWeeks),
+        sharingScope: values.sharingScope,
+      }
+
+      let res: Response
+      if (mode.kind === 'edit') {
+        res = await fetch(`/api/admin/news/${mode.item.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+      } else {
+        res = await fetch('/api/admin/news', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+      }
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err.error || 'Failed to save')
+      }
+
+      await loadItems()
+      setMode({ kind: 'list' })
+    } catch (e) {
+      console.error(e)
+      setErrorMessage(e instanceof Error ? e.message : 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (mode.kind !== 'edit') return
+    if (!confirm('Delete this news item? This cannot be undone.')) return
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/admin/news/${mode.item.id}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error('Failed to delete')
+      await loadItems()
+      setMode({ kind: 'list' })
+    } catch (e) {
+      console.error(e)
+      setErrorMessage(e instanceof Error ? e.message : 'Delete failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleSendAlert = async (test: boolean) => {
+    if (mode.kind !== 'edit') return
+    const confirmMsg = test
+      ? 'Send a test alert to the test list?'
+      : 'Send this alert to all newsletter subscribers? This can only be done once.'
+    if (!confirm(confirmMsg)) return
+
+    setSaving(true)
+    try {
+      const url = `/api/admin/news/${mode.item.id}/send-alert${test ? '?test=true' : ''}`
+      const res = await fetch(url, { method: 'POST' })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Alert send failed')
+      alert(
+        `Alert sent. ${data.sentCount} delivered, ${data.skippedCount} skipped.${
+          test ? ' (Test list)' : ''
+        }`
+      )
+      if (!test) {
+        await loadItems()
+        const refreshed = await fetch(`/api/admin/news/${mode.item.id}`).then((r) => r.json())
+        setMode({ kind: 'edit', item: refreshed })
+      }
+    } catch (e) {
+      console.error(e)
+      setErrorMessage(e instanceof Error ? e.message : 'Alert send failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (mode.kind === 'new' || mode.kind === 'edit') {
+    const initial =
+      mode.kind === 'edit'
+        ? {
+            title: mode.item.title,
+            body: mode.item.body,
+            category: mode.item.category || ('' as const),
+            durationWeeks: String(mode.item.durationWeeks) as '1' | '2' | '3',
+            sharingScope: mode.item.sharingScope,
+          }
+        : undefined
+
+    return (
+      <YStack padding="$4" gap="$4" maxWidth={800} alignSelf="center" width="100%">
+        <H1>{mode.kind === 'edit' ? 'Edit News' : 'New News'}</H1>
+        {errorMessage ? <Paragraph color="$error">{errorMessage}</Paragraph> : null}
+        <NewsItemForm
+          initialValues={initial}
+          isSaving={saving}
+          isExisting={mode.kind === 'edit'}
+          alertAlreadySent={mode.kind === 'edit' && !!mode.item.emailBlastSentAt}
+          onSave={handleSave}
+          onCancel={() => setMode({ kind: 'list' })}
+          onDelete={handleDelete}
+          onSendAlert={mode.kind === 'edit' ? handleSendAlert : undefined}
+        />
+      </YStack>
+    )
+  }
+
+  const active = items.filter((i) => isNewsActive(i))
+  const expired = items.filter((i) => !isNewsActive(i))
+
+  return (
+    <YStack padding="$4" gap="$4" maxWidth={900} alignSelf="center" width="100%">
+      <XStack justifyContent="space-between" alignItems="center" gap="$3">
+        <H1>News Manager</H1>
+        <Button
+          icon={<Plus size={16} />}
+          backgroundColor="$primary"
+          color="white"
+          hoverStyle={{ backgroundColor: '$primaryHover' }}
+          onPress={() => setMode({ kind: 'new' })}
+        >
+          New News
+        </Button>
+      </XStack>
+
+      {errorMessage ? <Paragraph color="$error">{errorMessage}</Paragraph> : null}
+
+      {loading ? (
+        <YStack alignItems="center" padding="$4">
+          <Spinner size="small" width={20} height={20} />
+        </YStack>
+      ) : (
+        <>
+          <YStack gap="$2">
+            <Text fontSize="$5" fontWeight="600">
+              Active ({active.length})
+            </Text>
+            {active.length === 0 ? (
+              <Paragraph color="$textSecondary">No active news items.</Paragraph>
+            ) : (
+              active.map((item) => (
+                <NewsCard
+                  key={item.id}
+                  title={item.title}
+                  body={item.body}
+                  category={item.category}
+                  publishedAt={item.publishedAt}
+                  expiresAt={item.expiresAt}
+                  emailBlastSentAt={item.emailBlastSentAt}
+                  onPress={() => setMode({ kind: 'edit', item })}
+                />
+              ))
+            )}
+          </YStack>
+
+          {expired.length > 0 ? (
+            <YStack gap="$2" marginTop="$4">
+              <Text fontSize="$5" fontWeight="600" color="$textSecondary">
+                Expired ({expired.length})
+              </Text>
+              {expired.map((item) => (
+                <NewsCard
+                  key={item.id}
+                  title={item.title}
+                  body={item.body}
+                  category={item.category}
+                  publishedAt={item.publishedAt}
+                  expiresAt={item.expiresAt}
+                  expired
+                  emailBlastSentAt={item.emailBlastSentAt}
+                  onPress={() => setMode({ kind: 'edit', item })}
+                />
+              ))}
+            </YStack>
+          ) : null}
+        </>
+      )}
+    </YStack>
+  )
+}

--- a/apps/next/app/api/admin/news/[newsId]/route.ts
+++ b/apps/next/app/api/admin/news/[newsId]/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+import {
+  deleteNewsItem,
+  getNewsItemById,
+  updateNewsItem,
+} from '@my/app/services/news-service'
+
+async function requireAdmin() {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const role = (session.user as any).role || ROLES.GUEST
+  if (role !== ROLES.ADMIN && role !== ROLES.OWNER) {
+    return { error: NextResponse.json({ error: 'Admin access required' }, { status: 403 }) }
+  }
+  return { session }
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ newsId: string }> }
+) {
+  const guard = await requireAdmin()
+  if ('error' in guard) return guard.error
+
+  try {
+    const { newsId } = await params
+    const news = await getNewsItemById(newsId)
+    if (!news) {
+      return NextResponse.json({ error: 'News item not found' }, { status: 404 })
+    }
+    return NextResponse.json(news)
+  } catch (error) {
+    console.error('Error fetching news:', error)
+    return NextResponse.json({ error: 'Failed to fetch news' }, { status: 500 })
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ newsId: string }> }
+) {
+  const guard = await requireAdmin()
+  if ('error' in guard) return guard.error
+
+  try {
+    const { newsId } = await params
+    const body = await request.json()
+
+    if (body.durationWeeks !== undefined && ![1, 2, 3].includes(body.durationWeeks)) {
+      return NextResponse.json({ error: 'durationWeeks must be 1, 2, or 3' }, { status: 400 })
+    }
+
+    const updated = await updateNewsItem({
+      ...body,
+      id: newsId,
+      publishedAt: body.publishedAt ? new Date(body.publishedAt) : undefined,
+    })
+    return NextResponse.json(updated)
+  } catch (error) {
+    console.error('Error updating news:', error)
+    const message = error instanceof Error ? error.message : 'Failed to update news'
+    const status = message.includes('not found') ? 404 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ newsId: string }> }
+) {
+  const guard = await requireAdmin()
+  if ('error' in guard) return guard.error
+
+  try {
+    const { newsId } = await params
+    const ok = await deleteNewsItem(newsId)
+    if (!ok) {
+      return NextResponse.json({ error: 'News item not found' }, { status: 404 })
+    }
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Error deleting news:', error)
+    return NextResponse.json({ error: 'Failed to delete news' }, { status: 500 })
+  }
+}

--- a/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
+++ b/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+import { render } from '@react-email/render'
+import { createElement } from 'react'
+import NewsAlert from 'email-builder/emails/NewsAlert'
+import { emailSend } from '@/utils/email/email-send'
+import {
+  getNewsItemById,
+  markNewsBlastSent,
+} from '@my/app/services/news-service'
+import { isNewsActive } from '@my/app/types/news'
+
+export const config = {
+  maxDuration: 60,
+}
+
+/**
+ * POST /api/admin/news/[newsId]/send-alert — News Manager (Issue #41)
+ * Triggers an email blast for a news item. One-shot: subsequent calls fail
+ * unless ?force=true (admin/owner only override).
+ * Query: ?test=true → send to test list only.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ newsId: string }> }
+) {
+  try {
+    const session = await auth()
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    const role = (session.user as any).role || ROLES.GUEST
+    if (role !== ROLES.ADMIN && role !== ROLES.OWNER) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+    }
+
+    const { newsId } = await params
+    const { searchParams } = new URL(request.url)
+    const isTest = searchParams.get('test') === 'true'
+    const force = searchParams.get('force') === 'true'
+
+    const news = await getNewsItemById(newsId)
+    if (!news) {
+      return NextResponse.json({ error: 'News item not found' }, { status: 404 })
+    }
+    if (!isNewsActive(news)) {
+      return NextResponse.json({ error: 'News item has expired' }, { status: 400 })
+    }
+    if (news.emailBlastSentAt && !force && !isTest) {
+      return NextResponse.json(
+        { error: 'Alert already sent for this news item' },
+        { status: 409 }
+      )
+    }
+
+    const emailElement = createElement(NewsAlert as any, {
+      title: news.title,
+      body: news.body,
+    })
+    const emailHtml = await render(emailElement)
+    const emailText = await render(emailElement, { plainText: true })
+
+    const result = await emailSend({
+      reason: 'news-alert',
+      emailHtml,
+      emailText,
+      test: isTest,
+      customSubject: news.title,
+      subReason: 'general',
+      description: `News alert: ${news.title}`,
+      sentBy: session.user.email,
+    })
+
+    if (result instanceof Error) {
+      return NextResponse.json({ error: result.message }, { status: 500 })
+    }
+
+    if (!isTest) {
+      await markNewsBlastSent(newsId)
+    }
+
+    return NextResponse.json({
+      success: true,
+      campaignId: result.campaignId,
+      sentCount: result.sends.length,
+      skippedCount: result.skips.length,
+    })
+  } catch (error) {
+    console.error('Error sending news alert:', error)
+    return NextResponse.json(
+      { success: false, error: 'Failed to send news alert' },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/next/app/api/admin/news/route.ts
+++ b/apps/next/app/api/admin/news/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+import { createNewsItem, listNewsItems } from '@my/app/services/news-service'
+import { personRepository } from '@my/app/provider/dynamodb/repositories/person-repository'
+import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
+
+/**
+ * Admin News API — News Manager (Issue #41)
+ * GET  → all news items including expired (admin only)
+ * POST → create a news item (admin/owner)
+ */
+
+export async function GET() {
+  try {
+    const session = await auth()
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const role = (session.user as any).role || ROLES.GUEST
+    if (role !== ROLES.ADMIN && role !== ROLES.OWNER) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+    }
+
+    const items = await listNewsItems({ includeExpired: true })
+    return NextResponse.json(items)
+  } catch (error) {
+    console.error('Error listing news (admin):', error)
+    return NextResponse.json({ error: 'Failed to list news' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await auth()
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const role = (session.user as any).role || ROLES.GUEST
+    if (role !== ROLES.ADMIN && role !== ROLES.OWNER) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+    }
+
+    const body = await request.json()
+    if (!body.title || !body.body) {
+      return NextResponse.json({ error: 'Title and body are required' }, { status: 400 })
+    }
+    if (![1, 2, 3].includes(body.durationWeeks)) {
+      return NextResponse.json({ error: 'durationWeeks must be 1, 2, or 3' }, { status: 400 })
+    }
+
+    // Resolve author's ecclesia (falls back to home ecclesia for single-tenant deploy)
+    const person = await personRepository.getByEmail(session.user.email)
+    const ecclesiaId = body.ecclesiaId || person?.ecclesia || HOME_ECCLESIA.canonicalName
+
+    const news = await createNewsItem({
+      ecclesiaId,
+      authorId: session.user.email,
+      title: body.title,
+      body: body.body,
+      category: body.category,
+      durationWeeks: body.durationWeeks,
+      sharingScope: body.sharingScope || 'own',
+      publishedAt: body.publishedAt ? new Date(body.publishedAt) : undefined,
+    })
+
+    return NextResponse.json(news, { status: 201 })
+  } catch (error) {
+    console.error('Error creating news:', error)
+    return NextResponse.json({ error: 'Failed to create news' }, { status: 500 })
+  }
+}

--- a/apps/next/app/api/news/[newsId]/route.ts
+++ b/apps/next/app/api/news/[newsId]/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getNewsItemById } from '@my/app/services/news-service'
+import { isNewsActive } from '@my/app/types/news'
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ newsId: string }> }
+) {
+  try {
+    const { newsId } = await params
+    const news = await getNewsItemById(newsId)
+    if (!news || !isNewsActive(news)) {
+      return NextResponse.json({ error: 'News item not found' }, { status: 404 })
+    }
+    return NextResponse.json(news)
+  } catch (error) {
+    console.error('Error fetching news:', error)
+    return NextResponse.json({ error: 'Failed to fetch news' }, { status: 500 })
+  }
+}

--- a/apps/next/app/api/news/route.ts
+++ b/apps/next/app/api/news/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+import { listNewsItems } from '@my/app/services/news-service'
+
+/**
+ * Public News API — returns active news items (expired items are filtered out).
+ * In single-tenant deployments this returns all active news. Multi-tenant
+ * resolution via news-sharing-resolver is wired into the data layer for
+ * future MULTI_TENANT_INIT use.
+ */
+export async function GET() {
+  try {
+    const items = await listNewsItems({ includeExpired: false })
+    return NextResponse.json(items)
+  } catch (error) {
+    console.error('Error listing news (public):', error)
+    return NextResponse.json({ error: 'Failed to list news' }, { status: 500 })
+  }
+}

--- a/apps/next/utils/email/email-send.tsx
+++ b/apps/next/utils/email/email-send.tsx
@@ -74,6 +74,11 @@ const senders = {
     contactList: 'interEcclesia',
     replyTo: REPLY_TO,
   },
+  'news-alert': {
+    subject: 'Important News',
+    contactList: 'newsletter',
+    replyTo: REPLY_TO,
+  },
 }
 
 export type emailSendProps = {

--- a/apps/next/utils/email/get-email-content.tsx
+++ b/apps/next/utils/email/get-email-content.tsx
@@ -20,6 +20,7 @@ import BaptismEmail from 'email-builder/emails/Baptism'
 import InterEcclesiaWrapper from 'email-builder/emails/InterEcclesiaWrapper'
 import { StudyWeekendContent } from 'email-builder/components/StudyWeekendContent'
 import { getEventById } from '@my/app/services/event-service'
+import { listNewsItems } from '@my/app/services/news-service'
 import { generateEcclesiaUpdateUrl } from './ecclesia-token'
 import { EventDurationCalculator } from '@my/app/utils/newsletter/event-duration'
 import type { DisplayDuration } from '@my/app/types/newsletter-rules'
@@ -214,17 +215,23 @@ export const getEmailContent = async (
       }
 
       // Fetch all required data for newsletter (including per-ecclesia service times)
-      const [scheduleData, upcomingEvents, readingsData, homeEcclesia] = await Promise.all([
-        get_upcoming_program(['memorial', 'sundaySchool', 'bibleClass']),
-        fetchEvents(),
-        fetchBibleReadings(),
-        getEcclesiaByName(HOME_ECCLESIA.canonicalName),
-      ])
+      const [scheduleData, upcomingEvents, readingsData, homeEcclesia, newsletterNewsItems] =
+        await Promise.all([
+          get_upcoming_program(['memorial', 'sundaySchool', 'bibleClass']),
+          fetchEvents(),
+          fetchBibleReadings(),
+          getEcclesiaByName(HOME_ECCLESIA.canonicalName),
+          listNewsItems({ includeExpired: false }).catch((err) => {
+            console.error('Failed to fetch news for newsletter (non-fatal):', err)
+            return []
+          }),
+        ])
 
       console.log('Newsletter data fetched:', {
         scheduleData: scheduleData.length,
         upcomingEvents: upcomingEvents.length,
-        readingsData: readingsData.length
+        readingsData: readingsData.length,
+        newsItems: newsletterNewsItems.length,
       })
 
       // Resolve per-ecclesia service times (falls back to catalogue defaults)
@@ -250,6 +257,7 @@ export const getEmailContent = async (
           upcomingEvents={upcomingEvents}
           readings={readingsData}
           note={note}
+          newsItems={newsletterNewsItems}
           serviceTimes={newsletterServiceTimes}
         />
       )
@@ -259,6 +267,7 @@ export const getEmailContent = async (
           upcomingEvents={upcomingEvents}
           readings={readingsData}
           note={note}
+          newsItems={newsletterNewsItems}
           serviceTimes={newsletterServiceTimes}
         />,
         { plainText: true }

--- a/packages/app/features/newsletter/newsletter-screen.tsx
+++ b/packages/app/features/newsletter/newsletter-screen.tsx
@@ -13,8 +13,11 @@ import { fetchReadings } from '@my/app/features/newsletter/readings/fetch-readin
 import { DailyReadings } from '@my/app/features/newsletter/readings/daily-readings'
 import { useHydrated } from '@my/app/hooks/use-hydrated'
 import { Event, isEventActive } from '@my/app/types/events'
+import type { NewsItem } from '@my/app/types/news'
+import { isNewsActive } from '@my/app/types/news'
 import { EventDurationCalculator } from '@my/app/utils/newsletter/event-duration'
 import { EventSummaryCard } from '@my/ui/src/events/event-summary-card'
+import { Paragraph } from '@my/ui'
 import { Vote } from '@tamagui/lucide-icons'
 
 // Helper function to check if an election-cycle event is currently active
@@ -52,6 +55,7 @@ export const NewsletterScreen: React.FC<NewsletterScreenProps> = ({
   const [program, setProgram] = useState<ProgramTypes[] | null>(null)
   const [readings, setReadings] = useState<[] | null>(null)
   const [upcomingEvents, setUpcomingEvents] = useState<Event[]>([])
+  const [newsItems, setNewsItems] = useState<NewsItem[]>([])
   const [clearingCache, setClearingCache] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
   const isHydrated = useHydrated()
@@ -60,10 +64,11 @@ export const NewsletterScreen: React.FC<NewsletterScreenProps> = ({
     setRefreshing(true)
     try {
       const cacheBuster = `?_t=${Date.now()}`
-      const [newProgram, newReadings, eventsResponse] = await Promise.all([
+      const [newProgram, newReadings, eventsResponse, newsResponse] = await Promise.all([
         fetchUpcoming({ bypassCache: true }),
         fetchReadings(true),
         fetch(`/api/events/public${cacheBuster}`, { cache: 'no-store' }),
+        fetch(`/api/news${cacheBuster}`, { cache: 'no-store' }),
       ])
       setProgram(newProgram)
       setReadings(newReadings)
@@ -72,6 +77,11 @@ export const NewsletterScreen: React.FC<NewsletterScreenProps> = ({
         const data = await eventsResponse.json()
         const publishedEvents = data.filter((event: Event) => isEventActive(event))
         setUpcomingEvents(publishedEvents)
+      }
+
+      if (newsResponse.ok) {
+        const data = await newsResponse.json()
+        setNewsItems((data as NewsItem[]).filter((item) => isNewsActive(item)))
       }
     } finally {
       setRefreshing(false)
@@ -111,10 +121,23 @@ export const NewsletterScreen: React.FC<NewsletterScreenProps> = ({
       }
     }
 
+    const fetchNews = async () => {
+      try {
+        const response = await fetch('/api/news', { cache: 'no-store' })
+        if (response.ok) {
+          const data = await response.json()
+          setNewsItems((data as NewsItem[]).filter((item) => isNewsActive(item)))
+        }
+      } catch (error) {
+        console.log('error fetching news', error)
+      }
+    }
+
     Promise.all([
       fetchUpcoming({}).then(setProgram),
       fetchReadings().then(setReadings),
-      fetchEvents()
+      fetchEvents(),
+      fetchNews(),
     ]).catch(
       (error) => console.log('error fetching data', error)
     )
@@ -405,11 +428,11 @@ export const NewsletterScreen: React.FC<NewsletterScreenProps> = ({
           // Sort all events with smart sorting
           const sortedEvents = [...specialEvents].sort(smartSort)
 
-          if (sortedEvents.length === 0) return null
+          if (sortedEvents.length === 0 && newsItems.length === 0) return null
 
           return (
             <YStack gap="$3" testID="newsletter-special-announcements">
-              <H2 fontFamily="$body" fontWeight="600">Special Announcements</H2>
+              <H2 fontFamily="$body" fontWeight="600">Announcements</H2>
               {sortedEvents.map((event) => (
                 <EventSummaryCard
                   key={event.id}
@@ -419,6 +442,24 @@ export const NewsletterScreen: React.FC<NewsletterScreenProps> = ({
                   userRole={userRole}
                   isMemberOrHigher={isMemberOrHigher}
                 />
+              ))}
+              {newsItems.map((item) => (
+                <Card
+                  key={item.id}
+                  elevation="$2"
+                  borderWidth={1}
+                  borderColor="$borderColor"
+                  padding="$4"
+                  borderRadius="$4"
+                  backgroundColor="$background"
+                >
+                  <YStack gap="$2">
+                    <Text fontSize="$6" fontWeight="600">
+                      {item.title}
+                    </Text>
+                    <Paragraph whiteSpace="pre-wrap">{item.body}</Paragraph>
+                  </YStack>
+                </Card>
               ))}
             </YStack>
           )

--- a/packages/app/features/simple-enhanced-navigation.tsx
+++ b/packages/app/features/simple-enhanced-navigation.tsx
@@ -54,6 +54,7 @@ const emailAdminPages: MainPageType[] = [
 const systemAdminPages: MainPageType[] = [
   { path: '/admin/youtube', label: 'YouTube' },
   { path: '/admin/events', label: 'Event Manager' },
+  { path: '/admin/news', label: 'News Manager' },
   { path: '/admin/meetings', label: 'Meeting Manager' },
   { path: '/admin/data-sync', label: 'Data Sync' },
   { path: '/admin/directory-email-sync', label: 'Directory Email Sync' },

--- a/packages/app/features/with-navigation.tsx
+++ b/packages/app/features/with-navigation.tsx
@@ -173,6 +173,12 @@ const AdminOwnerMenu: React.FC<SubMenuType> = ({ linkTo, path }) => {
         active={path === '/admin/events'}
       />
       <NavigationButtonItem
+        key="newsManager"
+        linkTo={linkTo('/admin/news')}
+        text="News Manager"
+        active={path === '/admin/news'}
+      />
+      <NavigationButtonItem
         key="meetingManager"
         linkTo={linkTo('/admin/meetings')}
         text="Meeting Manager"

--- a/packages/app/provider/dynamodb/repositories/schedule-repository.ts
+++ b/packages/app/provider/dynamodb/repositories/schedule-repository.ts
@@ -307,6 +307,29 @@ export class ScheduleRepository extends BaseRepository<ScheduleRecord> {
     return this.delete(this.buildEventPK(eventId), 'DETAILS')
   }
 
+  // News Manager (Issue #41) — News rides on the same tee-schedules table
+  // as Events. PK: NEWS#{newsId}, SK: DETAILS. GSI1PK: 'NEWS' for chronological
+  // listing, mirroring the Events partition.
+  private buildNewsPK(newsId: string): string {
+    return `NEWS#${newsId}`
+  }
+
+  async getNews(newsId: string): Promise<ScheduleRecord | null> {
+    return this.get(this.buildNewsPK(newsId), 'DETAILS')
+  }
+
+  async deleteNews(newsId: string): Promise<void> {
+    return this.delete(this.buildNewsPK(newsId), 'DETAILS')
+  }
+
+  async getAllNews(): Promise<ScheduleRecord[]> {
+    const result = await this.scan({
+      filterExpression: 'begins_with(PK, :prefix)',
+      expressionAttributeValues: { ':prefix': 'NEWS#' },
+    })
+    return result.items
+  }
+
   // Bulk operations for sheet sync - SAFE CHECKSUM-BASED APPROACH
   // IMPORTANT: Preserves externally-managed fields (YouTube URLs) that are not in Google Sheets
   async replaceSheetSchedules(

--- a/packages/app/services/news-service.ts
+++ b/packages/app/services/news-service.ts
@@ -1,0 +1,141 @@
+import { v4 as uuidv4 } from 'uuid'
+import { scheduleRepo } from '@my/app/provider/dynamodb'
+import type { ScheduleRecord } from '@my/app/provider/dynamodb/types'
+import {
+  NewsItem,
+  CreateNewsRequest,
+  UpdateNewsRequest,
+  computeNewsExpiresAt,
+  isNewsActive,
+} from '@my/app/types/news'
+
+/**
+ * News Service — CRUD for News items (Issue #41).
+ *
+ * Storage: tee-schedules table with PK: NEWS#{id}, SK: DETAILS.
+ * Full NewsItem is stored as JSON in the `details` field, matching the
+ * Event storage pattern.
+ */
+
+const serializeNews = (news: NewsItem): string => JSON.stringify(news)
+
+const deserializeNews = (raw: string): NewsItem => {
+  const parsed = JSON.parse(raw)
+  if (parsed.publishedAt) parsed.publishedAt = new Date(parsed.publishedAt)
+  if (parsed.expiresAt) parsed.expiresAt = new Date(parsed.expiresAt)
+  if (parsed.createdAt) parsed.createdAt = new Date(parsed.createdAt)
+  if (parsed.updatedAt) parsed.updatedAt = new Date(parsed.updatedAt)
+  if (parsed.emailBlastSentAt) parsed.emailBlastSentAt = new Date(parsed.emailBlastSentAt)
+  return parsed as NewsItem
+}
+
+const newsToRecord = (news: NewsItem): any => ({
+  PK: `NEWS#${news.id}`,
+  SK: 'DETAILS',
+  GSI1PK: 'NEWS',
+  GSI1SK: `${news.publishedAt.toISOString()}#${news.id}`,
+  type: 'news' as const,
+  ecclesia: news.ecclesiaId,
+  date: news.publishedAt.toISOString().split('T')[0],
+  newsId: news.id,
+  title: news.title,
+  sharingScope: news.sharingScope,
+  publishedAt: news.publishedAt.toISOString(),
+  expiresAt: news.expiresAt.toISOString(),
+  details: serializeNews(news),
+})
+
+const recordToNews = (record: ScheduleRecord): NewsItem => {
+  if (!record.details || typeof record.details !== 'string') {
+    throw new Error('News data not found in record')
+  }
+  return deserializeNews(record.details)
+}
+
+export const createNewsItem = async (data: CreateNewsRequest): Promise<NewsItem> => {
+  const id = uuidv4()
+  const now = new Date()
+  const publishedAt = data.publishedAt ? new Date(data.publishedAt) : now
+  const expiresAt = computeNewsExpiresAt(publishedAt, data.durationWeeks)
+
+  const news: NewsItem = {
+    id,
+    ecclesiaId: data.ecclesiaId,
+    authorId: data.authorId,
+    title: data.title,
+    body: data.body,
+    category: data.category,
+    publishedAt,
+    expiresAt,
+    durationWeeks: data.durationWeeks,
+    sharingScope: data.sharingScope,
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  await scheduleRepo.put({
+    ...newsToRecord(news),
+    lastUpdated: now.toISOString(),
+    version: 1,
+  } as any)
+
+  return news
+}
+
+export const getNewsItemById = async (id: string): Promise<NewsItem | null> => {
+  const record = await scheduleRepo.getNews(id)
+  if (!record) return null
+  return recordToNews(record)
+}
+
+export const updateNewsItem = async (update: UpdateNewsRequest): Promise<NewsItem> => {
+  const existing = await getNewsItemById(update.id)
+  if (!existing) throw new Error(`News item ${update.id} not found`)
+
+  // If durationWeeks changes, recompute expiresAt from the current publishedAt
+  const durationWeeks = update.durationWeeks ?? existing.durationWeeks
+  const publishedAt = update.publishedAt ? new Date(update.publishedAt) : existing.publishedAt
+  const expiresAt =
+    update.durationWeeks || update.publishedAt
+      ? computeNewsExpiresAt(publishedAt, durationWeeks)
+      : existing.expiresAt
+
+  const updated: NewsItem = {
+    ...existing,
+    ...update,
+    id: existing.id,
+    createdAt: existing.createdAt,
+    publishedAt,
+    durationWeeks,
+    expiresAt,
+    updatedAt: new Date(),
+  }
+
+  await scheduleRepo.update(`NEWS#${update.id}`, 'DETAILS', newsToRecord(updated) as any)
+  return updated
+}
+
+export const deleteNewsItem = async (id: string): Promise<boolean> => {
+  try {
+    await scheduleRepo.deleteNews(id)
+    return true
+  } catch (error) {
+    console.error('Failed to delete news item:', error)
+    return false
+  }
+}
+
+export const listNewsItems = async (
+  options: { includeExpired?: boolean } = {}
+): Promise<NewsItem[]> => {
+  const records = await scheduleRepo.getAllNews()
+  const items = records.map(recordToNews)
+  const filtered = options.includeExpired ? items : items.filter((item) => isNewsActive(item))
+  return filtered.sort(
+    (a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+  )
+}
+
+export const markNewsBlastSent = async (id: string): Promise<NewsItem> => {
+  return updateNewsItem({ id, emailBlastSentAt: new Date() })
+}

--- a/packages/app/services/news-sharing-resolver.ts
+++ b/packages/app/services/news-sharing-resolver.ts
@@ -1,0 +1,120 @@
+/**
+ * Cross-ecclesia News sharing resolution.
+ *
+ * Mirrors event-sharing-resolver.ts but for NewsItem. Default scope for News
+ * is 'own' (ecclesia-local) — broader scopes ('region', 'global') are used
+ * for major news that should reach nearby or all ecclesias.
+ */
+
+import type { NewsItem } from '@my/app/types/news'
+import { isNewsActive } from '@my/app/types/news'
+import type { SharingEcclesiaData } from '@my/app/services/event-sharing-resolver'
+import { haversineDistance, DEFAULT_SHARING_RADIUS_KM } from '@my/app/utils/geo'
+
+function canReceiveFrom(
+  receiver: SharingEcclesiaData,
+  sender: SharingEcclesiaData
+): boolean {
+  if (sender.sharingPreference === 'private') return false
+  if (sender.excludedEcclesias?.includes(receiver.name)) return false
+  if (receiver.excludedEcclesias?.includes(sender.name)) return false
+  return true
+}
+
+function isWithinRadius(
+  receiver: SharingEcclesiaData,
+  sender: SharingEcclesiaData
+): boolean {
+  if (!receiver.latitude || !receiver.longitude) return true
+  if (!sender.latitude || !sender.longitude) return true
+  if (receiver.country && sender.country && receiver.country !== sender.country) return false
+  const radius = receiver.sharingRadiusKm || DEFAULT_SHARING_RADIUS_KM
+  const distance = haversineDistance(
+    receiver.latitude,
+    receiver.longitude,
+    sender.latitude,
+    sender.longitude
+  )
+  return distance <= radius
+}
+
+export interface NewsSharingInput {
+  ecclesia: SharingEcclesiaData
+  subscribedEcclesias: string[]
+  allEcclesias: SharingEcclesiaData[]
+  news: NewsItem[]
+}
+
+export interface ResolvedNewsFeed {
+  ownNews: NewsItem[]
+  subscribedNews: NewsItem[]
+  nearbyNews: NewsItem[]
+  globalNews: NewsItem[]
+  allNews: NewsItem[]
+}
+
+export function resolveNewsFeed(input: NewsSharingInput): ResolvedNewsFeed {
+  const { ecclesia, subscribedEcclesias, allEcclesias, news } = input
+
+  const ecclesiaMap = new Map<string, SharingEcclesiaData>()
+  for (const e of allEcclesias) ecclesiaMap.set(e.name, e)
+
+  const nearbySet = new Set(ecclesia.nearbyEcclesias || [])
+  const subscribedSet = new Set(subscribedEcclesias)
+  const seen = new Set<string>()
+
+  const ownNews: NewsItem[] = []
+  const subscribedNews: NewsItem[] = []
+  const nearbyNews: NewsItem[] = []
+  const globalNews: NewsItem[] = []
+
+  for (const item of news) {
+    if (!isNewsActive(item)) continue
+    if (!item.id || seen.has(item.id)) continue
+
+    const senderName = item.ecclesiaId
+    const scope = item.sharingScope
+
+    if (senderName === ecclesia.name) {
+      ownNews.push(item)
+      seen.add(item.id)
+      continue
+    }
+
+    if (subscribedSet.has(senderName) && scope !== 'own') {
+      subscribedNews.push(item)
+      seen.add(item.id)
+      continue
+    }
+
+    if (nearbySet.has(senderName) && (scope === 'region' || scope === 'global')) {
+      const sender = ecclesiaMap.get(senderName)
+      if (
+        sender &&
+        sender.sharingPreference !== 'subscribers-only' &&
+        canReceiveFrom(ecclesia, sender) &&
+        isWithinRadius(ecclesia, sender)
+      ) {
+        nearbyNews.push(item)
+        seen.add(item.id)
+        continue
+      }
+    }
+
+    if (scope === 'global') {
+      const sender = ecclesiaMap.get(senderName)
+      if (!sender || canReceiveFrom(ecclesia, sender)) {
+        globalNews.push(item)
+        seen.add(item.id)
+        continue
+      }
+    }
+  }
+
+  const allResolved = [...ownNews, ...subscribedNews, ...nearbyNews, ...globalNews]
+  allResolved.sort(
+    (a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+  )
+
+  return { ownNews, subscribedNews, nearbyNews, globalNews, allNews: allResolved }
+}

--- a/packages/app/types.ts
+++ b/packages/app/types.ts
@@ -51,6 +51,7 @@ export type EmailReasonType =
   | 'custom'
   | 'event-announcement'
   | 'inter-ecclesia'
+  | 'news-alert'
 
 /**
  * Sub-reason for categorizing the purpose of an email send.

--- a/packages/app/types/news.ts
+++ b/packages/app/types/news.ts
@@ -1,0 +1,43 @@
+// News Manager types — lightweight retrospective counterpart to Events.
+// See https://github.com/keneasson/tee-admin/issues/41
+
+import type { EventSharingScope } from './events'
+
+export type NewsCategory = 'medical' | 'general' | 'announcement'
+
+export type NewsDurationWeeks = 1 | 2 | 3
+
+export interface NewsItem {
+  id: string
+  ecclesiaId: string
+  authorId: string
+  title: string
+  body: string
+  category?: NewsCategory
+  publishedAt: Date
+  expiresAt: Date
+  durationWeeks: NewsDurationWeeks
+  sharingScope: EventSharingScope
+  emailBlastSentAt?: Date
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type CreateNewsRequest = Omit<
+  NewsItem,
+  'id' | 'createdAt' | 'updatedAt' | 'expiresAt' | 'publishedAt' | 'emailBlastSentAt'
+> & {
+  publishedAt?: Date
+}
+
+export type UpdateNewsRequest = Partial<Omit<NewsItem, 'createdAt'>> & { id: string }
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+export function computeNewsExpiresAt(publishedAt: Date, durationWeeks: NewsDurationWeeks): Date {
+  return new Date(publishedAt.getTime() + durationWeeks * WEEK_MS)
+}
+
+export function isNewsActive(item: Pick<NewsItem, 'expiresAt'>, now: Date = new Date()): boolean {
+  return new Date(item.expiresAt).getTime() > now.getTime()
+}

--- a/packages/ui/src/news/index.ts
+++ b/packages/ui/src/news/index.ts
@@ -1,0 +1,3 @@
+export * from './news-item-form'
+export * from './news-card'
+export * from './news-public-card'

--- a/packages/ui/src/news/news-card.tsx
+++ b/packages/ui/src/news/news-card.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import React from 'react'
+import { Card, H3, Paragraph, XStack, YStack } from 'tamagui'
+
+export type NewsCardProps = {
+  title: string
+  body: string
+  category?: 'medical' | 'general' | 'announcement'
+  publishedAt: Date | string
+  expiresAt?: Date | string
+  expired?: boolean
+  emailBlastSentAt?: Date | string
+  onPress?: () => void
+}
+
+function formatDate(d: Date | string): string {
+  return new Date(d).toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+const CATEGORY_LABELS: Record<NonNullable<NewsCardProps['category']>, string> = {
+  medical: 'Medical',
+  general: 'General',
+  announcement: 'Announcement',
+}
+
+export function NewsCard({
+  title,
+  body,
+  category,
+  publishedAt,
+  expiresAt,
+  expired = false,
+  emailBlastSentAt,
+  onPress,
+}: NewsCardProps) {
+  const snippet = body.length > 200 ? `${body.slice(0, 200)}…` : body
+
+  return (
+    <Card
+      elevate
+      padded
+      bordered
+      hoverStyle={onPress ? { borderColor: '$primary' } : undefined}
+      cursor={onPress ? 'pointer' : undefined}
+      onPress={onPress}
+      opacity={expired ? 0.6 : 1}
+    >
+      <YStack gap="$2">
+        <XStack gap="$2" alignItems="center" flexWrap="wrap">
+          {category ? (
+            <Paragraph
+              fontSize="$2"
+              fontWeight="600"
+              color="$primary"
+              textTransform="uppercase"
+              letterSpacing={0.5}
+            >
+              {CATEGORY_LABELS[category]}
+            </Paragraph>
+          ) : null}
+          <Paragraph fontSize="$2" color="$textSecondary">
+            {formatDate(publishedAt)}
+          </Paragraph>
+          {expired ? (
+            <Paragraph fontSize="$2" color="$textTertiary" fontStyle="italic">
+              (expired)
+            </Paragraph>
+          ) : expiresAt ? (
+            <Paragraph fontSize="$2" color="$textTertiary">
+              until {formatDate(expiresAt)}
+            </Paragraph>
+          ) : null}
+          {emailBlastSentAt ? (
+            <Paragraph fontSize="$2" color="$info">
+              alert sent
+            </Paragraph>
+          ) : null}
+        </XStack>
+        <H3>{title}</H3>
+        <Paragraph whiteSpace="pre-wrap" numberOfLines={3}>
+          {snippet}
+        </Paragraph>
+      </YStack>
+    </Card>
+  )
+}

--- a/packages/ui/src/news/news-item-form.tsx
+++ b/packages/ui/src/news/news-item-form.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+import React from 'react'
+import { useForm } from 'react-hook-form'
+import { Button, Paragraph, XStack, YStack } from 'tamagui'
+import { FormInput } from '../form/form-input'
+import { OptimizedTextarea } from '../form/optimized-textarea'
+import { EventFormSelect } from '../form/event-form-select'
+
+export type NewsFormValues = {
+  title: string
+  body: string
+  category: '' | 'medical' | 'general' | 'announcement'
+  durationWeeks: '1' | '2' | '3'
+  sharingScope: 'own' | 'region' | 'global'
+}
+
+export type NewsItemFormProps = {
+  initialValues?: Partial<NewsFormValues>
+  isSaving?: boolean
+  isExisting?: boolean
+  alertAlreadySent?: boolean
+  onSave: (values: NewsFormValues) => void | Promise<void>
+  onCancel: () => void
+  onDelete?: () => void | Promise<void>
+  onSendAlert?: (test: boolean) => void | Promise<void>
+}
+
+const CATEGORY_OPTIONS = [
+  { value: '', label: 'No category' },
+  { value: 'medical', label: 'Medical' },
+  { value: 'general', label: 'General' },
+  { value: 'announcement', label: 'Announcement' },
+]
+
+const DURATION_OPTIONS = [
+  { value: '1', label: '1 week' },
+  { value: '2', label: '2 weeks' },
+  { value: '3', label: '3 weeks' },
+]
+
+const SCOPE_OPTIONS = [
+  { value: 'own', label: 'Own ecclesia only (default)' },
+  { value: 'region', label: 'Nearby ecclesias' },
+  { value: 'global', label: 'All ecclesias' },
+]
+
+export function NewsItemForm({
+  initialValues,
+  isSaving = false,
+  isExisting = false,
+  alertAlreadySent = false,
+  onSave,
+  onCancel,
+  onDelete,
+  onSendAlert,
+}: NewsItemFormProps) {
+  const { control, handleSubmit, formState } = useForm<NewsFormValues>({
+    defaultValues: {
+      title: initialValues?.title || '',
+      body: initialValues?.body || '',
+      category: initialValues?.category || '',
+      durationWeeks: initialValues?.durationWeeks || '1',
+      sharingScope: initialValues?.sharingScope || 'own',
+    },
+  })
+
+  return (
+    <YStack gap="$4" padding="$4">
+      <FormInput
+        control={control}
+        name="title"
+        label="Title"
+        rules={{ required: 'Title is required' }}
+      />
+
+      <OptimizedTextarea
+        control={control}
+        name="body"
+        label="Body"
+        placeholder="What happened? Use # for headings, **bold** for emphasis, plain URLs auto-link."
+        required
+        rows={8}
+        maxLength={4000}
+      />
+
+      <EventFormSelect
+        control={control}
+        name="category"
+        label="Category"
+        options={CATEGORY_OPTIONS}
+        placeholder="No category"
+      />
+
+      <EventFormSelect
+        control={control}
+        name="durationWeeks"
+        label="Show for"
+        options={DURATION_OPTIONS}
+        required
+      />
+
+      <EventFormSelect
+        control={control}
+        name="sharingScope"
+        label="Visibility"
+        options={SCOPE_OPTIONS}
+        required
+      />
+
+      <XStack gap="$3" flexWrap="wrap" marginTop="$2">
+        <Button
+          theme="active"
+          backgroundColor="$primary"
+          color="white"
+          hoverStyle={{ backgroundColor: '$primaryHover' }}
+          disabled={isSaving || formState.isSubmitting}
+          onPress={handleSubmit(onSave)}
+        >
+          {isSaving ? 'Saving…' : isExisting ? 'Save changes' : 'Create news item'}
+        </Button>
+        <Button
+          variant="outlined"
+          borderColor="$borderColor"
+          hoverStyle={{ borderColor: '$textSecondary' }}
+          onPress={onCancel}
+          disabled={isSaving}
+        >
+          Cancel
+        </Button>
+        {isExisting && onSendAlert ? (
+          <>
+            <Button
+              backgroundColor="$info"
+              color="white"
+              hoverStyle={{ backgroundColor: '$infoHover' }}
+              onPress={() => onSendAlert(true)}
+              disabled={isSaving}
+            >
+              Send test alert
+            </Button>
+            <Button
+              backgroundColor={alertAlreadySent ? '$gray8' : '$warning'}
+              color="white"
+              hoverStyle={{ backgroundColor: alertAlreadySent ? '$gray8' : '$warningHover' }}
+              onPress={() => onSendAlert(false)}
+              disabled={isSaving || alertAlreadySent}
+            >
+              {alertAlreadySent ? 'Alert already sent' : 'Send alert to subscribers'}
+            </Button>
+          </>
+        ) : null}
+        {isExisting && onDelete ? (
+          <Button
+            backgroundColor="$error"
+            color="white"
+            hoverStyle={{ backgroundColor: '$errorHover' }}
+            onPress={onDelete}
+            disabled={isSaving}
+            marginLeft="auto"
+          >
+            Delete
+          </Button>
+        ) : null}
+      </XStack>
+
+      {alertAlreadySent ? (
+        <Paragraph color="$textSecondary" fontSize="$3">
+          An email alert has already been sent for this news item. Sending again is disabled to
+          prevent duplicates.
+        </Paragraph>
+      ) : null}
+    </YStack>
+  )
+}

--- a/packages/ui/src/news/news-public-card.tsx
+++ b/packages/ui/src/news/news-public-card.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import { Card, H3, Paragraph } from 'tamagui'
+
+export type NewsPublicCardProps = {
+  id: string
+  title: string
+  body: string
+}
+
+export function NewsPublicCard({ id, title, body }: NewsPublicCardProps) {
+  return (
+    <Link href={`/news/${id}`} style={{ textDecoration: 'none' }}>
+      <Card
+        elevate
+        padded
+        bordered
+        hoverStyle={{ borderColor: '$primary' }}
+        cursor="pointer"
+      >
+        <H3
+          color="$primary"
+          hoverStyle={{ textDecorationLine: 'underline' }}
+          marginBottom="$2"
+        >
+          {title}
+        </H3>
+        <Paragraph whiteSpace="pre-wrap" color="$color">
+          {body}
+        </Paragraph>
+      </Card>
+    </Link>
+  )
+}

--- a/packages/ui/src/news/news-public-card.tsx
+++ b/packages/ui/src/news/news-public-card.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import Link from 'next/link'
+import { Link } from 'solito/link'
 import { Card, H3, Paragraph } from 'tamagui'
 
 export type NewsPublicCardProps = {
@@ -12,7 +12,7 @@ export type NewsPublicCardProps = {
 
 export function NewsPublicCard({ id, title, body }: NewsPublicCardProps) {
   return (
-    <Link href={`/news/${id}`} style={{ textDecoration: 'none' }}>
+    <Link href={`/news/${id}`}>
       <Card
         elevate
         padded


### PR DESCRIPTION
## Summary

Lightweight retrospective counterpart to Events for items that aren't baptisms/weddings/engagements/funerals — medical news, general info, announcements. Title + body + visibility window (1/2/3 weeks), auto-expires, optional one-shot email blast. Closes #41.

- News persists in `tee-schedules` table (PK: `NEWS#{id}`, GSI1PK: `'NEWS'`) alongside Events — sharing model mirrors `event-sharing-resolver` (own / region / global).
- New `'news-alert'` reason + `NewsAlert` React Email template; `/api/admin/news/[id]/send-alert` is one-shot (records `emailBlastSentAt`, `?force=true` override, `?test=true` for test list).
- Weekly Newsletter (web `/newsletter` + email template) renders active news inside the **renamed "Special Announcements" → "Announcements"** section, after events, under the single existing heading.
- Admin nav (`simple-enhanced-navigation` + `with-navigation`) gains a **News Manager** entry directly below **Event Manager**.

## Test plan

- [ ] Sign in as admin/owner, go to `/admin/news`, create a news item with title + body, set duration to 1 week, scope to "Own ecclesia only" — confirm it appears in the admin list as Active.
- [ ] Open `/news` — confirm the item shows with title-as-link and full body (no date, no category badge).
- [ ] Click the title — confirm it navigates to `/news/[id]` and renders.
- [ ] Open `/newsletter` — confirm the news item appears inside the **Announcements** section, after any baptism/wedding/engagement/funeral events.
- [ ] Edit the news item, click **Send test alert** — confirm a test email lands in the test list using the `news-alert` template (title + body only, no date / category).
- [ ] Click **Send alert to subscribers** — confirm send succeeds, the button becomes disabled, and the admin card shows "alert sent".
- [ ] Confirm a second "Send alert" attempt returns a 409 (already sent).
- [ ] (Smoke) Visit `/admin/events` — confirm the Multi-brand Sender Router and other unrelated features from main still work; the existing newsletter cron path still renders.

## Deployment note

This branch was rebased on latest `main` (which includes the multi-brand sender router refactor). The `news-alert` senders entry was adapted to the new shape (no per-reason `name`/`email` — those come from the tenant resolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)