### PR TITLE
Multi-tenant slice 2: ecclesia-scoped read filtering + RB/Rep content-manager access

### DIFF
--- a/apps/next/app/api/admin/events/route.ts
+++ b/apps/next/app/api/admin/events/route.ts
@@ -11,8 +11,18 @@ import {
 import { isEventActive } from '@my/app/types/events'
 import { invalidateEventsCache } from '@/utils/cache'
 import { notifyRBsOfSharedEvent } from '@/utils/notify-rbs-of-shared-event'
-import { authorizeContentEcclesia, canAuthorForEcclesia } from '@/utils/ecclesia-permissions'
+import {
+  authorizeContentEcclesia,
+  canAuthorForEcclesia,
+  canManageEcclesia,
+  listManageableEcclesias,
+} from '@/utils/ecclesia-permissions'
 import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
+import type { Event } from '@my/app/types/events'
+
+/** Ecclesia that owns an event for authz/scoping (display field + legacy fallback). */
+const eventOwner = (event: Pick<Event, 'ownerEcclesia' | 'hostingEcclesia'>): string =>
+  event.ownerEcclesia || event.hostingEcclesia?.name || HOME_ECCLESIA.canonicalName
 
 // Helper functions to extract date/time for sorting
 const extractEventDate = (event: any): string => {
@@ -90,7 +100,11 @@ export async function GET(request: NextRequest) {
     }
 
     const callerRole = (session.user as any).role as string || ROLES.GUEST
-    if (callerRole !== ROLES.ADMIN && callerRole !== ROLES.OWNER) {
+
+    // Ecclesia-scoped read access: OWNER sees all; staff/RB see their own +
+    // managed-region ecclesias. Anyone with no manageable ecclesias is denied.
+    const manageable = await listManageableEcclesias(session.user.email, callerRole)
+    if (!manageable.all && manageable.ecclesias.size === 0) {
       return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
     }
 
@@ -102,11 +116,17 @@ export async function GET(request: NextRequest) {
       if (!event) {
         return NextResponse.json({ error: 'Event not found' }, { status: 404 })
       }
+      if (!canManageEcclesia(manageable, eventOwner(event))) {
+        return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+      }
       return NextResponse.json(event)
     }
 
-    // Return all events for admin, sorted by start date/time ascending
-    const events = await getAllEvents(false)
+    // Return events the caller may manage, sorted by start date/time ascending
+    const allEvents = await getAllEvents(false)
+    const events = manageable.all
+      ? allEvents
+      : allEvents.filter((e) => canManageEcclesia(manageable, eventOwner(e)))
 
     // Sort by start date/time in ascending order (earliest first)
     const sortedEvents = events.sort((a, b) => {

--- a/apps/next/app/api/admin/news/route.ts
+++ b/apps/next/app/api/admin/news/route.ts
@@ -2,7 +2,12 @@ import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/utils/auth'
 import { ROLES } from '@my/app/provider/auth/auth-roles'
 import { createNewsItem, listNewsItems } from '@my/app/services/news-service'
-import { authorizeContentEcclesia } from '@/utils/ecclesia-permissions'
+import {
+  authorizeContentEcclesia,
+  canManageEcclesia,
+  listManageableEcclesias,
+} from '@/utils/ecclesia-permissions'
+import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
 
 /**
  * Admin News API — News Manager (Issue #41)
@@ -18,11 +23,19 @@ export async function GET() {
     }
 
     const role = (session.user as any).role || ROLES.GUEST
-    if (role !== ROLES.ADMIN && role !== ROLES.OWNER) {
+
+    // Ecclesia-scoped read access.
+    const manageable = await listManageableEcclesias(session.user.email, role)
+    if (!manageable.all && manageable.ecclesias.size === 0) {
       return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
     }
 
-    const items = await listNewsItems({ includeExpired: true })
+    const all = await listNewsItems({ includeExpired: true })
+    const items = manageable.all
+      ? all
+      : all.filter((n) =>
+          canManageEcclesia(manageable, n.ecclesiaId || HOME_ECCLESIA.canonicalName)
+        )
     return NextResponse.json(items)
   } catch (error) {
     console.error('Error listing news (admin):', error)

--- a/apps/next/app/layout.tsx
+++ b/apps/next/app/layout.tsx
@@ -28,6 +28,7 @@ function NavigationWithAuth({ children }: { children: React.ReactNode }) {
         email: session.user.email,
         role: (session.user as any)?.role,
         ecclesia: (session.user as any)?.ecclesia,
+        isRecordingBrother: (session.user as any)?.isRecordingBrother,
       }
     : null
 

--- a/apps/next/hooks/use-admin-access.tsx
+++ b/apps/next/hooks/use-admin-access.tsx
@@ -16,9 +16,15 @@ export function useAdminAccess() {
   const isRecordingBrother = !!(session?.user as any)?.isRecordingBrother
   const isRecorderOrRep = isRecordingBrother || role === ROLES.RECORDER || role === ROLES.REP
 
-  // Recorder/Rep can access /admin/community/* pages only
+  // Recorder/Rep/RB can access the community pages AND the content managers
+  // (events / news / meetings) — the routes themselves enforce per-ecclesia scoping.
   const isCommunityPage = pathname?.startsWith('/admin/community')
-  const hasAccess = isAdminOrOwner || (isRecorderOrRep && isCommunityPage)
+  const isContentManagerPage =
+    pathname?.startsWith('/admin/events') ||
+    pathname?.startsWith('/admin/news') ||
+    pathname?.startsWith('/admin/meetings')
+  const hasAccess =
+    isAdminOrOwner || (isRecorderOrRep && (isCommunityPage || isContentManagerPage))
 
   useEffect(() => {
     if (status === 'loading') return // Still loading

--- a/apps/next/utils/ecclesia-permissions.ts
+++ b/apps/next/utils/ecclesia-permissions.ts
@@ -1,7 +1,7 @@
 import { ROLES } from '@my/app/provider/auth/auth-roles'
 import { personRepository } from '@my/app/provider/dynamodb/repositories/person-repository'
 import { getDefaultRegion } from '@my/app/config/regions'
-import { getEcclesiaByName } from './dynamodb/locations'
+import { getEcclesiaByName, getAllEcclesia } from './dynamodb/locations'
 
 /**
  * Check if a user can edit a given ecclesia.
@@ -185,4 +185,54 @@ export async function authorizeContentEcclesia(
   }
 
   return { ok: true, ecclesia: target }
+}
+
+/**
+ * The set of ecclesias whose content a user may manage (for READ-side scoping of
+ * admin lists). `{ all: true }` means no filter — OWNER sees everything. Mirrors
+ * {@link canAuthorForEcclesia}: own ecclesia for staff/RB, plus ecclesias covered
+ * by an ADMIN/REP/RECORDER's managedRegions.
+ */
+export type ManageableEcclesias = { all: true } | { all: false; ecclesias: Set<string> }
+
+export async function listManageableEcclesias(
+  userEmail: string,
+  userRole: string
+): Promise<ManageableEcclesias> {
+  if (userRole === ROLES.OWNER) {
+    return { all: true }
+  }
+
+  const person = await personRepository.getByEmail(userEmail)
+  const ecclesias = new Set<string>()
+  if (!person) {
+    return { all: false, ecclesias }
+  }
+
+  const isStaff =
+    userRole === ROLES.ADMIN || userRole === ROLES.RECORDER || userRole === ROLES.REP
+
+  if (person.ecclesia && (isStaff || person.isRecordingBrother)) {
+    ecclesias.add(person.ecclesia)
+  }
+
+  if (isStaff && person.managedRegions && person.managedRegions.length > 0) {
+    const all = await getAllEcclesia()
+    for (const e of all) {
+      const region = e.region || (e.country ? getDefaultRegion(e.country, e.province) : null)
+      if (region && person.managedRegions.includes(region)) {
+        ecclesias.add(e.name)
+      }
+    }
+  }
+
+  return { all: false, ecclesias }
+}
+
+/** True if the given manageable set covers `ecclesiaName`. */
+export function canManageEcclesia(
+  manageable: ManageableEcclesias,
+  ecclesiaName: string
+): boolean {
+  return manageable.all || manageable.ecclesias.has(ecclesiaName)
 }

--- a/packages/app/features/feature-gated-navigation.tsx
+++ b/packages/app/features/feature-gated-navigation.tsx
@@ -9,6 +9,8 @@ type UserSession = {
   role?: string
   /** Signed-in user's home ecclesia, surfaced in the navigation header */
   ecclesia?: string | null
+  /** Recording Brother designation — grants content-manager nav access */
+  isRecordingBrother?: boolean
 }
 
 type FeatureGatedNavigationProps = {

--- a/packages/app/features/simple-enhanced-navigation.tsx
+++ b/packages/app/features/simple-enhanced-navigation.tsx
@@ -17,6 +17,8 @@ type UserSession = {
   role?: string
   /** Signed-in user's home ecclesia, shown in the header */
   ecclesia?: string | null
+  /** Recording Brother designation — grants content-manager nav access */
+  isRecordingBrother?: boolean
 }
 
 type SimpleEnhancedNavigationProps = {
@@ -51,12 +53,17 @@ const emailAdminPages: MainPageType[] = [
   { path: '/admin/email/schedule', label: 'Schedule Emails to Send' },
 ]
 
-// Admin Tools - System Management
-const systemAdminPages: MainPageType[] = [
-  { path: '/admin/youtube', label: 'YouTube' },
+// Content managers — available to content authors (admin/owner + rep/recorder/RB).
+// Per-ecclesia scoping is enforced by the routes themselves.
+const contentManagerPages: MainPageType[] = [
   { path: '/admin/events', label: 'Event Manager' },
   { path: '/admin/news', label: 'News Manager' },
   { path: '/admin/meetings', label: 'Meeting Manager' },
+]
+
+// Admin Tools - System Management (admin/owner only)
+const systemAdminPages: MainPageType[] = [
+  { path: '/admin/youtube', label: 'YouTube' },
   { path: '/admin/schedule-overrides', label: 'Service Overrides' },
   { path: '/admin/data-sync', label: 'Data Sync' },
   { path: '/admin/directory-email-sync', label: 'Directory Email Sync' },
@@ -291,6 +298,49 @@ export const SimpleEnhancedNavigation: React.FC<SimpleEnhancedNavigationProps> =
               </Button>
               )
             })}
+          </YStack> : null}
+
+      {/* Content Managers — admin/owner + rep/recorder/RB (routes enforce ecclesia scope) */}
+      {user &&
+        (user.role === ROLES.ADMIN ||
+          user.role === ROLES.OWNER ||
+          user.role === ROLES.REP ||
+          user.role === ROLES.RECORDER ||
+          user.isRecordingBrother) ? <YStack gap="$1">
+            <Text
+              fontSize="$2"
+              fontWeight="600"
+              color={colors.textSecondary}
+              textTransform="uppercase"
+            >
+              Content
+            </Text>
+            {contentManagerPages.map((page) => (
+              <Button
+                key={page.path}
+                onPress={navigateTo(page.path)}
+                backgroundColor={currentPath === page.path ? colors.primary : 'transparent'}
+                borderRadius="$2"
+                justifyContent="flex-start"
+                paddingHorizontal="$3"
+                paddingVertical="$2"
+                hoverStyle={{
+                  backgroundColor: currentPath === page.path ? colors.primaryHover : colors.backgroundSecondary,
+                }}
+              >
+                <Text
+                  color={
+                    currentPath === page.path ? colors.primaryForeground : colors.textPrimary
+                  }
+                  fontWeight={currentPath === page.path ? '600' : '400'}
+                  hoverStyle={{
+                    color: currentPath === page.path ? colors.primaryForeground : colors.textSecondary,
+                  }}
+                >
+                  {page.label}
+                </Text>
+              </Button>
+            ))}
           </YStack> : null}
 
       {/* System Admin Tools */}


### PR DESCRIPTION
Builds on the write-side authz (#52). Makes that slice usable end-to-end for an ecclesia's RB/Rep, and scopes admin lists to what each user may manage.

## 2a — read-side list filtering
- New `listManageableEcclesias(email, role)` + `canManageEcclesia()` in `ecclesia-permissions.ts` — the read-side mirror of `canAuthorForEcclesia` (OWNER → all; staff/RB → own ecclesia; ADMIN/REP/RECORDER → managed-region ecclesias).
- Admin **events** GET (list + single) and **news** GET now return only content the caller may manage, and are open to RB/Rep-with-content (not just global ADMIN/OWNER). Event owner resolved as `ownerEcclesia → hostingEcclesia → home`.
- Meetings GET left unchanged (member-viewing semantics, feature-flagged) — separate follow-up.

## 2b — UI exposure for RB/Rep
- `use-admin-access`: grants RB/Rep/Recorder access to `/admin/events|news|meetings` (previously `/admin/community` only).
- Nav: split the content managers out of the admin-only "System Tools" into a new **"Content"** group shown to admin/owner + rep/recorder/RB; admin tools (data-sync, metrics, etc.) stay admin/owner only.
- Threaded `isRecordingBrother` session → layout → nav (RB is a designation, not a role).

## Notes
- Per-ecclesia scope is enforced by the routes themselves (slice 1); this slice gates the read lists + nav visibility to match.
- **Deferred:** OWNER "operating as…" / ecclesia-picker on content forms (slice 2c); meetings read-scoping; runtime verification with multi-ecclesia test accounts.
- 2 pre-existing `occurrenceDate` typecheck errors are inherited from `main` (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)