### PR TITLE
News: image/PDF upload + asset-driven details page (#47)

### DIFF
--- a/apps/email-builder/emails/NewsAlert.tsx
+++ b/apps/email-builder/emails/NewsAlert.tsx
@@ -4,6 +4,7 @@ import {
   Head,
   Heading,
   Html,
+  Link,
   Preview,
   Section,
   Text,
@@ -11,20 +12,20 @@ import {
 import React from 'react'
 import {
   container,
-  defaultText,
   globalCss,
   header,
+  link,
   main,
 } from '../styles'
 import { Footer } from '../components/Footer'
-import { AutoLinkText } from '../components/AutoLinkText'
 
 export type NewsAlertProps = {
   title: string
-  body: string
+  /** Absolute URL to the news details page (per-brand domain). */
+  detailsUrl: string
 }
 
-const NewsAlert: React.FC<NewsAlertProps> = ({ title, body }) => {
+const NewsAlert: React.FC<NewsAlertProps> = ({ title, detailsUrl }) => {
   return (
     <Html lang="en">
       <Head>
@@ -41,10 +42,10 @@ const NewsAlert: React.FC<NewsAlertProps> = ({ title, body }) => {
             {title}
           </Heading>
 
-          <Section>
-            <Text style={{ ...defaultText, whiteSpace: 'pre-wrap' }}>
-              <AutoLinkText text={body} />
-            </Text>
+          <Section style={{ marginTop: '8px' }}>
+            <Link href={detailsUrl} style={link}>
+              Click to read →
+            </Link>
           </Section>
         </Container>
 

--- a/apps/next/app/(public)/news/[newsId]/page.tsx
+++ b/apps/next/app/(public)/news/[newsId]/page.tsx
@@ -2,8 +2,8 @@
 
 import React, { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
-import { Button, H1, Paragraph, Spinner, YStack } from '@my/ui'
-import { ArrowLeft } from '@tamagui/lucide-icons'
+import { Button, H1, Paragraph, Spinner, Text, XStack, YStack } from '@my/ui'
+import { ArrowLeft, FileText } from '@tamagui/lucide-icons'
 import { useHydrated } from '@my/app/hooks/use-hydrated'
 import type { NewsItem } from '@my/app/types/news'
 
@@ -80,6 +80,41 @@ export default function NewsDetailPage() {
       <Paragraph whiteSpace="pre-wrap" lineHeight="$6">
         {item.body}
       </Paragraph>
+
+      {item.posterImage ? (
+        <img
+          src={item.posterImage.url}
+          alt={item.posterImage.originalName || item.title}
+          style={{ maxWidth: '100%', height: 'auto', borderRadius: 8 }}
+        />
+      ) : null}
+
+      {item.documents && item.documents.length > 0 ? (
+        <YStack gap="$2" marginTop="$2">
+          {item.documents.map((doc) => (
+            <a
+              key={doc.id}
+              href={doc.fileUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ textDecoration: 'none' }}
+            >
+              <XStack
+                gap="$2"
+                alignItems="center"
+                padding="$3"
+                borderWidth={1}
+                borderColor="$borderColor"
+                borderRadius="$4"
+                hoverStyle={{ borderColor: '$primary' }}
+              >
+                <FileText size={18} color="$primary" />
+                <Text color="$primary">{doc.originalName || 'Attachment'}</Text>
+              </XStack>
+            </a>
+          ))}
+        </YStack>
+      ) : null}
     </YStack>
   )
 }

--- a/apps/next/app/admin/(admin-plus)/news/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/news/page.tsx
@@ -62,6 +62,8 @@ export default function AdminNewsPage() {
         category: values.category || undefined,
         durationWeeks: Number(values.durationWeeks),
         sharingScope: values.sharingScope,
+        posterImage: values.posterImage ?? null,
+        documents: values.documents ?? [],
       }
 
       let res: Response
@@ -151,6 +153,8 @@ export default function AdminNewsPage() {
             category: mode.item.category || ('' as const),
             durationWeeks: String(mode.item.durationWeeks) as '1' | '2' | '3',
             sharingScope: mode.item.sharingScope,
+            posterImage: mode.item.posterImage,
+            documents: mode.item.documents || [],
           }
         : undefined
 

--- a/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
+++ b/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
@@ -10,6 +10,7 @@ import {
   markNewsBlastSent,
 } from '@my/app/services/news-service'
 import { isNewsActive } from '@my/app/types/news'
+import { getTenantFromHeaders, resolveTenantFromEnv } from '@my/app/config/tenants'
 
 export const config = {
   maxDuration: 60,
@@ -54,9 +55,15 @@ export async function POST(
       )
     }
 
+    // Resolve the brand domain so the "click to read" link points at the
+    // correct surface (tee-admin.com vs echadhub.org). Falls back to the
+    // deployment's env-configured tenant when the host isn't recognized.
+    const tenant = getTenantFromHeaders(request.headers) || resolveTenantFromEnv()
+    const detailsUrl = `https://www.${tenant.senderDomain}/news/${news.id}`
+
     const emailElement = createElement(NewsAlert as any, {
       title: news.title,
-      body: news.body,
+      detailsUrl,
     })
     const emailHtml = await render(emailElement)
     const emailText = await render(emailElement, { plainText: true })
@@ -70,6 +77,7 @@ export async function POST(
       subReason: 'general',
       description: `News alert: ${news.title}`,
       sentBy: session.user.email,
+      tenant,
     })
 
     if (result instanceof Error) {

--- a/apps/next/app/api/admin/news/route.ts
+++ b/apps/next/app/api/admin/news/route.ts
@@ -61,6 +61,8 @@ export async function POST(request: NextRequest) {
       title: body.title,
       body: body.body,
       category: body.category,
+      posterImage: body.posterImage || undefined,
+      documents: Array.isArray(body.documents) ? body.documents : undefined,
       durationWeeks: body.durationWeeks,
       sharingScope: body.sharingScope || 'own',
       publishedAt: body.publishedAt ? new Date(body.publishedAt) : undefined,

--- a/packages/app/features/newsletter/newsletter-screen.tsx
+++ b/packages/app/features/newsletter/newsletter-screen.tsx
@@ -17,7 +17,6 @@ import type { NewsItem } from '@my/app/types/news'
 import { isNewsActive } from '@my/app/types/news'
 import { EventDurationCalculator } from '@my/app/utils/newsletter/event-duration'
 import { EventSummaryCard } from '@my/ui/src/events/event-summary-card'
-import { Paragraph } from '@my/ui'
 import { Vote } from '@tamagui/lucide-icons'
 
 // Helper function to check if an election-cycle event is currently active
@@ -452,12 +451,17 @@ export const NewsletterScreen: React.FC<NewsletterScreenProps> = ({
                   padding="$4"
                   borderRadius="$4"
                   backgroundColor="$background"
+                  cursor="pointer"
+                  hoverStyle={{ borderColor: '$primary' }}
+                  onPress={() => onNavigate?.(`/news/${item.id}`)}
                 >
                   <YStack gap="$2">
                     <Text fontSize="$6" fontWeight="600">
                       {item.title}
                     </Text>
-                    <Paragraph whiteSpace="pre-wrap">{item.body}</Paragraph>
+                    <Text color="$primary" hoverStyle={{ textDecorationLine: 'underline' }}>
+                      Read details →
+                    </Text>
                   </YStack>
                 </Card>
               ))}

--- a/packages/app/services/news-service.ts
+++ b/packages/app/services/news-service.ts
@@ -26,6 +26,15 @@ const deserializeNews = (raw: string): NewsItem => {
   if (parsed.createdAt) parsed.createdAt = new Date(parsed.createdAt)
   if (parsed.updatedAt) parsed.updatedAt = new Date(parsed.updatedAt)
   if (parsed.emailBlastSentAt) parsed.emailBlastSentAt = new Date(parsed.emailBlastSentAt)
+  if (parsed.posterImage?.uploadedAt) {
+    parsed.posterImage.uploadedAt = new Date(parsed.posterImage.uploadedAt)
+  }
+  if (Array.isArray(parsed.documents)) {
+    parsed.documents = parsed.documents.map((doc: any) => ({
+      ...doc,
+      uploadedAt: doc.uploadedAt ? new Date(doc.uploadedAt) : doc.uploadedAt,
+    }))
+  }
   return parsed as NewsItem
 }
 
@@ -65,6 +74,8 @@ export const createNewsItem = async (data: CreateNewsRequest): Promise<NewsItem>
     title: data.title,
     body: data.body,
     category: data.category,
+    posterImage: data.posterImage,
+    documents: data.documents,
     publishedAt,
     expiresAt,
     durationWeeks: data.durationWeeks,

--- a/packages/app/types/news.ts
+++ b/packages/app/types/news.ts
@@ -1,11 +1,22 @@
 // News Manager types — lightweight retrospective counterpart to Events.
 // See https://github.com/keneasson/tee-admin/issues/41
 
-import type { EventSharingScope } from './events'
+import type { DocumentAttachment, EventSharingScope } from './events'
 
 export type NewsCategory = 'medical' | 'general' | 'announcement'
 
 export type NewsDurationWeeks = 1 | 2 | 3
+
+/**
+ * Poster image attached to a News item (Issue #47 — v2 of #41). Matches the
+ * shape produced by the shared ImageUpload component (and Event photos).
+ */
+export interface NewsImage {
+  url: string
+  fileName: string
+  originalName: string
+  uploadedAt: Date
+}
 
 export interface NewsItem {
   id: string
@@ -14,6 +25,10 @@ export interface NewsItem {
   title: string
   body: string
   category?: NewsCategory
+  /** Optional poster image shown on the details page (Issue #47). */
+  posterImage?: NewsImage
+  /** Optional attachments (PDFs etc.) linked from the details page (Issue #47). */
+  documents?: DocumentAttachment[]
   publishedAt: Date
   expiresAt: Date
   durationWeeks: NewsDurationWeeks

--- a/packages/ui/src/news/news-item-form.tsx
+++ b/packages/ui/src/news/news-item-form.tsx
@@ -1,11 +1,15 @@
 'use client'
 
 import React from 'react'
-import { useForm } from 'react-hook-form'
+import { Controller, useForm } from 'react-hook-form'
 import { Button, Paragraph, XStack, YStack } from 'tamagui'
 import { FormInput } from '../form/form-input'
 import { OptimizedTextarea } from '../form/optimized-textarea'
 import { EventFormSelect } from '../form/event-form-select'
+import { ImageUpload } from '../form/image-upload'
+import { DocumentUpload } from '../form/document-upload'
+import type { DocumentAttachment } from '@my/app/types/events'
+import type { NewsImage } from '@my/app/types/news'
 
 export type NewsFormValues = {
   title: string
@@ -13,6 +17,8 @@ export type NewsFormValues = {
   category: '' | 'medical' | 'general' | 'announcement'
   durationWeeks: '1' | '2' | '3'
   sharingScope: 'own' | 'region' | 'global'
+  posterImage?: NewsImage
+  documents: DocumentAttachment[]
 }
 
 export type NewsItemFormProps = {
@@ -62,6 +68,8 @@ export function NewsItemForm({
       category: initialValues?.category || '',
       durationWeeks: initialValues?.durationWeeks || '1',
       sharingScope: initialValues?.sharingScope || 'own',
+      posterImage: initialValues?.posterImage,
+      documents: initialValues?.documents || [],
     },
   })
 
@@ -82,6 +90,40 @@ export function NewsItemForm({
         required
         rows={8}
         maxLength={4000}
+      />
+
+      <Controller
+        control={control}
+        name="posterImage"
+        render={({ field }) => (
+          <ImageUpload
+            label="Poster image (optional)"
+            placeholder="Add a poster or photo for the details page"
+            value={field.value}
+            onChange={field.onChange}
+            disabled={isSaving}
+          />
+        )}
+      />
+
+      <Controller
+        control={control}
+        name="documents"
+        render={({ field }) => (
+          <YStack gap="$2">
+            <Paragraph fontSize="$4" fontWeight="500" color="$gray12">
+              Attachments (optional)
+            </Paragraph>
+            <Paragraph fontSize="$3" color="$gray10">
+              PDFs or files to link from the details page.
+            </Paragraph>
+            <DocumentUpload
+              documents={field.value || []}
+              onChange={field.onChange}
+              disabled={isSaving}
+            />
+          </YStack>
+        )}
       />
 
       <EventFormSelect


### PR DESCRIPTION
## Summary
Implements #47 — News items can carry a **poster image** and **PDF/file attachments**, reusing the existing Event S3 upload system. The newsletter and email now link out to a details page instead of inlining the full body.

## Changes
- **Data:** `NewsItem` gains `posterImage` + `documents`, stored in the existing `details` JSON blob — **no DynamoDB schema change**. Dates revived on read in `news-service`.
- **Editor:** `ImageUpload` ("Poster image") + `DocumentUpload` ("Attachments") wired into the News form via react-hook-form `Controller`; threaded through the admin page + `POST /api/admin/news`.
- **Details page** (`/news/[id]`): renders the poster image and attachment links after the body.
- **Newsletter (web):** news reduced to title + "Read details →" link.
- **NewsAlert email:** reduced to title + "Click to read" link to the details page (per-brand absolute URL).

## Notes
- Reuses `packages/ui/src/form/{image-upload,document-upload}.tsx` → `/api/files/upload` → S3 (the same flow Events use). No new asset infrastructure.
- The `PATCH` route already spreads the body, so updates carry the new fields automatically.

## Verification
- Typecheck + build verified on the source commit; CI will re-verify here.
- Manual: create/edit a News item with an image + PDF, confirm they render on the details page and that the newsletter/email link out correctly.

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)