### PR TITLE
Multi-tenant slice 2c: owner 'operating as' ecclesia picker (news form)

### DIFF
--- a/apps/next/app/admin/(admin-plus)/news/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/news/page.tsx
@@ -23,9 +23,15 @@ export default function AdminNewsPage() {
   const [saving, setSaving] = useState(false)
   const [mode, setMode] = useState<Mode>({ kind: 'list' })
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [ecclesiaOptions, setEcclesiaOptions] = useState<string[]>([])
 
   useEffect(() => {
-    if (hasAccess) loadItems()
+    if (!hasAccess) return
+    loadItems()
+    fetch('/api/admin/manageable-ecclesias')
+      .then((r) => (r.ok ? r.json() : { ecclesias: [] }))
+      .then((d) => setEcclesiaOptions(Array.isArray(d.ecclesias) ? d.ecclesias : []))
+      .catch(() => setEcclesiaOptions([]))
   }, [hasAccess])
 
   const loadItems = async () => {
@@ -63,6 +69,8 @@ export default function AdminNewsPage() {
         durationWeeks: Number(values.durationWeeks),
         sharingScope: values.sharingScope,
         documents: values.documents ?? [],
+        // Only sent when the picker was shown; server validates + falls back to home.
+        ecclesiaId: values.ecclesiaId || undefined,
       }
 
       let res: Response
@@ -153,6 +161,7 @@ export default function AdminNewsPage() {
             durationWeeks: String(mode.item.durationWeeks) as '1' | '2' | '3',
             sharingScope: mode.item.sharingScope,
             documents: mode.item.documents || [],
+            ecclesiaId: mode.item.ecclesiaId,
           }
         : undefined
 
@@ -165,6 +174,7 @@ export default function AdminNewsPage() {
           isSaving={saving}
           isExisting={mode.kind === 'edit'}
           alertAlreadySent={mode.kind === 'edit' && !!mode.item.emailBlastSentAt}
+          ecclesiaOptions={ecclesiaOptions}
           onSave={handleSave}
           onCancel={() => setMode({ kind: 'list' })}
           onDelete={handleDelete}

--- a/apps/next/app/api/admin/manageable-ecclesias/route.ts
+++ b/apps/next/app/api/admin/manageable-ecclesias/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+import { listSelectableEcclesias } from '@/utils/ecclesia-permissions'
+
+/**
+ * Ecclesias the signed-in user may author content for — powers the "operating
+ * as" ecclesia picker on the content forms. OWNER gets every ecclesia; scoped
+ * roles get their own + managed-region ecclesias. `home` is the natural default.
+ */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const role = (session.user as any).role || ROLES.GUEST
+  const ecclesias = await listSelectableEcclesias(session.user.email, role)
+  return NextResponse.json({
+    ecclesias,
+    home: (session.user as any).ecclesia ?? null,
+  })
+}

--- a/apps/next/utils/ecclesia-permissions.ts
+++ b/apps/next/utils/ecclesia-permissions.ts
@@ -236,3 +236,32 @@ export function canManageEcclesia(
 ): boolean {
   return manageable.all || manageable.ecclesias.has(ecclesiaName)
 }
+
+/**
+ * Concrete, sorted list of ecclesia NAMES a user may author for — for the
+ * content-form ecclesia picker (the "operating as" selector). Resolves the
+ * `{ all: true }` OWNER case to every ecclesia name. The caller's home ecclesia
+ * (when present) sorts first as the natural default.
+ */
+export async function listSelectableEcclesias(
+  userEmail: string,
+  userRole: string
+): Promise<string[]> {
+  const manageable = await listManageableEcclesias(userEmail, userRole)
+  let names: string[]
+  if (manageable.all) {
+    names = (await getAllEcclesia()).map((e) => e.name).filter(Boolean)
+  } else {
+    names = Array.from(manageable.ecclesias)
+  }
+
+  const person = await personRepository.getByEmail(userEmail)
+  const home = person?.ecclesia
+  return names.sort((a, b) => {
+    if (home) {
+      if (a === home) return -1
+      if (b === home) return 1
+    }
+    return a.localeCompare(b)
+  })
+}

--- a/packages/ui/src/news/news-item-form.tsx
+++ b/packages/ui/src/news/news-item-form.tsx
@@ -31,6 +31,8 @@ export type NewsFormValues = {
   durationWeeks: '1' | '2' | '3'
   sharingScope: 'own' | 'region' | 'global'
   documents: DocumentAttachment[]
+  /** Owning ecclesia ("operating as"). Only meaningful when ecclesiaOptions > 1. */
+  ecclesiaId?: string
 }
 
 export type NewsItemFormProps = {
@@ -38,6 +40,12 @@ export type NewsItemFormProps = {
   isSaving?: boolean
   isExisting?: boolean
   alertAlreadySent?: boolean
+  /**
+   * Ecclesias the signed-in user may post for. When more than one, a picker is
+   * shown so an owner / regional admin can choose which ecclesia owns the item.
+   * When 0–1, no picker is rendered (the server defaults to the user's home).
+   */
+  ecclesiaOptions?: string[]
   onSave: (values: NewsFormValues) => void | Promise<void>
   onCancel: () => void
   onDelete?: () => void | Promise<void>
@@ -68,6 +76,7 @@ export function NewsItemForm({
   isSaving = false,
   isExisting = false,
   alertAlreadySent = false,
+  ecclesiaOptions,
   onSave,
   onCancel,
   onDelete,
@@ -81,11 +90,24 @@ export function NewsItemForm({
       durationWeeks: initialValues?.durationWeeks || '1',
       sharingScope: initialValues?.sharingScope || 'own',
       documents: initialValues?.documents || [],
+      ecclesiaId: initialValues?.ecclesiaId || ecclesiaOptions?.[0] || '',
     },
   })
 
+  const showEcclesiaPicker = (ecclesiaOptions?.length ?? 0) > 1
+
   return (
     <YStack gap="$4" padding="$4">
+      {showEcclesiaPicker ? (
+        <EventFormSelect
+          control={control}
+          name="ecclesiaId"
+          label="Posting for ecclesia"
+          options={ecclesiaOptions!.map((name) => ({ value: name, label: name }))}
+          required
+        />
+      ) : null}
+
       <FormInput
         control={control}
         name="title"


### PR DESCRIPTION
The UI counterpart to slice 1's server-side ecclesia validation — lets an OWNER (or a regional admin with >1 manageable ecclesia) choose *which* ecclesia they're authoring as. Membership (`PersonRecord.ecclesia`) is untouched; this is the separate operating context.

## What
- `listSelectableEcclesias(email, role)` + `GET /api/admin/manageable-ecclesias` — the ecclesia NAMES a user may author for (OWNER → all; scoped → own + managed regions), home sorted first as the default.
- **News form**: new `ecclesiaOptions` prop → renders a "Posting for ecclesia" picker **only when >1 option** (scoped admins with a single ecclesia see no change). The page fetches the options, sends the chosen `ecclesiaId` on create/edit (server validates via slice 1 + falls back to home), and seeds it from the item on edit.

## Scope notes
- **Events** are already covered: the event form's existing hosting-ecclesia search flows into `ownerEcclesia` via slice 1's server derivation (`ownerEcclesia || hostingEcclesia?.name`), so an owner picks the ecclesia there. *Follow-up:* constrain that free-text search to the caller's manageable ecclesias for non-owners (today a scoped admin typing a foreign ecclesia gets a 403 on save rather than not seeing it).
- **Meetings** have no create form in the UI yet (API-only, feature-flagged) — nothing to wire.
- 2 pre-existing `occurrenceDate` typecheck errors inherited from `main` (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)