### PR TITLE
fix(news): render news-alert without the client-side EmailIdentityProvider

### DIFF
--- a/apps/email-builder/components/Footer.tsx
+++ b/apps/email-builder/components/Footer.tsx
@@ -2,9 +2,16 @@ import { defaultText, footer, footerLink, footerText } from '../styles'
 import { Link, Section, Text } from '@react-email/components'
 import React from 'react'
 import { useEmailIdentity } from './email-identity'
+import type { EmailIdentity } from '@my/app/types/brand-profile'
 
-export const Footer = () => {
-  const identity = useEmailIdentity()
+/**
+ * Footer identity defaults to the {@link EmailIdentityProvider} context.
+ * Callers rendering from an App Router server route — where the `'use client'`
+ * provider can't be used as an element — can pass `identity` directly instead.
+ */
+export const Footer = ({ identity: identityProp }: { identity?: EmailIdentity } = {}) => {
+  const contextIdentity = useEmailIdentity()
+  const identity = identityProp ?? contextIdentity
   return (
     <Section style={footer}>
       <Text style={defaultText}>

--- a/apps/email-builder/emails/NewsAlert.tsx
+++ b/apps/email-builder/emails/NewsAlert.tsx
@@ -19,6 +19,7 @@ import {
   main,
 } from '../styles'
 import { Footer } from '../components/Footer'
+import type { EmailIdentity } from '@my/app/types/brand-profile'
 
 export type NewsAlertProps = {
   title: string
@@ -26,9 +27,15 @@ export type NewsAlertProps = {
   detailsUrl: string
   /** Optional poster preview (image URL or PDF page-1 thumbnail). */
   previewImageUrl?: string
+  /**
+   * Brand identity for the footer. Passed as a prop (not via the
+   * EmailIdentityProvider context) so this template renders from an App Router
+   * server route without invoking the `'use client'` provider element.
+   */
+  identity?: EmailIdentity
 }
 
-const NewsAlert: React.FC<NewsAlertProps> = ({ title, detailsUrl, previewImageUrl }) => {
+const NewsAlert: React.FC<NewsAlertProps> = ({ title, detailsUrl, previewImageUrl, identity }) => {
   return (
     <Html lang="en">
       <Head>
@@ -67,7 +74,7 @@ const NewsAlert: React.FC<NewsAlertProps> = ({ title, detailsUrl, previewImageUr
         <Container>
           <Text>&nbsp;</Text>
         </Container>
-        <Footer />
+        <Footer identity={identity} />
       </Body>
     </Html>
   )

--- a/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
+++ b/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
@@ -15,7 +15,6 @@ import { getPreviewImageUrl } from '@my/app/types/events'
 import { getTenantFromHeaders, resolveTenantFromEnv } from '@my/app/config/tenants'
 import { resolveBrandProfile } from '@/utils/email/resolve-brand-profile'
 import { emailIdentityFromProfile } from '@my/app/types/brand-profile'
-import { EmailIdentityProvider } from 'email-builder/components/email-identity'
 import { canAuthorForEcclesia } from '@/utils/ecclesia-permissions'
 import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
 
@@ -92,16 +91,17 @@ export async function POST(
     const detailsUrl = `https://www.${tenant.senderDomain}/news/${news.id}`
 
     // Brand the footer from the news item's owning ecclesia (per-org branding).
+    // Identity is passed as a prop rather than via EmailIdentityProvider: that
+    // provider is a `'use client'` component and can't be rendered as an element
+    // from this App Router server route (react-dom/server can't invoke a client
+    // reference). See NewsAlert/Footer `identity` prop.
     const profile = await resolveBrandProfile({ ownerEcclesiaName: news.ecclesiaId, tenant })
-    const emailElement = createElement(
-      EmailIdentityProvider,
-      { value: emailIdentityFromProfile(profile) },
-      createElement(NewsAlert as any, {
-        title: news.title,
-        detailsUrl,
-        previewImageUrl: getPreviewImageUrl(news.documents),
-      })
-    )
+    const emailElement = createElement(NewsAlert as any, {
+      title: news.title,
+      detailsUrl,
+      previewImageUrl: getPreviewImageUrl(news.documents),
+      identity: emailIdentityFromProfile(profile),
+    })
     const emailHtml = await render(emailElement)
     const emailText = await render(emailElement, { plainText: true })
 


### PR DESCRIPTION
## Root cause
Sending a news alert (test or live) failed with:
> Attempted to call EmailIdentityProvider() from the server but EmailIdentityProvider is on the client.

The `send-alert` route is an **App Router server route** and wrapped `NewsAlert` in `EmailIdentityProvider` — a `'use client'` context provider. `react-dom/server` (`@react-email/render`) can't render a client-reference element, so it threw and the send aborted (no email). This News path was never exercised with a real send until now.

## Fix
Pass brand identity as a **prop** instead of through context:
- `Footer` takes an optional `identity` prop, falling back to the `EmailIdentityProvider` context → **every other template (rendered via `get-email-content`) is unchanged**.
- `NewsAlert` accepts `identity` and forwards it to `Footer`.
- The route renders `<NewsAlert identity={…} />` directly — no client provider element in the server render tree. Per-ecclesia footer branding is preserved.

Builds on the diagnostic #66 (which surfaced the real error in the UI).

## Verification
- [x] Typecheck clean (2 pre-existing `get-upcoming-program` errors only).
- [ ] Prod: send test alert → email arrives, footer address correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)