### PR TITLE
feat(email): per-recipient send analytics — foundation (C1)

### DIFF
--- a/apps/next/app/api/ses/bounce-webhook/route.ts
+++ b/apps/next/app/api/ses/bounce-webhook/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { unsubscribeContact } from '../../../../utils/email/contact'
 import { sendRecordRepository } from '@my/app/provider/dynamodb/repositories/send-record-repository'
+import { sendRecipientRepository } from '@my/app/provider/dynamodb/repositories/send-recipient-repository'
 
 // Types for SNS/SES notifications
 interface SNSMessage {
@@ -106,11 +107,15 @@ export async function POST(request: NextRequest) {
       // Extract campaign ID from SES message tags (best-effort)
       const campaignId = sesNotification.mail.tags?.Campaign?.[0]
 
+      // Recipient(s) for this event — present on every SES notification.
+      const eventRecipients = sesNotification.mail.destination ?? []
+
       // Handle Open events — update send record metrics
       if (sesNotification.notificationType === 'Open') {
         console.log('📬 Open event received')
         if (campaignId) {
           await sendRecordRepository.incrementMetric(campaignId, 'opens')
+          await Promise.all(eventRecipients.map((e) => sendRecipientRepository.recordOpen(campaignId, e)))
         }
         return NextResponse.json({ success: true, type: 'open', campaignId })
       }
@@ -120,6 +125,7 @@ export async function POST(request: NextRequest) {
         console.log('📬 Click event received:', sesNotification.click?.link)
         if (campaignId) {
           await sendRecordRepository.incrementMetric(campaignId, 'clicks')
+          await Promise.all(eventRecipients.map((e) => sendRecipientRepository.recordClick(campaignId, e)))
         }
         return NextResponse.json({ success: true, type: 'click', campaignId })
       }
@@ -156,6 +162,11 @@ export async function POST(request: NextRequest) {
         // Update send record bounce count
         if (campaignId) {
           await sendRecordRepository.incrementMetric(campaignId, 'bounces', bouncedRecipients.length)
+          await Promise.all(
+            bouncedRecipients.map((r) =>
+              sendRecipientRepository.recordBounce(campaignId, r.emailAddress, bounceType)
+            )
+          )
         }
 
         return NextResponse.json({
@@ -191,6 +202,11 @@ export async function POST(request: NextRequest) {
         // Update send record complaint count
         if (campaignId) {
           await sendRecordRepository.incrementMetric(campaignId, 'complaints', complainedRecipients.length)
+          await Promise.all(
+            complainedRecipients.map((r) =>
+              sendRecipientRepository.recordComplaint(campaignId, r.emailAddress)
+            )
+          )
         }
 
         return NextResponse.json({
@@ -205,8 +221,8 @@ export async function POST(request: NextRequest) {
       if (sesNotification.notificationType === 'Delivery') {
         console.log('📬 Delivery confirmation received')
         if (campaignId) {
-          const recipientCount = sesNotification.mail.destination.length
-          await sendRecordRepository.incrementMetric(campaignId, 'deliveries', recipientCount)
+          await sendRecordRepository.incrementMetric(campaignId, 'deliveries', eventRecipients.length)
+          await Promise.all(eventRecipients.map((e) => sendRecipientRepository.recordDelivery(campaignId, e)))
         }
         return NextResponse.json({ success: true, type: 'delivery', campaignId })
       }

--- a/apps/next/utils/email/email-send.tsx
+++ b/apps/next/utils/email/email-send.tsx
@@ -7,6 +7,7 @@ import { chunkArray } from '../chunkArray'
 import { generateEcclesiaUpdateUrl } from './ecclesia-token'
 import { addUtmParameters } from './utm-links'
 import { sendRecordRepository } from '@my/app/provider/dynamodb/repositories/send-record-repository'
+import { sendRecipientRepository } from '@my/app/provider/dynamodb/repositories/send-recipient-repository'
 import { resolveTenantFromEnv, type TenantConfig } from '@my/app/config/tenants'
 
 const SES_RATE_LIMIT = 14
@@ -222,6 +223,21 @@ export const emailSend = async function ({
       })
     } catch (recordError) {
       console.error('Failed to create send record (non-fatal):', recordError)
+    }
+
+    // Per-recipient roster snapshot — the send-time record of exactly who this
+    // campaign went to. SES delivery/open/click/bounce events fill in the rest
+    // per recipient (see the SES webhook). Best-effort; killable per-deployment
+    // with RECIPIENT_TRACKING_ENABLED=false (newsletter = thousands of writes).
+    if (process.env.RECIPIENT_TRACKING_ENABLED !== 'false') {
+      try {
+        await sendRecipientRepository.snapshotRoster(campaignId, [
+          ...allSent.sends.map((email) => ({ email, status: 'sent' as const })),
+          ...allSent.skips.map((email) => ({ email, status: 'failed' as const })),
+        ])
+      } catch (rosterError) {
+        console.error('Failed to snapshot recipient roster (non-fatal):', rosterError)
+      }
     }
 
     return { ...allSent, campaignId }

--- a/packages/app/provider/dynamodb/repositories/send-recipient-repository.ts
+++ b/packages/app/provider/dynamodb/repositories/send-recipient-repository.ts
@@ -1,0 +1,182 @@
+import { UpdateCommand } from '@aws-sdk/lib-dynamodb'
+import { BaseRepository } from './base-repository'
+import { docClient } from '../config'
+import type { CampaignRecipient, EmailRecipientRecord } from '../../../types/analytics'
+
+const TTL_SECONDS = 180 * 24 * 60 * 60 // 180 days, matches the send-record TTL
+
+/**
+ * Per-recipient send tracking (Mailchimp-style drill-down). One item per
+ * (campaign, recipient) under the campaign's partition:
+ *   pkey = SEND#{campaignId}, skey = RECIPIENT#{email}
+ *
+ * - `snapshotRoster` captures every intended recipient at send time (batched).
+ * - the SES webhook calls `recordDelivery/Open/Click/Bounce/Complaint` per event.
+ * - `getCampaignRecipients` returns the full breakdown for a campaign.
+ *
+ * Event methods upsert (SET ... if_not_exists) so an event that arrives before
+ * (or without) the roster snapshot still creates a coherent record.
+ */
+class SendRecipientRepository extends BaseRepository<EmailRecipientRecord> {
+  constructor() {
+    super('admin', false) // tee-admin table, pkey/skey naming
+  }
+
+  protected buildSheetPK(): string {
+    return 'SEND'
+  }
+
+  private static skey(email: string): string {
+    return `RECIPIENT#${email.toLowerCase()}`
+  }
+
+  /** Persist the intended-recipient roster for a campaign (best-effort, batched). */
+  async snapshotRoster(
+    campaignId: string,
+    recipients: Array<{ email: string; status: 'sent' | 'failed'; ecclesia?: string }>
+  ): Promise<void> {
+    if (recipients.length === 0) return
+    const sentAt = new Date().toISOString()
+    const ttl = Math.floor(Date.now() / 1000) + TTL_SECONDS
+    const items: EmailRecipientRecord[] = recipients.map((r) => ({
+      pkey: `SEND#${campaignId}`,
+      skey: SendRecipientRepository.skey(r.email),
+      campaignId,
+      email: r.email.toLowerCase(),
+      ...(r.ecclesia ? { ecclesia: r.ecclesia } : {}),
+      status: r.status,
+      sentAt,
+      opens: 0,
+      clicks: 0,
+      ttl,
+    }))
+    await this.batchWrite(items)
+  }
+
+  /** Shared upsert: ensures identity fields exist, then applies event-specific changes. */
+  private async applyEvent(
+    campaignId: string,
+    email: string,
+    extra: {
+      set?: Record<string, string> // attrName -> valuePlaceholderKey
+      add?: Record<string, string> // attrName -> valuePlaceholderKey
+      names?: Record<string, string>
+      values?: Record<string, any>
+    }
+  ): Promise<void> {
+    const now = new Date().toISOString()
+    const ttl = Math.floor(Date.now() / 1000) + TTL_SECONDS
+
+    const names: Record<string, string> = {
+      '#status': 'status',
+      '#ttl': 'ttl',
+      '#lastUpdated': 'lastUpdated',
+      ...(extra.names ?? {}),
+    }
+    const values: Record<string, any> = {
+      ':cid': campaignId,
+      ':em': email.toLowerCase(),
+      ':sent': 'sent',
+      ':now': now,
+      ':ttl': ttl,
+      ...(extra.values ?? {}),
+    }
+
+    // Note: opens/clicks are NOT initialized here — recordOpen/recordClick ADD
+    // them (ADD treats a missing attribute as 0), and a SET + ADD on the same
+    // path in one expression is rejected. Reads default missing counters to 0.
+    const setParts = [
+      'campaignId = if_not_exists(campaignId, :cid)',
+      'email = if_not_exists(email, :em)',
+      '#status = if_not_exists(#status, :sent)',
+      'sentAt = if_not_exists(sentAt, :now)',
+      '#ttl = if_not_exists(#ttl, :ttl)',
+      '#lastUpdated = :now',
+      ...Object.entries(extra.set ?? {}).map(([n, v]) => `${n} = ${v}`),
+    ]
+
+    const addParts = Object.entries(extra.add ?? {}).map(([n, v]) => `${n} ${v}`)
+
+    let expr = `SET ${setParts.join(', ')}`
+    if (addParts.length) expr += ` ADD ${addParts.join(', ')}`
+
+    try {
+      await docClient.send(
+        new UpdateCommand({
+          TableName: this.tableName,
+          Key: { pkey: `SEND#${campaignId}`, skey: SendRecipientRepository.skey(email) },
+          UpdateExpression: expr,
+          ExpressionAttributeNames: names,
+          ExpressionAttributeValues: values,
+        })
+      )
+    } catch (error) {
+      console.error(`Error recording recipient event for ${email} / ${campaignId}:`, error)
+      // Best-effort — never throw from the webhook path.
+    }
+  }
+
+  recordDelivery(campaignId: string, email: string) {
+    return this.applyEvent(campaignId, email, { set: { deliveredAt: 'if_not_exists(deliveredAt, :now)' } })
+  }
+
+  recordOpen(campaignId: string, email: string) {
+    return this.applyEvent(campaignId, email, {
+      set: { lastOpenAt: ':now' },
+      add: { opens: ':one' },
+      values: { ':one': 1 },
+    })
+  }
+
+  recordClick(campaignId: string, email: string) {
+    return this.applyEvent(campaignId, email, {
+      set: { lastClickAt: ':now' },
+      add: { clicks: ':one' },
+      values: { ':one': 1 },
+    })
+  }
+
+  recordBounce(campaignId: string, email: string, bounceType?: string) {
+    return this.applyEvent(campaignId, email, {
+      set: { bouncedAt: ':now', bounceType: ':bt' },
+      values: { ':bt': bounceType ?? 'Unknown' },
+    })
+  }
+
+  recordComplaint(campaignId: string, email: string) {
+    return this.applyEvent(campaignId, email, { set: { complainedAt: ':now' } })
+  }
+
+  /** Full per-recipient breakdown for one campaign (paginated). */
+  async getCampaignRecipients(campaignId: string): Promise<CampaignRecipient[]> {
+    const out: CampaignRecipient[] = []
+    let lastKey: Record<string, any> | undefined
+    do {
+      const { items, lastEvaluatedKey } = await this.query(
+        'pkey = :pk AND begins_with(skey, :sk)',
+        { ':pk': `SEND#${campaignId}`, ':sk': 'RECIPIENT#' },
+        { lastEvaluatedKey: lastKey }
+      )
+      for (const r of items) {
+        out.push({
+          email: r.email,
+          ecclesia: r.ecclesia,
+          status: r.status,
+          sentAt: r.sentAt,
+          deliveredAt: r.deliveredAt,
+          opens: r.opens ?? 0,
+          lastOpenAt: r.lastOpenAt,
+          clicks: r.clicks ?? 0,
+          lastClickAt: r.lastClickAt,
+          bouncedAt: r.bouncedAt,
+          bounceType: r.bounceType,
+          complainedAt: r.complainedAt,
+        })
+      }
+      lastKey = lastEvaluatedKey
+    } while (lastKey)
+    return out
+  }
+}
+
+export const sendRecipientRepository = new SendRecipientRepository()

--- a/packages/app/types/analytics.ts
+++ b/packages/app/types/analytics.ts
@@ -57,6 +57,49 @@ export interface EmailSendRecord {
   clickRate: number
 }
 
+/**
+ * Per-recipient send record — one per (campaign, email). Enables Mailchimp-style
+ * drill-down: exactly who was sent to and, from SES events, who was delivered /
+ * opened / clicked / bounced. Stored under the same partition as the campaign's
+ * METADATA record (pkey SEND#{campaignId}, skey RECIPIENT#{email}).
+ */
+export interface EmailRecipientRecord {
+  pkey: string // SEND#{campaignId}
+  skey: string // RECIPIENT#{email-lowercased}
+  campaignId: string
+  email: string
+  ecclesia?: string
+  status: 'sent' | 'failed'
+  sentAt: string // ISO
+  deliveredAt?: string
+  opens: number
+  lastOpenAt?: string
+  clicks: number
+  lastClickAt?: string
+  bouncedAt?: string
+  bounceType?: string
+  complainedAt?: string
+  ttl: number
+  lastUpdated?: string
+  version?: number
+}
+
+/** API-facing per-recipient row for a campaign report */
+export interface CampaignRecipient {
+  email: string
+  ecclesia?: string
+  status: 'sent' | 'failed'
+  sentAt: string
+  deliveredAt?: string
+  opens: number
+  lastOpenAt?: string
+  clicks: number
+  lastClickAt?: string
+  bouncedAt?: string
+  bounceType?: string
+  complainedAt?: string
+}
+
 export interface EmailMetricsSummary {
   totals: {
     sends: number


### PR DESCRIPTION
Foundation for Mailchimp/Mailgun-style per-recipient metrics across **all** sends (Phase C / #65).

## Data model
One item per (campaign, recipient), under the campaign's partition:
```
SEND#{campaignId} / METADATA            (existing aggregate)
SEND#{campaignId} / RECIPIENT#{email}   (NEW: status, deliveredAt, opens, clicks, bouncedAt, complainedAt, …)
```
A campaign's full breakdown = one partition query.

## Changes
- **`sendRecipientRepository`** — `snapshotRoster` (batched via existing `batchWrite`), per-event upserts (`recordDelivery/Open/Click/Bounce/Complaint`), `getCampaignRecipients`.
- **`emailSend`** — snapshots the intended-recipient roster at send time. **Best-effort** (never breaks a send) and **killable** via `RECIPIENT_TRACKING_ENABLED=false`.
- **SES webhook** — writes the per-recipient row on every event (the `campaignId` + recipient email were already in each notification, just discarded), alongside the existing aggregate counters.

## Notes
- Applies to **all reasons** automatically.
- Ecclesia isn't captured at send time (cheap path); the C2 report can enrich per recipient.
- Does **not** backfill the inter-ecclesia send you just did — that roster is saved separately (`~/Downloads/inter-ecclesia-roster-*.csv`).

## Next
- **C2** — the campaign report UI (recipient list + delivered/opened/clicked/bounced, filter by ecclesia) in the existing email-metrics admin surface.
- Separate: register the `abs`/`ABs` ("Arranging Brothers") audiences (they ripple into contact-preference + draft types, and look like SES duplicates — worth consolidating first).

## Verification
- [x] Typecheck clean (2 pre-existing `get-upcoming-program` errors only).
- [ ] After deploy, a test send writes RECIPIENT# rows; SES events populate delivered/opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)