### PR TITLE
Update no-services message to clarify Zoom/YouTube continue

### DIFF
--- a/apps/email-builder/components/ReplacementEventCard.tsx
+++ b/apps/email-builder/components/ReplacementEventCard.tsx
@@ -142,7 +142,7 @@ export const ReplacementEventCard: React.FC<ReplacementEventCardProps> = ({
   return (
     <>
       <Text style={defaultText}>
-        <strong>There will be no Services at Toronto East in person or Online.</strong>
+        <strong>There will be no IN PERSON Services at Toronto East, Zoom and YouTube will remain unchanged.</strong>
         {explanation ? (
           <>
             <br />


### PR DESCRIPTION
## What & why
Urgent wording fix needed tonight. When there are no in-person services at Toronto East, the email message previously read:

> There will be no Services at Toronto East in person or Online.

This is misleading — Zoom and YouTube worship **do** continue. Updated to:

> There will be no IN PERSON Services at Toronto East, Zoom and YouTube will remain unchanged.

## Scope
- One-line change in the shared `ReplacementEventCard` component (`apps/email-builder/components/ReplacementEventCard.tsx:145`), so it applies to **both** the Newsletter and Memorial (recap) emails when a replacement event is shown.

## Known limitation / follow-up
- This is a hardcoded string fix. A separate fallback message (`"There will be no service at our hall."` in `Newsletter.tsx` / `Memorial.tsx`) shows when **no replacement event** exists — it is NOT changed here. If the schedule hits that path, the message will differ.
- **Planned follow-up:** make this message admin-controlled from the Event Editor when creating the replacement event, rather than hardcoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)