### PR TITLE
feat(news): body in alert email + inter-ecclesia framing by audience

### DIFF
--- a/apps/email-builder/emails/NewsAlert.tsx
+++ b/apps/email-builder/emails/NewsAlert.tsx
@@ -13,16 +13,20 @@ import {
 import React from 'react'
 import {
   container,
+  defaultText,
   globalCss,
   header,
   link,
   main,
 } from '../styles'
 import { FooterContent } from '../components/FooterContent'
+import { AutoLinkText } from '../components/AutoLinkText'
 import type { EmailIdentity } from '@my/app/types/brand-profile'
 
 export type NewsAlertProps = {
   title: string
+  /** The news item body — the actual information. Supports #/##, **bold**, - bullets, auto-linked URLs. */
+  body?: string
   /** Absolute URL to the news details page (per-brand domain). */
   detailsUrl: string
   /** Optional poster preview (image URL or PDF page-1 thumbnail). */
@@ -33,19 +37,59 @@ export type NewsAlertProps = {
    * server route without invoking the `'use client'` provider element.
    */
   identity?: EmailIdentity
+  /**
+   * When true, the audience is other ecclesias' leaders — render the
+   * "Please share with your ecclesia" framing instead of the standard header.
+   * Driven by the selected audience, so it applies to test sends too.
+   */
+  interEcclesia?: boolean
 }
 
-const NewsAlert: React.FC<NewsAlertProps> = ({ title, detailsUrl, previewImageUrl, identity }) => {
+const interEcclesiaHeaderStyle = {
+  backgroundColor: '#4a5568',
+  textAlign: 'center' as const,
+  padding: '20px 24px',
+  color: 'white',
+}
+
+const NewsAlert: React.FC<NewsAlertProps> = ({
+  title,
+  body,
+  detailsUrl,
+  previewImageUrl,
+  identity,
+  interEcclesia = false,
+}) => {
+  const previewText = interEcclesia ? `Please share with your ecclesia: ${title}` : title
   return (
     <Html lang="en">
       <Head>
         <style>{globalCss}</style>
       </Head>
-      <Preview>{title}</Preview>
+      <Preview>{previewText}</Preview>
       <Body style={main}>
-        <Section style={header}>
-          <Heading>Toronto East Communications</Heading>
-        </Section>
+        {interEcclesia ? (
+          <Section style={interEcclesiaHeaderStyle}>
+            <Text
+              style={{
+                fontSize: '12px',
+                margin: '0 0 4px 0',
+                color: '#e2e8f0',
+                textTransform: 'uppercase',
+                letterSpacing: '1px',
+              }}
+            >
+              Inter-Ecclesia Communication
+            </Text>
+            <Heading style={{ color: 'white', margin: '0', fontSize: '24px', fontWeight: '600' }}>
+              Please Share With Your Ecclesia
+            </Heading>
+          </Section>
+        ) : (
+          <Section style={header}>
+            <Heading>{identity?.name ?? 'Toronto East Christadelphians'}</Heading>
+          </Section>
+        )}
 
         <Container style={{ ...container, marginTop: '24px' }} className="container">
           <Heading as="h2" style={{ margin: '0 0 16px 0' }}>
@@ -64,9 +108,15 @@ const NewsAlert: React.FC<NewsAlertProps> = ({ title, detailsUrl, previewImageUr
             </Section>
           ) : null}
 
+          {body ? (
+            <Section style={{ ...defaultText, marginBottom: '8px' }}>
+              <AutoLinkText text={body} linkStyle={link} />
+            </Section>
+          ) : null}
+
           <Section style={{ marginTop: '8px' }}>
             <Link href={detailsUrl} style={link}>
-              Click to read →
+              View this on the web (with any attachments) →
             </Link>
           </Section>
         </Container>

--- a/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
+++ b/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
@@ -98,9 +98,13 @@ export async function POST(
     const profile = await resolveBrandProfile({ ownerEcclesiaName: news.ecclesiaId, tenant })
     const emailElement = createElement(NewsAlert as any, {
       title: news.title,
+      body: news.body,
       detailsUrl,
       previewImageUrl: getPreviewImageUrl(news.documents),
       identity: emailIdentityFromProfile(profile),
+      // "Please share with your ecclesia" framing is driven by the selected
+      // audience (not the send mode), so it also applies to test sends.
+      interEcclesia: audienceKey === EmailListTypes.interEcclesia,
     })
     const emailHtml = await render(emailElement)
     const emailText = await render(emailElement, { plainText: true })


### PR DESCRIPTION
Addresses two things about the news-alert email:

1. **It was just a poster.** `NewsAlert` never rendered `news.body`. Now it renders the body via `AutoLinkText` (same `#`/`**bold**`/bullets/auto-link renderer used by other emails), so the email carries the actual information — closer to the event emails. The web link is kept for attachments/full page.
2. **Missing "please share" header for inter-ecclesia.** That framing only existed for `reason === 'inter-ecclesia'`, so a news alert to the inter-ecclesia audience never showed it. Now it's driven by the **selected audience** (`audienceKey === interEcclesia`), so it renders for that audience — **including test sends** (test only changes delivery, not the intended audience).

Also: the standard header now brands from the resolved identity name instead of a hardcoded string.

Server-safe: `AutoLinkText` (used by the Baptism email) and the prop-only `FooterContent` — no `'use client'` in the render tree.

## Not included (still epic #55 / #56)
- Per-recipient "update your ecclesia contact" link (needs the audience-driven personalization from #56). This PR does the header/tone; the token link comes with #56.

## Verification
- [x] Typecheck clean.
- [ ] Prod: send test alert (audience = Inter-Ecclesia Leaders) → email shows body + "Please share" header; send with a normal audience → standard header, body present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)