### PR TITLE
fix(news): surface the real error on news-alert send failure

### DIFF
--- a/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
+++ b/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
@@ -133,9 +133,10 @@ export async function POST(
       skippedCount: result.skips.length,
     })
   } catch (error) {
-    console.error('Error sending news alert:', error)
+    const message = error instanceof Error ? error.message : String(error)
+    console.error('Error sending news alert:', message, error instanceof Error ? error.stack : error)
     return NextResponse.json(
-      { success: false, error: 'Failed to send news alert' },
+      { success: false, error: `Failed to send news alert: ${message}` },
       { status: 500 }
     )
   }


### PR DESCRIPTION
Diagnostic + UX fix. The send-alert route swallowed every exception behind a generic "Failed to send news alert", so the prod test-send failure has no visible cause (the real error only hit a short-lived runtime log).

This includes the actual `error.message` in the 500 response (and logs the stack), so the failure is diagnosable from the UI on the next attempt.

Error-message/logging only — no behavioural change to the send path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)