### PR TITLE
fix(news): readable send buttons (hover/disabled were white-on-white)

### DIFF
--- a/packages/ui/src/news/news-item-form.tsx
+++ b/packages/ui/src/news/news-item-form.tsx
@@ -2,7 +2,10 @@
 
 import React from 'react'
 import { Controller, useForm } from 'react-hook-form'
-import { Button, Paragraph, XStack, YStack } from 'tamagui'
+import { Paragraph, XStack, YStack } from 'tamagui'
+// Project Button (not raw tamagui): disables hoverTheme so a colored button's
+// background doesn't swap to the page background on hover (white-on-white).
+import { Button } from '../Button'
 import { FormInput } from '../form/form-input'
 import { OptimizedTextarea } from '../form/optimized-textarea'
 import { EventFormSelect } from '../form/event-form-select'
@@ -249,9 +252,11 @@ export function NewsItemForm({
               Send test alert
             </Button>
             <Button
-              backgroundColor={alertAlreadySent ? '$gray8' : '$warning'}
-              color="white"
-              hoverStyle={{ backgroundColor: alertAlreadySent ? '$gray8' : '$warningHover' }}
+              backgroundColor={alertAlreadySent ? '$gray4' : '$warning'}
+              color={alertAlreadySent ? '$gray11' : 'white'}
+              borderColor={alertAlreadySent ? '$gray6' : undefined}
+              hoverStyle={{ backgroundColor: alertAlreadySent ? '$gray4' : '$warningHover' }}
+              disabledStyle={{ opacity: 1 }}
               onPress={() => onSendAlert(false, selectedAudience)}
               disabled={isSaving || alertAlreadySent}
             >


### PR DESCRIPTION
"Send test alert" went **white-on-white on hover**, and the disabled "Already sent to this list" was white on light gray — both unreadable.

**Root cause:** the News form imported `Button` from `tamagui` directly, bypassing the project `@my/ui` Button that exists specifically to disable Tamagui's `hoverTheme` (which swaps any colored button's background to the page background on hover).

**Fix:**
- Use `@my/ui` Button in the News form → hover darkens via opacity, background stays colored. Fixes every button in the form.
- Disabled "Already sent" state → dark `$gray11` text on light `$gray4`, full opacity (readable, subtle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)