### PR TITLE
fix(news): render news-alert footer without the client-only identity hook

### DIFF
--- a/apps/email-builder/components/Footer.tsx
+++ b/apps/email-builder/components/Footer.tsx
@@ -1,37 +1,15 @@
-import { defaultText, footer, footerLink, footerText } from '../styles'
-import { Link, Section, Text } from '@react-email/components'
 import React from 'react'
 import { useEmailIdentity } from './email-identity'
+import { FooterContent } from './FooterContent'
 import type { EmailIdentity } from '@my/app/types/brand-profile'
 
 /**
- * Footer identity defaults to the {@link EmailIdentityProvider} context.
- * Callers rendering from an App Router server route — where the `'use client'`
- * provider can't be used as an element — can pass `identity` directly instead.
+ * Hook-based footer: takes identity from the {@link EmailIdentityProvider}
+ * context (or an explicit `identity` prop). Used by templates rendered through
+ * get-email-content. Server routes that can't invoke the `'use client'` context
+ * hook should render {@link FooterContent} directly with an `identity` prop.
  */
 export const Footer = ({ identity: identityProp }: { identity?: EmailIdentity } = {}) => {
   const contextIdentity = useEmailIdentity()
-  const identity = identityProp ?? contextIdentity
-  return (
-    <Section style={footer}>
-      <Text style={defaultText}>
-        To change your email preferences or unsubscribe please follow this link:
-      </Text>
-      <Link href="{{amazonSESUnsubscribeUrl}}" style={footerLink}>
-        {'Unsubscribe & Email Preferences'}
-      </Link>
-
-      <Text style={footerText}>
-        <strong>Our address is:</strong>
-        <br />
-        {identity.name}
-        {(identity.addressLines ?? []).map((line, i) => (
-          <React.Fragment key={i}>
-            <br />
-            {line}
-          </React.Fragment>
-        ))}
-      </Text>
-    </Section>
-  )
+  return <FooterContent identity={identityProp ?? contextIdentity} />
 }

--- a/apps/email-builder/components/FooterContent.tsx
+++ b/apps/email-builder/components/FooterContent.tsx
@@ -1,0 +1,49 @@
+import { defaultText, footer, footerLink, footerText } from '../styles'
+import { Link, Section, Text } from '@react-email/components'
+import React from 'react'
+import type { EmailIdentity } from '@my/app/types/brand-profile'
+
+/**
+ * Default footer identity (Toronto East). Lives in this server-safe module — NOT
+ * in the `'use client'` email-identity module — so it can be imported and used
+ * from App Router server routes without creating a client reference.
+ */
+export const DEFAULT_EMAIL_IDENTITY: EmailIdentity = {
+  name: 'Toronto East Christadelphians',
+  addressLines: ['975 Cosburn Avenue', 'Toronto, On M4C 2W8', 'Canada'],
+}
+
+/**
+ * Pure, presentational email footer. Identity is a plain prop — no React
+ * context / hook — so this renders from any server context. The hook-based
+ * {@link Footer} wraps this for templates that take identity from the
+ * EmailIdentityProvider context.
+ */
+export const FooterContent = ({
+  identity = DEFAULT_EMAIL_IDENTITY,
+}: {
+  identity?: EmailIdentity
+}) => {
+  return (
+    <Section style={footer}>
+      <Text style={defaultText}>
+        To change your email preferences or unsubscribe please follow this link:
+      </Text>
+      <Link href="{{amazonSESUnsubscribeUrl}}" style={footerLink}>
+        {'Unsubscribe & Email Preferences'}
+      </Link>
+
+      <Text style={footerText}>
+        <strong>Our address is:</strong>
+        <br />
+        {identity.name}
+        {(identity.addressLines ?? []).map((line, i) => (
+          <React.Fragment key={i}>
+            <br />
+            {line}
+          </React.Fragment>
+        ))}
+      </Text>
+    </Section>
+  )
+}

--- a/apps/email-builder/components/email-identity.tsx
+++ b/apps/email-builder/components/email-identity.tsx
@@ -2,17 +2,12 @@
 
 import React, { createContext, useContext } from 'react'
 import type { EmailIdentity } from '@my/app/types/brand-profile'
+// Default lives in the server-safe FooterContent module (single source of
+// truth) so it can also be used from App Router server routes; re-exported here
+// for existing importers.
+import { DEFAULT_EMAIL_IDENTITY } from './FooterContent'
 
-/**
- * Brand identity for the email footer, supplied at render time. Defaults to
- * Toronto East so any template rendered without a provider is unchanged
- * (no regression). Callers wrap the rendered element with
- * <EmailIdentityProvider value={...}> to brand the footer per tenant/org.
- */
-export const DEFAULT_EMAIL_IDENTITY: EmailIdentity = {
-  name: 'Toronto East Christadelphians',
-  addressLines: ['975 Cosburn Avenue', 'Toronto, On M4C 2W8', 'Canada'],
-}
+export { DEFAULT_EMAIL_IDENTITY }
 
 const EmailIdentityContext = createContext<EmailIdentity>(DEFAULT_EMAIL_IDENTITY)
 

--- a/apps/email-builder/emails/NewsAlert.tsx
+++ b/apps/email-builder/emails/NewsAlert.tsx
@@ -18,7 +18,7 @@ import {
   link,
   main,
 } from '../styles'
-import { Footer } from '../components/Footer'
+import { FooterContent } from '../components/FooterContent'
 import type { EmailIdentity } from '@my/app/types/brand-profile'
 
 export type NewsAlertProps = {
@@ -74,7 +74,7 @@ const NewsAlert: React.FC<NewsAlertProps> = ({ title, detailsUrl, previewImageUr
         <Container>
           <Text>&nbsp;</Text>
         </Container>
-        <Footer identity={identity} />
+        <FooterContent identity={identity} />
       </Body>
     </Html>
   )


### PR DESCRIPTION
Completes the news-alert send fix. #67 removed the `EmailIdentityProvider` element, but the send then failed at:
> Attempted to call useEmailIdentity() from the server but useEmailIdentity is on the client.

`Footer` still invoked the `'use client'` context **hook**, which an App Router server route can't call either.

## Fix
- Extract a pure, **prop-only `FooterContent`** (no hook; default identity lives in this server-safe module).
- `NewsAlert` renders `FooterContent` directly with the `identity` prop → the news-alert render tree references **nothing** from the `'use client'` email-identity module.
- The hook-based `Footer` is kept as a thin wrapper over `FooterContent` for **every other template** (rendered via `get-email-content`), so their context-driven branding is unchanged.

## Verification
- [x] Typecheck clean (2 pre-existing `get-upcoming-program` errors only).
- [ ] Prod: send test alert → email delivers, footer address correct.

> ⚠️ Follow-up worth checking: App Router routes that render emails via `get-email-content` (`/api/email/test-thursday`, `/api/cron/email-queue`) also call `useEmailIdentity()` and may hit the same error. Flagging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)