### PR TITLE
Multi-tenant: ecclesia-scoped authorization on content write routes

### DIFF
--- a/apps/next/app/api/admin/events/route.ts
+++ b/apps/next/app/api/admin/events/route.ts
@@ -11,6 +11,8 @@ import {
 import { isEventActive } from '@my/app/types/events'
 import { invalidateEventsCache } from '@/utils/cache'
 import { notifyRBsOfSharedEvent } from '@/utils/notify-rbs-of-shared-event'
+import { authorizeContentEcclesia, canAuthorForEcclesia } from '@/utils/ecclesia-permissions'
+import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
 
 // Helper functions to extract date/time for sorting
 const extractEventDate = (event: any): string => {
@@ -140,12 +142,22 @@ export async function POST(request: NextRequest) {
     }
 
     const postCallerRole = (session.user as any).role as string || ROLES.GUEST
-    if (postCallerRole !== ROLES.ADMIN && postCallerRole !== ROLES.OWNER) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
-    }
 
     const eventData = await request.json()
     eventData.createdBy = session.user.email
+
+    // Ecclesia-scoped authorization — validate/derive the owning ecclesia and
+    // stamp it server-side (never trust the raw client value). OWNER may author
+    // for any ecclesia; scoped roles only for their own / managed region.
+    const postAuthz = await authorizeContentEcclesia(
+      session.user.email,
+      postCallerRole,
+      eventData.ownerEcclesia || eventData.hostingEcclesia?.name
+    )
+    if (!postAuthz.ok) {
+      return NextResponse.json({ error: postAuthz.error }, { status: postAuthz.status })
+    }
+    eventData.ownerEcclesia = postAuthz.ecclesia
 
     // Determine if this is a draft save or full create
     let event
@@ -183,9 +195,6 @@ export async function PUT(request: NextRequest) {
     }
 
     const putCallerRole = (session.user as any).role as string || ROLES.GUEST
-    if (putCallerRole !== ROLES.ADMIN && putCallerRole !== ROLES.OWNER) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
-    }
 
     const eventData = await request.json()
 
@@ -193,9 +202,36 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Event ID required for update' }, { status: 400 })
     }
 
-    // Fetch old event to detect activation transitions
+    // Fetch old event to detect activation transitions + check ownership
     const oldEvent = await getEventById(eventData.id)
     const wasActive = oldEvent ? isEventActive(oldEvent) : false
+
+    // Ecclesia-scoped authorization: must be allowed to manage the event's
+    // current owner; if reassigning ownership, must also be allowed for the new one.
+    const currentOwner =
+      oldEvent?.ownerEcclesia || oldEvent?.hostingEcclesia?.name || HOME_ECCLESIA.canonicalName
+    if (oldEvent) {
+      const canEditExisting = await canAuthorForEcclesia(
+        session.user.email,
+        putCallerRole,
+        currentOwner
+      )
+      if (!canEditExisting) {
+        return NextResponse.json(
+          { error: `You do not have permission to manage content for ${currentOwner}.` },
+          { status: 403 }
+        )
+      }
+    }
+    const putAuthz = await authorizeContentEcclesia(
+      session.user.email,
+      putCallerRole,
+      eventData.ownerEcclesia || eventData.hostingEcclesia?.name || currentOwner
+    )
+    if (!putAuthz.ok) {
+      return NextResponse.json({ error: putAuthz.error }, { status: putAuthz.status })
+    }
+    eventData.ownerEcclesia = putAuthz.ecclesia
 
     // Update uses saveEventDraft which handles both draft and published updates
     const event = await saveEventDraft(eventData)
@@ -230,15 +266,31 @@ export async function DELETE(request: NextRequest) {
     }
 
     const deleteCallerRole = (session.user as any).role as string || ROLES.GUEST
-    if (deleteCallerRole !== ROLES.ADMIN && deleteCallerRole !== ROLES.OWNER) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
-    }
 
     const { searchParams } = new URL(request.url)
     const eventId = searchParams.get('id')
 
     if (!eventId) {
       return NextResponse.json({ error: 'Event ID required' }, { status: 400 })
+    }
+
+    // Ecclesia-scoped authorization against the event's owner.
+    const existing = await getEventById(eventId)
+    if (!existing) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+    const deleteOwner =
+      existing.ownerEcclesia || existing.hostingEcclesia?.name || HOME_ECCLESIA.canonicalName
+    const canDelete = await canAuthorForEcclesia(
+      session.user.email,
+      deleteCallerRole,
+      deleteOwner
+    )
+    if (!canDelete) {
+      return NextResponse.json(
+        { error: `You do not have permission to manage content for ${deleteOwner}.` },
+        { status: 403 }
+      )
     }
 
     const success = await deleteEvent(eventId)

--- a/apps/next/app/api/admin/meetings/[meetingId]/route.ts
+++ b/apps/next/app/api/admin/meetings/[meetingId]/route.ts
@@ -4,6 +4,7 @@ import { ROLES } from '@my/app/provider/auth/auth-roles'
 import { checkFeatureFlagFromDB } from '@my/app/features/feature-flags/use-feature-flag-wrapper'
 import { FEATURE_FLAGS } from '@my/app/features/feature-flags/feature-flags'
 import { meetingRepository } from '@my/app/provider/dynamodb/repositories/meeting-repository'
+import { authorizeContentEcclesia, canAuthorForEcclesia } from '@/utils/ecclesia-permissions'
 
 /**
  * GET /api/admin/meetings/[meetingId] - Fetch a single meeting
@@ -62,9 +63,6 @@ export async function PATCH(
     }
 
     const userRole = (session.user as any).role || ROLES.GUEST
-    if (userRole !== ROLES.ADMIN && userRole !== ROLES.OWNER) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
-    }
 
     const showMultiTenant = await checkFeatureFlagFromDB(FEATURE_FLAGS.MULTI_TENANT_INIT, session as any)
     if (!showMultiTenant) {
@@ -72,6 +70,24 @@ export async function PATCH(
     }
 
     const { meetingId } = await params
+
+    // Ecclesia-scoped authorization against the meeting's current owner.
+    const existing = await meetingRepository.getById(meetingId)
+    if (!existing) {
+      return NextResponse.json({ error: 'Meeting not found' }, { status: 404 })
+    }
+    if (existing.ownerType === 'ecclesia') {
+      const canEdit = await canAuthorForEcclesia(session.user.email, userRole, existing.ownerName)
+      if (!canEdit) {
+        return NextResponse.json(
+          { error: `You do not have permission to manage content for ${existing.ownerName}.` },
+          { status: 403 }
+        )
+      }
+    } else if (userRole !== ROLES.ADMIN && userRole !== ROLES.OWNER) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+    }
+
     const body = await request.json()
 
     // Remove immutable fields
@@ -85,6 +101,23 @@ export async function PATCH(
       createdBy: _createdBy,
       ...updateFields
     } = body
+
+    // If reassigning to a different ecclesia, the caller must also be permitted there.
+    if (
+      updateFields.ownerType === 'ecclesia' &&
+      updateFields.ownerName &&
+      updateFields.ownerName !== existing.ownerName
+    ) {
+      const authz = await authorizeContentEcclesia(
+        session.user.email,
+        userRole,
+        updateFields.ownerName
+      )
+      if (!authz.ok) {
+        return NextResponse.json({ error: authz.error }, { status: authz.status })
+      }
+      updateFields.ownerName = authz.ecclesia
+    }
 
     const updated = await meetingRepository.updateMeeting(meetingId, updateFields)
     if (!updated) {
@@ -116,9 +149,6 @@ export async function DELETE(
     }
 
     const userRole = (session.user as any).role || ROLES.GUEST
-    if (userRole !== ROLES.OWNER) {
-      return NextResponse.json({ error: 'Owner access required' }, { status: 403 })
-    }
 
     const showMultiTenant = await checkFeatureFlagFromDB(FEATURE_FLAGS.MULTI_TENANT_INIT, session as any)
     if (!showMultiTenant) {
@@ -126,6 +156,26 @@ export async function DELETE(
     }
 
     const { meetingId } = await params
+
+    // Ecclesia-scoped authorization against the meeting's owner. Ecclesia-owned
+    // meetings can be deleted by anyone who manages that ecclesia; organization-
+    // owned meetings remain owner-only until org permissions are modelled.
+    const existing = await meetingRepository.getById(meetingId)
+    if (!existing) {
+      return NextResponse.json({ error: 'Meeting not found' }, { status: 404 })
+    }
+    if (existing.ownerType === 'ecclesia') {
+      const canDelete = await canAuthorForEcclesia(session.user.email, userRole, existing.ownerName)
+      if (!canDelete) {
+        return NextResponse.json(
+          { error: `You do not have permission to manage content for ${existing.ownerName}.` },
+          { status: 403 }
+        )
+      }
+    } else if (userRole !== ROLES.OWNER) {
+      return NextResponse.json({ error: 'Owner access required' }, { status: 403 })
+    }
+
     const deleted = await meetingRepository.deleteMeeting(meetingId)
     if (!deleted) {
       return NextResponse.json({ error: 'Meeting not found' }, { status: 404 })

--- a/apps/next/app/api/admin/meetings/[meetingId]/send/route.ts
+++ b/apps/next/app/api/admin/meetings/[meetingId]/send/route.ts
@@ -9,6 +9,7 @@ import { createElement } from 'react'
 import MeetingEmail from 'email-builder/emails/MeetingEmail'
 import { emailSend } from '@/utils/email/email-send'
 import { meetingRecordToEmailProps } from '@/utils/email/meeting-email-helpers'
+import { canAuthorForEcclesia } from '@/utils/ecclesia-permissions'
 
 export const config = {
   maxDuration: 60,
@@ -29,9 +30,6 @@ export async function POST(
     }
 
     const userRole = (session.user as any).role || ROLES.GUEST
-    if (userRole !== ROLES.ADMIN && userRole !== ROLES.OWNER) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
-    }
 
     const showMultiTenant = await checkFeatureFlagFromDB(FEATURE_FLAGS.MULTI_TENANT_INIT, session as any)
     if (!showMultiTenant) {
@@ -45,6 +43,19 @@ export async function POST(
     const meeting = await meetingRepository.getById(meetingId)
     if (!meeting) {
       return NextResponse.json({ error: 'Meeting not found' }, { status: 404 })
+    }
+
+    // Ecclesia-scoped authorization against the meeting's owner.
+    if (meeting.ownerType === 'ecclesia') {
+      const canSend = await canAuthorForEcclesia(session.user.email, userRole, meeting.ownerName)
+      if (!canSend) {
+        return NextResponse.json(
+          { error: `You do not have permission to manage content for ${meeting.ownerName}.` },
+          { status: 403 }
+        )
+      }
+    } else if (userRole !== ROLES.ADMIN && userRole !== ROLES.OWNER) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
     }
 
     // Map MeetingRecord to MeetingEmail props

--- a/apps/next/app/api/admin/meetings/route.ts
+++ b/apps/next/app/api/admin/meetings/route.ts
@@ -4,6 +4,7 @@ import { ROLES } from '@my/app/provider/auth/auth-roles'
 import { checkFeatureFlagFromDB } from '@my/app/features/feature-flags/use-feature-flag-wrapper'
 import { FEATURE_FLAGS } from '@my/app/features/feature-flags/feature-flags'
 import { meetingRepository } from '@my/app/provider/dynamodb/repositories/meeting-repository'
+import { authorizeContentEcclesia } from '@/utils/ecclesia-permissions'
 
 /**
  * GET /api/admin/meetings - List meetings
@@ -65,9 +66,6 @@ export async function POST(request: NextRequest) {
     }
 
     const userRole = (session.user as any).role || ROLES.GUEST
-    if (userRole !== ROLES.ADMIN && userRole !== ROLES.OWNER) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
-    }
 
     const showMultiTenant = await checkFeatureFlagFromDB(FEATURE_FLAGS.MULTI_TENANT_INIT, session as any)
     if (!showMultiTenant) {
@@ -103,11 +101,25 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // Ecclesia-scoped authorization. Ecclesia-owned meetings are gated by the
+    // owning ecclesia; organization-owned meetings keep the global admin gate
+    // until organization-level permissions are modelled.
+    let resolvedOwnerName = ownerName
+    if (ownerType === 'ecclesia') {
+      const authz = await authorizeContentEcclesia(session.user.email, userRole, ownerName)
+      if (!authz.ok) {
+        return NextResponse.json({ error: authz.error }, { status: authz.status })
+      }
+      resolvedOwnerName = authz.ecclesia
+    } else if (userRole !== ROLES.ADMIN && userRole !== ROLES.OWNER) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+    }
+
     const meeting = await meetingRepository.create({
       title,
       meetingType,
       ownerType,
-      ownerName,
+      ownerName: resolvedOwnerName,
       recurrence,
       oneOffDate,
       startTime,

--- a/apps/next/app/api/admin/news/[newsId]/route.ts
+++ b/apps/next/app/api/admin/news/[newsId]/route.ts
@@ -6,7 +6,7 @@ import {
   getNewsItemById,
   updateNewsItem,
 } from '@my/app/services/news-service'
-import { canAuthorForEcclesia } from '@/utils/ecclesia-permissions'
+import { authorizeContentEcclesia, canAuthorForEcclesia } from '@/utils/ecclesia-permissions'
 import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
 
 async function requireAuth() {
@@ -78,9 +78,24 @@ export async function PATCH(
       return NextResponse.json({ error: 'durationWeeks must be 1, 2, or 3' }, { status: 400 })
     }
 
-    // Ecclesia-scoped authorization against the item's owner.
+    // Ecclesia-scoped authorization against the item's current owner.
     const authz = await authorizeNewsItem(guard.session, newsId)
     if ('error' in authz) return authz.error
+
+    // If reassigning to a different ecclesia, the caller must also be permitted
+    // there (mirrors events PUT / meetings PATCH). Stamp the validated value.
+    if (body.ecclesiaId && body.ecclesiaId !== authz.news.ecclesiaId) {
+      const role = (guard.session.user as any).role || ROLES.GUEST
+      const target = await authorizeContentEcclesia(
+        guard.session.user!.email!,
+        role,
+        body.ecclesiaId
+      )
+      if (!target.ok) {
+        return NextResponse.json({ error: target.error }, { status: target.status })
+      }
+      body.ecclesiaId = target.ecclesia
+    }
 
     const updated = await updateNewsItem({
       ...body,

--- a/apps/next/app/api/admin/news/[newsId]/route.ts
+++ b/apps/next/app/api/admin/news/[newsId]/route.ts
@@ -6,24 +6,48 @@ import {
   getNewsItemById,
   updateNewsItem,
 } from '@my/app/services/news-service'
+import { canAuthorForEcclesia } from '@/utils/ecclesia-permissions'
+import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
 
-async function requireAdmin() {
+async function requireAuth() {
   const session = await auth()
   if (!session?.user?.email) {
     return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   }
-  const role = (session.user as any).role || ROLES.GUEST
-  if (role !== ROLES.ADMIN && role !== ROLES.OWNER) {
-    return { error: NextResponse.json({ error: 'Admin access required' }, { status: 403 }) }
-  }
   return { session }
+}
+
+/**
+ * Authorize the caller to manage a specific news item, scoped to its owning
+ * ecclesia. Returns the item on success, or a NextResponse error (404/403).
+ */
+async function authorizeNewsItem(
+  session: NonNullable<Awaited<ReturnType<typeof auth>>>,
+  newsId: string
+) {
+  const news = await getNewsItemById(newsId)
+  if (!news) {
+    return { error: NextResponse.json({ error: 'News item not found' }, { status: 404 }) }
+  }
+  const role = (session.user as any).role || ROLES.GUEST
+  const owner = news.ecclesiaId || HOME_ECCLESIA.canonicalName
+  const allowed = await canAuthorForEcclesia(session.user!.email!, role, owner)
+  if (!allowed) {
+    return {
+      error: NextResponse.json(
+        { error: `You do not have permission to manage content for ${owner}.` },
+        { status: 403 }
+      ),
+    }
+  }
+  return { news }
 }
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ newsId: string }> }
 ) {
-  const guard = await requireAdmin()
+  const guard = await requireAuth()
   if ('error' in guard) return guard.error
 
   try {
@@ -43,7 +67,7 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ newsId: string }> }
 ) {
-  const guard = await requireAdmin()
+  const guard = await requireAuth()
   if ('error' in guard) return guard.error
 
   try {
@@ -53,6 +77,10 @@ export async function PATCH(
     if (body.durationWeeks !== undefined && ![1, 2, 3].includes(body.durationWeeks)) {
       return NextResponse.json({ error: 'durationWeeks must be 1, 2, or 3' }, { status: 400 })
     }
+
+    // Ecclesia-scoped authorization against the item's owner.
+    const authz = await authorizeNewsItem(guard.session, newsId)
+    if ('error' in authz) return authz.error
 
     const updated = await updateNewsItem({
       ...body,
@@ -72,11 +100,16 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ newsId: string }> }
 ) {
-  const guard = await requireAdmin()
+  const guard = await requireAuth()
   if ('error' in guard) return guard.error
 
   try {
     const { newsId } = await params
+
+    // Ecclesia-scoped authorization against the item's owner.
+    const authz = await authorizeNewsItem(guard.session, newsId)
+    if ('error' in authz) return authz.error
+
     const ok = await deleteNewsItem(newsId)
     if (!ok) {
       return NextResponse.json({ error: 'News item not found' }, { status: 404 })

--- a/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
+++ b/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
@@ -15,6 +15,8 @@ import { getTenantFromHeaders, resolveTenantFromEnv } from '@my/app/config/tenan
 import { resolveBrandProfile } from '@/utils/email/resolve-brand-profile'
 import { emailIdentityFromProfile } from '@my/app/types/brand-profile'
 import { EmailIdentityProvider } from 'email-builder/components/email-identity'
+import { canAuthorForEcclesia } from '@/utils/ecclesia-permissions'
+import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
 
 export const config = {
   maxDuration: 60,
@@ -36,9 +38,6 @@ export async function POST(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
     const role = (session.user as any).role || ROLES.GUEST
-    if (role !== ROLES.ADMIN && role !== ROLES.OWNER) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
-    }
 
     const { newsId } = await params
     const { searchParams } = new URL(request.url)
@@ -48,6 +47,17 @@ export async function POST(
     const news = await getNewsItemById(newsId)
     if (!news) {
       return NextResponse.json({ error: 'News item not found' }, { status: 404 })
+    }
+
+    // Ecclesia-scoped authorization — only someone who manages this item's
+    // owning ecclesia may blast an alert for it.
+    const alertOwner = news.ecclesiaId || HOME_ECCLESIA.canonicalName
+    const canSend = await canAuthorForEcclesia(session.user.email, role, alertOwner)
+    if (!canSend) {
+      return NextResponse.json(
+        { error: `You do not have permission to manage content for ${alertOwner}.` },
+        { status: 403 }
+      )
     }
     if (!isNewsActive(news)) {
       return NextResponse.json({ error: 'News item has expired' }, { status: 400 })

--- a/apps/next/app/api/admin/news/route.ts
+++ b/apps/next/app/api/admin/news/route.ts
@@ -2,8 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/utils/auth'
 import { ROLES } from '@my/app/provider/auth/auth-roles'
 import { createNewsItem, listNewsItems } from '@my/app/services/news-service'
-import { personRepository } from '@my/app/provider/dynamodb/repositories/person-repository'
-import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
+import { authorizeContentEcclesia } from '@/utils/ecclesia-permissions'
 
 /**
  * Admin News API — News Manager (Issue #41)
@@ -39,9 +38,6 @@ export async function POST(request: NextRequest) {
     }
 
     const role = (session.user as any).role || ROLES.GUEST
-    if (role !== ROLES.ADMIN && role !== ROLES.OWNER) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
-    }
 
     const body = await request.json()
     if (!body.title || !body.body) {
@@ -51,9 +47,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'durationWeeks must be 1, 2, or 3' }, { status: 400 })
     }
 
-    // Resolve author's ecclesia (falls back to home ecclesia for single-tenant deploy)
-    const person = await personRepository.getByEmail(session.user.email)
-    const ecclesiaId = body.ecclesiaId || person?.ecclesia || HOME_ECCLESIA.canonicalName
+    // Ecclesia-scoped authorization — validate/derive the owning ecclesia
+    // (defaults to the author's home ecclesia when not supplied).
+    const authz = await authorizeContentEcclesia(session.user.email, role, body.ecclesiaId)
+    if (!authz.ok) {
+      return NextResponse.json({ error: authz.error }, { status: authz.status })
+    }
+    const ecclesiaId = authz.ecclesia
 
     const news = await createNewsItem({
       ecclesiaId,

--- a/apps/next/utils/ecclesia-permissions.ts
+++ b/apps/next/utils/ecclesia-permissions.ts
@@ -1,5 +1,7 @@
 import { ROLES } from '@my/app/provider/auth/auth-roles'
 import { personRepository } from '@my/app/provider/dynamodb/repositories/person-repository'
+import { getDefaultRegion } from '@my/app/config/regions'
+import { getEcclesiaByName } from './dynamodb/locations'
 
 /**
  * Check if a user can edit a given ecclesia.
@@ -74,4 +76,113 @@ export async function checkRecordingBrotherPermission(
   }
 
   return false
+}
+
+/**
+ * Resolve which region an ecclesia belongs to: its explicit `region` field if
+ * set, otherwise derived from country/province. Returns null if the ecclesia
+ * isn't found or has no location to derive from.
+ */
+async function getEcclesiaRegion(ecclesiaName: string): Promise<string | null> {
+  const ecclesia = await getEcclesiaByName(ecclesiaName)
+  if (!ecclesia) return null
+  if (ecclesia.region) return ecclesia.region
+  if (!ecclesia.country) return null
+  return getDefaultRegion(ecclesia.country, ecclesia.province)
+}
+
+/**
+ * Can this user AUTHOR content (events / news / meetings) for a given ecclesia?
+ *
+ * Same ownership rules as {@link checkEcclesiaEditPermission}, plus regional
+ * admins: an ADMIN/REP/RECORDER whose `managedRegions` covers the ecclesia's
+ * region may author for it. OWNER may author for any ecclesia (this is how the
+ * owner "selects" which org they operate as — content is still stamped with a
+ * real, validated ecclesia, never a blind body value).
+ *
+ * NOTE: this is the WRITE/authoring gate; it does not change a person's home
+ * ecclesia membership (PersonRecord.ecclesia), which is where they appear in
+ * directories.
+ */
+export async function canAuthorForEcclesia(
+  userEmail: string,
+  userRole: string,
+  ecclesiaName: string
+): Promise<boolean> {
+  if (userRole === ROLES.OWNER) {
+    return true
+  }
+
+  const person = await personRepository.getByEmail(userEmail)
+  if (!person) {
+    return false
+  }
+
+  const isStaff =
+    userRole === ROLES.ADMIN || userRole === ROLES.RECORDER || userRole === ROLES.REP
+  const isSameEcclesia = person.ecclesia === ecclesiaName
+
+  // Own ecclesia: staff roles, or the recording brother designation.
+  if (isSameEcclesia && (isStaff || person.isRecordingBrother)) {
+    return true
+  }
+
+  // Regional admin: managedRegions covers the target ecclesia's region.
+  if (isStaff && person.managedRegions && person.managedRegions.length > 0) {
+    const region = await getEcclesiaRegion(ecclesiaName)
+    if (region && person.managedRegions.includes(region)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export type ContentEcclesiaAuth =
+  | { ok: true; ecclesia: string }
+  | { ok: false; status: number; error: string }
+
+/**
+ * Resolve AND authorize the ecclesia a content write targets.
+ *
+ * - `requestedEcclesia` is what the client asked for (e.g. event.hostingEcclesia.name,
+ *   news.ecclesiaId, meeting.ownerName). It is never trusted blindly.
+ * - If omitted, defaults to the caller's home ecclesia (so a scoped admin who
+ *   doesn't specify simply authors for their own ecclesia).
+ * - The resolved ecclesia is only returned if {@link canAuthorForEcclesia} passes,
+ *   otherwise a 403 (or 400 when no ecclesia can be determined).
+ *
+ * Callers should stamp the returned `ecclesia` onto the content rather than
+ * re-reading the client value.
+ */
+export async function authorizeContentEcclesia(
+  userEmail: string,
+  userRole: string,
+  requestedEcclesia: string | null | undefined
+): Promise<ContentEcclesiaAuth> {
+  let target = (requestedEcclesia || '').trim()
+
+  if (!target) {
+    const person = await personRepository.getByEmail(userEmail)
+    target = (person?.ecclesia || '').trim()
+  }
+
+  if (!target) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'Could not determine which ecclesia this content belongs to.',
+    }
+  }
+
+  const allowed = await canAuthorForEcclesia(userEmail, userRole, target)
+  if (!allowed) {
+    return {
+      ok: false,
+      status: 403,
+      error: `You do not have permission to manage content for ${target}.`,
+    }
+  }
+
+  return { ok: true, ecclesia: target }
 }

--- a/packages/app/types/events.ts
+++ b/packages/app/types/events.ts
@@ -369,6 +369,14 @@ export interface Event extends BaseEvent {
 
   // Multi-tenant event sharing
   sharingScope?: EventSharingScope
+
+  /**
+   * Ecclesia that OWNS this event for authorization (who may edit/delete it).
+   * Distinct from `hostingEcclesia` (a display field). Set server-side from the
+   * validated authoring context on create; legacy events without it fall back to
+   * hostingEcclesia?.name then the home ecclesia.
+   */
+  ownerEcclesia?: string
 }
 
 // Type-specific event aliases for use in type-narrowed contexts


### PR DESCRIPTION
## What

Closes the write-side multi-tenancy gap: events/news/meetings create/update/delete previously gated only on a **global** `ADMIN||OWNER` role and took the target ecclesia from the request body **unchecked** — so any admin could write to any ecclesia, and an ecclesia's RB/Rep couldn't author their own content.

New authoring gate in `apps/next/utils/ecclesia-permissions.ts`:
- `canAuthorForEcclesia(email, role, ecclesia)` — OWNER → any (how the owner "selects" which org they operate as); ADMIN/REP/RECORDER or RB → own ecclesia; ADMIN/REP/RECORDER → ecclesias covered by their `managedRegions` (first enforcement of that field, via `regions.ts`).
- `authorizeContentEcclesia(...)` — resolves + validates the owning ecclesia (defaults to caller's home), returns 403/400 or the validated name to stamp.

Wired into every content **write** path; owner derived/validated server-side, never trusted from the body:
- events POST/PUT/DELETE — new `Event.ownerEcclesia` (authz owner, distinct from display-only `hostingEcclesia`; legacy fallback `hostingEcclesia` → home).
- news POST + `[newsId]` PATCH/DELETE + send-alert (owner = `ecclesiaId`).
- meetings POST + `[meetingId]` PATCH/DELETE + send (owner = `ownerName` when `ownerType === 'ecclesia'`; org-owned kept on the global admin gate until org perms are modelled).

Member directory membership (`PersonRecord.ecclesia`) is untouched — that's the separate operating/authoring context.

## ⚠️ Reviewer notes
- **Behavior change**: non-OWNER admins are now restricted to their own ecclesia (+ managed regions). In the single-ecclesia (TEE) world existing admins still pass (their ecclesia matches the content). OWNER is unaffected.
- **Not yet end-to-end for RB/Rep**: admin nav still gates the UI to ADMIN/OWNER — read-side scoping is the next slice.
- **Not runtime-verified** — typecheck/build green; multi-ecclesia authz needs test accounts to exercise. Lands live (prod builds with `typescript.ignoreBuildErrors`).
- The 2 pre-existing `occurrenceDate` typecheck errors are inherited from `main` (separate issue), not from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)