### PR TITLE
feat(news): send News alerts to any audience (incl. inter-ecclesia leaders)

### DIFF
--- a/apps/next/app/admin/(admin-plus)/news/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/news/page.tsx
@@ -11,18 +11,10 @@ import {
   type NewsFormValues,
 } from '@my/ui/src/news/news-item-form'
 import type { NewsItem } from '@my/app/types/news'
-import { isNewsActive } from '@my/app/types/news'
+import { isNewsActive, blastedAudiences } from '@my/app/types/news'
 import { getContactsList } from '@my/app/provider/get-data'
 
 type Audience = { key: string; label: string }
-
-/**
- * Audiences this item has been blasted to live. Mirrors the server's
- * `blastedAudiences` helper, treating a legacy `emailBlastSentAt` as a
- * newsletter send so the per-audience "already sent" state stays correct.
- */
-const sentAudiencesOf = (item: NewsItem): string[] =>
-  item.emailBlastAudiences ?? (item.emailBlastSentAt ? ['newsletter'] : [])
 
 type Mode = { kind: 'list' } | { kind: 'new' } | { kind: 'edit'; item: NewsItem }
 
@@ -199,7 +191,7 @@ export default function AdminNewsPage() {
           initialValues={initial}
           isSaving={saving}
           isExisting={mode.kind === 'edit'}
-          sentAudiences={mode.kind === 'edit' ? sentAudiencesOf(mode.item) : []}
+          sentAudiences={mode.kind === 'edit' ? blastedAudiences(mode.item) : []}
           audiences={audiences}
           ecclesiaOptions={ecclesiaOptions}
           onSave={handleSave}

--- a/apps/next/app/admin/(admin-plus)/news/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/news/page.tsx
@@ -12,6 +12,17 @@ import {
 } from '@my/ui/src/news/news-item-form'
 import type { NewsItem } from '@my/app/types/news'
 import { isNewsActive } from '@my/app/types/news'
+import { getContactsList } from '@my/app/provider/get-data'
+
+type Audience = { key: string; label: string }
+
+/**
+ * Audiences this item has been blasted to live. Mirrors the server's
+ * `blastedAudiences` helper, treating a legacy `emailBlastSentAt` as a
+ * newsletter send so the per-audience "already sent" state stays correct.
+ */
+const sentAudiencesOf = (item: NewsItem): string[] =>
+  item.emailBlastAudiences ?? (item.emailBlastSentAt ? ['newsletter'] : [])
 
 type Mode = { kind: 'list' } | { kind: 'new' } | { kind: 'edit'; item: NewsItem }
 
@@ -24,6 +35,7 @@ export default function AdminNewsPage() {
   const [mode, setMode] = useState<Mode>({ kind: 'list' })
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [ecclesiaOptions, setEcclesiaOptions] = useState<string[]>([])
+  const [audiences, setAudiences] = useState<Audience[]>([])
 
   useEffect(() => {
     if (!hasAccess) return
@@ -32,6 +44,17 @@ export default function AdminNewsPage() {
       .then((r) => (r.ok ? r.json() : { ecclesias: [] }))
       .then((d) => setEcclesiaOptions(Array.isArray(d.ecclesias) ? d.ecclesias : []))
       .catch(() => setEcclesiaOptions([]))
+    // Email audiences for the alert sender — same source as the Email Sender.
+    // The test list is excluded (the "Send test alert" button covers it).
+    getContactsList()
+      .then((d) =>
+        setAudiences(
+          (d.lists ?? [])
+            .filter((l) => l.key !== 'testList')
+            .map((l) => ({ key: l.key, label: l.displayName }))
+        )
+      )
+      .catch(() => setAudiences([]))
   }, [hasAccess])
 
   const loadItems = async () => {
@@ -120,22 +143,25 @@ export default function AdminNewsPage() {
     }
   }
 
-  const handleSendAlert = async (test: boolean) => {
+  const handleSendAlert = async (test: boolean, audience: string) => {
     if (mode.kind !== 'edit') return
+    const audienceLabel = audiences.find((a) => a.key === audience)?.label ?? audience
     const confirmMsg = test
-      ? 'Send a test alert to the test list?'
-      : 'Send this alert to all newsletter subscribers? This can only be done once.'
+      ? `Send a TEST alert to the test list? (Live target would be: ${audienceLabel})`
+      : `Send this alert to "${audienceLabel}"? This can only be done once for this audience.`
     if (!confirm(confirmMsg)) return
 
     setSaving(true)
     try {
-      const url = `/api/admin/news/${mode.item.id}/send-alert${test ? '?test=true' : ''}`
+      const params = new URLSearchParams({ list: audience })
+      if (test) params.set('test', 'true')
+      const url = `/api/admin/news/${mode.item.id}/send-alert?${params.toString()}`
       const res = await fetch(url, { method: 'POST' })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'Alert send failed')
       alert(
         `Alert sent. ${data.sentCount} delivered, ${data.skippedCount} skipped.${
-          test ? ' (Test list)' : ''
+          test ? ' (Test list)' : ` (${audienceLabel})`
         }`
       )
       if (!test) {
@@ -173,7 +199,8 @@ export default function AdminNewsPage() {
           initialValues={initial}
           isSaving={saving}
           isExisting={mode.kind === 'edit'}
-          alertAlreadySent={mode.kind === 'edit' && !!mode.item.emailBlastSentAt}
+          sentAudiences={mode.kind === 'edit' ? sentAudiencesOf(mode.item) : []}
+          audiences={audiences}
           ecclesiaOptions={ecclesiaOptions}
           onSave={handleSave}
           onCancel={() => setMode({ kind: 'list' })}

--- a/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
+++ b/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
@@ -8,9 +8,8 @@ import { emailSend } from '@/utils/email/email-send'
 import {
   getNewsItemById,
   markNewsBlastSent,
-  blastedAudiences,
 } from '@my/app/services/news-service'
-import { isNewsActive } from '@my/app/types/news'
+import { isNewsActive, blastedAudiences } from '@my/app/types/news'
 import { EmailListTypes } from '@my/app/types'
 import { getPreviewImageUrl } from '@my/app/types/events'
 import { getTenantFromHeaders, resolveTenantFromEnv } from '@my/app/config/tenants'

--- a/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
+++ b/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
@@ -8,8 +8,10 @@ import { emailSend } from '@/utils/email/email-send'
 import {
   getNewsItemById,
   markNewsBlastSent,
+  blastedAudiences,
 } from '@my/app/services/news-service'
 import { isNewsActive } from '@my/app/types/news'
+import { EmailListTypes } from '@my/app/types'
 import { getPreviewImageUrl } from '@my/app/types/events'
 import { getTenantFromHeaders, resolveTenantFromEnv } from '@my/app/config/tenants'
 import { resolveBrandProfile } from '@/utils/email/resolve-brand-profile'
@@ -44,6 +46,19 @@ export async function POST(
     const isTest = searchParams.get('test') === 'true'
     const force = searchParams.get('force') === 'true'
 
+    // Which audience to blast to. Defaults to 'newsletter' (the historical
+    // behaviour); 'interEcclesia' and the other lists are now selectable.
+    // Test sends always go to the test list regardless (enforced in emailSend).
+    const DEFAULT_AUDIENCE = EmailListTypes.newsletter
+    const requestedList = searchParams.get('list')
+    if (requestedList && !(Object.values(EmailListTypes) as string[]).includes(requestedList)) {
+      return NextResponse.json(
+        { error: `Unknown audience '${requestedList}'.` },
+        { status: 400 }
+      )
+    }
+    const audienceKey = requestedList || DEFAULT_AUDIENCE
+
     const news = await getNewsItemById(newsId)
     if (!news) {
       return NextResponse.json({ error: 'News item not found' }, { status: 404 })
@@ -62,9 +77,11 @@ export async function POST(
     if (!isNewsActive(news)) {
       return NextResponse.json({ error: 'News item has expired' }, { status: 400 })
     }
-    if (news.emailBlastSentAt && !force && !isTest) {
+    // One-shot guard is now per-audience: a prior blast to one list never
+    // blocks a fresh send to a different list.
+    if (!isTest && !force && blastedAudiences(news).includes(audienceKey)) {
       return NextResponse.json(
-        { error: 'Alert already sent for this news item' },
+        { error: `Alert already sent to '${audienceKey}' for this news item.` },
         { status: 409 }
       )
     }
@@ -94,9 +111,10 @@ export async function POST(
       emailHtml,
       emailText,
       test: isTest,
+      customList: audienceKey,
       customSubject: news.title,
       subReason: 'general',
-      description: `News alert: ${news.title}`,
+      description: `News alert: ${news.title} → ${audienceKey}`,
       sentBy: session.user.email,
       tenant,
     })
@@ -106,7 +124,7 @@ export async function POST(
     }
 
     if (!isTest) {
-      await markNewsBlastSent(newsId)
+      await markNewsBlastSent(newsId, audienceKey)
     }
 
     return NextResponse.json({

--- a/packages/app/services/news-service.ts
+++ b/packages/app/services/news-service.ts
@@ -7,6 +7,7 @@ import {
   UpdateNewsRequest,
   computeNewsExpiresAt,
   isNewsActive,
+  blastedAudiences,
 } from '@my/app/types/news'
 
 /**
@@ -142,13 +143,6 @@ export const listNewsItems = async (
     (a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
   )
 }
-
-/**
- * Treat a legacy item (blasted before per-audience tracking existed) as having
- * gone to the newsletter, so the one-shot guard stays correct after upgrade.
- */
-export const blastedAudiences = (item: Pick<NewsItem, 'emailBlastAudiences' | 'emailBlastSentAt'>): string[] =>
-  item.emailBlastAudiences ?? (item.emailBlastSentAt ? ['newsletter'] : [])
 
 export const markNewsBlastSent = async (id: string, audienceKey: string): Promise<NewsItem> => {
   const existing = await getNewsItemById(id)

--- a/packages/app/services/news-service.ts
+++ b/packages/app/services/news-service.ts
@@ -143,6 +143,16 @@ export const listNewsItems = async (
   )
 }
 
-export const markNewsBlastSent = async (id: string): Promise<NewsItem> => {
-  return updateNewsItem({ id, emailBlastSentAt: new Date() })
+/**
+ * Treat a legacy item (blasted before per-audience tracking existed) as having
+ * gone to the newsletter, so the one-shot guard stays correct after upgrade.
+ */
+export const blastedAudiences = (item: Pick<NewsItem, 'emailBlastAudiences' | 'emailBlastSentAt'>): string[] =>
+  item.emailBlastAudiences ?? (item.emailBlastSentAt ? ['newsletter'] : [])
+
+export const markNewsBlastSent = async (id: string, audienceKey: string): Promise<NewsItem> => {
+  const existing = await getNewsItemById(id)
+  if (!existing) throw new Error(`News item ${id} not found`)
+  const emailBlastAudiences = Array.from(new Set([...blastedAudiences(existing), audienceKey]))
+  return updateNewsItem({ id, emailBlastSentAt: new Date(), emailBlastAudiences })
 }

--- a/packages/app/types/news.ts
+++ b/packages/app/types/news.ts
@@ -61,3 +61,14 @@ export function computeNewsExpiresAt(publishedAt: Date, durationWeeks: NewsDurat
 export function isNewsActive(item: Pick<NewsItem, 'expiresAt'>, now: Date = new Date()): boolean {
   return new Date(item.expiresAt).getTime() > now.getTime()
 }
+
+/**
+ * Email audiences (EmailListTypes keys) a News item has been blasted to live.
+ * Treats a legacy item (only `emailBlastSentAt`, predating per-audience
+ * tracking) as having gone to the newsletter, so the one-shot guard stays
+ * correct after upgrade. Pure — single source of truth for both the server
+ * send route and the client editor.
+ */
+export const blastedAudiences = (
+  item: Pick<NewsItem, 'emailBlastAudiences' | 'emailBlastSentAt'>
+): string[] => item.emailBlastAudiences ?? (item.emailBlastSentAt ? ['newsletter'] : [])

--- a/packages/app/types/news.ts
+++ b/packages/app/types/news.ts
@@ -25,13 +25,27 @@ export interface NewsItem {
   durationWeeks: NewsDurationWeeks
   sharingScope: EventSharingScope
   emailBlastSentAt?: Date
+  /**
+   * Email audiences (EmailListTypes keys, e.g. 'newsletter', 'interEcclesia')
+   * this item has been blasted to live. Lets the same post go to multiple
+   * audiences without the one-shot guard falsely blocking a second, different
+   * send. Legacy items predating this field are treated as having gone to
+   * 'newsletter' when `emailBlastSentAt` is set.
+   */
+  emailBlastAudiences?: string[]
   createdAt: Date
   updatedAt: Date
 }
 
 export type CreateNewsRequest = Omit<
   NewsItem,
-  'id' | 'createdAt' | 'updatedAt' | 'expiresAt' | 'publishedAt' | 'emailBlastSentAt'
+  | 'id'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'expiresAt'
+  | 'publishedAt'
+  | 'emailBlastSentAt'
+  | 'emailBlastAudiences'
 > & {
   publishedAt?: Date
 }

--- a/packages/ui/src/news/news-item-form.tsx
+++ b/packages/ui/src/news/news-item-form.tsx
@@ -35,11 +35,22 @@ export type NewsFormValues = {
   ecclesiaId?: string
 }
 
+export type AudienceOption = { key: string; label: string }
+
 export type NewsItemFormProps = {
   initialValues?: Partial<NewsFormValues>
   isSaving?: boolean
   isExisting?: boolean
-  alertAlreadySent?: boolean
+  /**
+   * Audiences (EmailListTypes keys) this item has already been blasted to live.
+   * The "Send alert" button disables only for the currently-selected audience,
+   * so the same post can still go to a different list.
+   */
+  sentAudiences?: string[]
+  /** Selectable send audiences ({ key, label }), e.g. Newsletter, Inter-Ecclesia Leaders. */
+  audiences?: AudienceOption[]
+  /** Default selected audience key. Falls back to 'newsletter'. */
+  defaultAudience?: string
   /**
    * Ecclesias the signed-in user may post for. When more than one, a picker is
    * shown so an owner / regional admin can choose which ecclesia owns the item.
@@ -49,7 +60,7 @@ export type NewsItemFormProps = {
   onSave: (values: NewsFormValues) => void | Promise<void>
   onCancel: () => void
   onDelete?: () => void | Promise<void>
-  onSendAlert?: (test: boolean) => void | Promise<void>
+  onSendAlert?: (test: boolean, audience: string) => void | Promise<void>
 }
 
 const CATEGORY_OPTIONS = [
@@ -75,13 +86,17 @@ export function NewsItemForm({
   initialValues,
   isSaving = false,
   isExisting = false,
-  alertAlreadySent = false,
+  sentAudiences = [],
+  audiences = [],
+  defaultAudience = 'newsletter',
   ecclesiaOptions,
   onSave,
   onCancel,
   onDelete,
   onSendAlert,
 }: NewsItemFormProps) {
+  const [selectedAudience, setSelectedAudience] = React.useState(defaultAudience)
+  const alertAlreadySent = sentAudiences.includes(selectedAudience)
   const { control, handleSubmit, formState } = useForm<NewsFormValues>({
     defaultValues: {
       title: initialValues?.title || '',
@@ -172,6 +187,36 @@ export function NewsItemForm({
         required
       />
 
+      {isExisting && onSendAlert && audiences.length > 0 ? (
+        <YStack gap="$2" marginTop="$2">
+          <Paragraph fontSize="$3" fontWeight="600" color="$gray12">
+            Send alert to
+          </Paragraph>
+          <XStack gap="$2" flexWrap="wrap">
+            {audiences.map((a) => {
+              const selected = a.key === selectedAudience
+              const sent = sentAudiences.includes(a.key)
+              return (
+                <Button
+                  key={a.key}
+                  size="$2"
+                  backgroundColor={selected ? '$info' : '$backgroundStrong'}
+                  color={selected ? 'white' : '$color'}
+                  borderColor={selected ? '$info' : '$borderColor'}
+                  hoverStyle={{
+                    backgroundColor: selected ? '$infoHover' : '$backgroundHover',
+                    borderColor: '$textSecondary',
+                  }}
+                  onPress={() => setSelectedAudience(a.key)}
+                >
+                  {sent ? `${a.label} ✓` : a.label}
+                </Button>
+              )
+            })}
+          </XStack>
+        </YStack>
+      ) : null}
+
       <XStack gap="$3" flexWrap="wrap" marginTop="$2">
         <Button
           theme="active"
@@ -198,7 +243,7 @@ export function NewsItemForm({
               backgroundColor="$info"
               color="white"
               hoverStyle={{ backgroundColor: '$infoHover' }}
-              onPress={() => onSendAlert(true)}
+              onPress={() => onSendAlert(true, selectedAudience)}
               disabled={isSaving}
             >
               Send test alert
@@ -207,10 +252,10 @@ export function NewsItemForm({
               backgroundColor={alertAlreadySent ? '$gray8' : '$warning'}
               color="white"
               hoverStyle={{ backgroundColor: alertAlreadySent ? '$gray8' : '$warningHover' }}
-              onPress={() => onSendAlert(false)}
+              onPress={() => onSendAlert(false, selectedAudience)}
               disabled={isSaving || alertAlreadySent}
             >
-              {alertAlreadySent ? 'Alert already sent' : 'Send alert to subscribers'}
+              {alertAlreadySent ? 'Already sent to this list' : 'Send alert to subscribers'}
             </Button>
           </>
         ) : null}
@@ -230,8 +275,8 @@ export function NewsItemForm({
 
       {alertAlreadySent ? (
         <Paragraph color="$textSecondary" fontSize="$3">
-          An email alert has already been sent for this news item. Sending again is disabled to
-          prevent duplicates.
+          An alert has already been sent to this audience. Sending to it again is disabled to
+          prevent duplicates — pick a different audience above to reach another list.
         </Paragraph>
       ) : null}
     </YStack>


### PR DESCRIPTION
First slice of #57 (toward epic #55). Unblocks directing a **News post to the inter-ecclesia leaders** — previously News alerts were hardcoded to the newsletter list.

## What changed
- **News editor** (`news-item-form` + admin news page): a "Send alert to" audience selector (chips), sourced from the same contact lists as the Email Sender (test list excluded — the "Send test alert" button covers it). The chosen audience is passed through to the send.
- **Send-alert route**: accepts a validated `?list=` param and passes it as `customList` to `emailSend` (which already honours the override for any reason). Test sends still force the test list.
- **Per-audience one-shot guard**: new additive `emailBlastAudiences: string[]` on `NewsItem` tracks which lists an item has gone to, so a prior newsletter blast no longer blocks a separate inter-ecclesia send. Legacy items with only `emailBlastSentAt` are treated as a newsletter send. Existing field/format untouched.

## Not included (deliberately)
- Universal per-recipient personalization (one-click login / `ecclesiaUpdateUrl`) — that's #56. The `NewsAlert` template links to the public `/news/{id}` page, which is appropriate for this audience.
- Inter-ecclesia "please share with your ecclesia" framing — future, with the shared sender.

## Verification
- [ ] Typecheck: clean for changed files (two pre-existing `get-upcoming-program.tsx` errors are unrelated/on `main`).
- [ ] **Manual (gating the live send):** on the preview, open a News item → "Send alert to" → **Inter-Ecclesia Leaders** → **Send test alert**, confirm delivery, then the live send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)