### PR TITLE
feat(news): inter-ecclesia header 'From {ecclesia}' + spacing/link tweaks

### DIFF
--- a/apps/email-builder/emails/NewsAlert.tsx
+++ b/apps/email-builder/emails/NewsAlert.tsx
@@ -43,6 +43,8 @@ export type NewsAlertProps = {
    * Driven by the selected audience, so it applies to test sends too.
    */
   interEcclesia?: boolean
+  /** Sending ecclesia's display name, shown as "From {fromEcclesia}" in the inter-ecclesia header. */
+  fromEcclesia?: string
 }
 
 const interEcclesiaHeaderStyle = {
@@ -59,6 +61,7 @@ const NewsAlert: React.FC<NewsAlertProps> = ({
   previewImageUrl,
   identity,
   interEcclesia = false,
+  fromEcclesia,
 }) => {
   const previewText = interEcclesia ? `Please share with your ecclesia: ${title}` : title
   return (
@@ -79,7 +82,7 @@ const NewsAlert: React.FC<NewsAlertProps> = ({
                 letterSpacing: '1px',
               }}
             >
-              Inter-Ecclesia Communication
+              From {fromEcclesia ?? identity?.name ?? 'Toronto East Ecclesia'}
             </Text>
             <Heading style={{ color: 'white', margin: '0', fontSize: '24px', fontWeight: '600' }}>
               Please Share With Your Ecclesia
@@ -114,9 +117,9 @@ const NewsAlert: React.FC<NewsAlertProps> = ({
             </Section>
           ) : null}
 
-          <Section style={{ marginTop: '8px' }}>
+          <Section style={{ marginTop: '28px' }}>
             <Link href={detailsUrl} style={link}>
-              View this on the web (with any attachments) →
+              View this on the web →
             </Link>
           </Section>
         </Container>

--- a/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
+++ b/apps/next/app/api/admin/news/[newsId]/send-alert/route.ts
@@ -105,6 +105,9 @@ export async function POST(
       // "Please share with your ecclesia" framing is driven by the selected
       // audience (not the send mode), so it also applies to test sends.
       interEcclesia: audienceKey === EmailListTypes.interEcclesia,
+      // "From {ecclesia}" — the sending ecclesia's display name (e.g. "Toronto
+      // East Ecclesia"), distinct from the footer's public name.
+      fromEcclesia: profile.displayName,
     })
     const emailHtml = await render(emailElement)
     const emailText = await render(emailElement, { plainText: true })


### PR DESCRIPTION
Small polish on the news-alert email (follows #69):
- Inter-ecclesia header top line: **"From {ecclesia}"** (sending ecclesia's `displayName`, e.g. "Toronto East Ecclesia") instead of "Inter-Ecclesia Communication".
- Extra space between the body and the web link.
- Link text simplified to **"View this on the web →"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)