### PR TITLE
feat(email): per-recipient campaign report (C2)

### DIFF
--- a/apps/next/app/admin/(admin-plus)/metrics/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/metrics/page.tsx
@@ -10,14 +10,20 @@ import {
   Tabs,
   Card,
   Button,
+  Input,
   ScrollView,
   useThemeName,
 } from '@my/ui'
 import { useHydrated } from '@my/app/hooks/use-hydrated'
 import { brandColors } from '@my/ui/src/branding/brand-colors'
 import { useState, useEffect, useCallback } from 'react'
-import { RefreshCw } from '@tamagui/lucide-icons'
-import type { WebMetricsSummary, EmailMetricsSummary, EmailSendRecord } from '@my/app/types/analytics'
+import { RefreshCw, X } from '@tamagui/lucide-icons'
+import type {
+  WebMetricsSummary,
+  EmailMetricsSummary,
+  EmailSendRecord,
+  CampaignRecipient,
+} from '@my/app/types/analytics'
 import {
   LineChart,
   Line,
@@ -273,6 +279,7 @@ function EmailMetricsView({
   mode: 'light' | 'dark'
 }) {
   const textColor = mode === 'dark' ? '#e0e0e0' : '#333333'
+  const [selectedCampaign, setSelectedCampaign] = useState<string | null>(null)
 
   return (
     <YStack gap="$4">
@@ -395,7 +402,21 @@ function EmailMetricsView({
 
       {/* Recent Email Performance (per-send tracking) */}
       {metrics.recentSends && metrics.recentSends.length > 0 ? (
-        <RecentSendsTable sends={metrics.recentSends} colors={colors} />
+        <RecentSendsTable
+          sends={metrics.recentSends}
+          colors={colors}
+          selectedCampaign={selectedCampaign}
+          onSelect={(id) => setSelectedCampaign((cur) => (cur === id ? null : id))}
+        />
+      ) : null}
+
+      {/* Per-recipient drill-down for the selected campaign */}
+      {selectedCampaign ? (
+        <RecipientDrilldown
+          campaignId={selectedCampaign}
+          colors={colors}
+          onClose={() => setSelectedCampaign(null)}
+        />
       ) : null}
     </YStack>
   )
@@ -422,14 +443,21 @@ function formatDate(iso: string): string {
 function RecentSendsTable({
   sends,
   colors,
+  onSelect,
+  selectedCampaign,
 }: {
   sends: EmailSendRecord[]
   colors: BrandColorsType
+  onSelect: (campaignId: string) => void
+  selectedCampaign: string | null
 }) {
   return (
     <Card padding="$4" backgroundColor={colors.backgroundTertiary}>
-      <Text fontSize="$4" fontWeight="600" color={colors.textPrimary} marginBottom="$3">
+      <Text fontSize="$4" fontWeight="600" color={colors.textPrimary} marginBottom="$1">
         Recent Email Performance
+      </Text>
+      <Text fontSize="$2" color={colors.textSecondary} marginBottom="$3">
+        Click a send to see exactly who received it and who opened / clicked / bounced.
       </Text>
       <YStack gap="$1">
         {/* Header row */}
@@ -471,6 +499,12 @@ function RecentSendsTable({
             borderBottomWidth={1}
             borderBottomColor={colors.border}
             alignItems="center"
+            cursor="pointer"
+            backgroundColor={
+              selectedCampaign === send.campaignId ? colors.backgroundSecondary : 'transparent'
+            }
+            hoverStyle={{ backgroundColor: colors.backgroundSecondary }}
+            onPress={() => onSelect(send.campaignId)}
           >
             <Text flex={2} color={colors.textPrimary} fontSize="$2" numberOfLines={1}>
               {formatDate(send.sentAt)}
@@ -526,6 +560,161 @@ function RecentSendsTable({
           </XStack>
         ))}
       </YStack>
+    </Card>
+  )
+}
+
+function fmtEventDate(iso?: string): string {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleDateString('en-CA', {
+    timeZone: 'America/Toronto',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+// Per-recipient drill-down for one campaign (who received / opened / clicked / bounced)
+function RecipientDrilldown({
+  campaignId,
+  colors,
+  onClose,
+}: {
+  campaignId: string
+  colors: BrandColorsType
+  onClose: () => void
+}) {
+  const [recipients, setRecipients] = useState<CampaignRecipient[]>([])
+  const [enrichedEcclesia, setEnrichedEcclesia] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [filter, setFilter] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    fetch(`/api/admin/metrics/email/${campaignId}/recipients`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error('Failed to load recipients'))))
+      .then((d) => {
+        if (cancelled) return
+        setRecipients(d.data.recipients ?? [])
+        setEnrichedEcclesia(!!d.data.enrichedEcclesia)
+      })
+      .catch((e) => !cancelled && setError(e.message))
+      .finally(() => !cancelled && setLoading(false))
+    return () => {
+      cancelled = true
+    }
+  }, [campaignId])
+
+  const q = filter.trim().toLowerCase()
+  const rows = q
+    ? recipients.filter(
+        (r) => r.email.toLowerCase().includes(q) || (r.ecclesia ?? '').toLowerCase().includes(q)
+      )
+    : recipients
+
+  const summary = {
+    total: recipients.length,
+    delivered: recipients.filter((r) => r.deliveredAt).length,
+    opened: recipients.filter((r) => r.opens > 0).length,
+    clicked: recipients.filter((r) => r.clicks > 0).length,
+    bounced: recipients.filter((r) => r.bouncedAt).length,
+  }
+
+  return (
+    <Card padding="$4" backgroundColor={colors.backgroundTertiary}>
+      <XStack justifyContent="space-between" alignItems="center" marginBottom="$2">
+        <Text fontSize="$4" fontWeight="600" color={colors.textPrimary}>
+          Recipients — who received this send
+        </Text>
+        <Button size="$2" icon={X} onPress={onClose} backgroundColor="transparent" />
+      </XStack>
+
+      {loading ? (
+        <YStack alignItems="center" padding="$4">
+          <Spinner />
+        </YStack>
+      ) : error ? (
+        <Text color={colors.error}>{error}</Text>
+      ) : recipients.length === 0 ? (
+        <Text color={colors.textSecondary} fontSize="$3">
+          No per-recipient data for this send. (Only sends after per-recipient tracking was enabled
+          are captured.)
+        </Text>
+      ) : (
+        <YStack gap="$3">
+          <Text fontSize="$2" color={colors.textSecondary}>
+            {summary.total} recipients · {summary.delivered} delivered · {summary.opened} opened ·{' '}
+            {summary.clicked} clicked · {summary.bounced} bounced
+            {enrichedEcclesia ? '' : ' · (ecclesia not shown for large sends)'}
+          </Text>
+
+          <Input
+            size="$3"
+            placeholder="Filter by ecclesia or email…"
+            value={filter}
+            onChangeText={setFilter}
+            backgroundColor={colors.background}
+          />
+
+          {/* Header */}
+          <XStack paddingHorizontal="$2" paddingVertical="$1" borderBottomWidth={1} borderBottomColor={colors.border}>
+            <Text flex={2} fontSize="$1" fontWeight="600" color={colors.textSecondary}>Ecclesia</Text>
+            <Text flex={3} fontSize="$1" fontWeight="600" color={colors.textSecondary}>Email</Text>
+            <Text flex={2} fontSize="$1" fontWeight="600" color={colors.textSecondary}>Delivered</Text>
+            <Text flex={1} fontSize="$1" fontWeight="600" color={colors.textSecondary} textAlign="right">Opens</Text>
+            <Text flex={1} fontSize="$1" fontWeight="600" color={colors.textSecondary} textAlign="right">Clicks</Text>
+            <Text flex={2} fontSize="$1" fontWeight="600" color={colors.textSecondary} textAlign="right">Status</Text>
+          </XStack>
+
+          {rows.map((r) => {
+            const bounced = !!r.bouncedAt
+            const complained = !!r.complainedAt
+            const failed = r.status === 'failed'
+            const statusText = complained
+              ? 'Complaint'
+              : bounced
+                ? `Bounced${r.bounceType ? ` (${r.bounceType})` : ''}`
+                : failed
+                  ? 'Send failed'
+                  : r.deliveredAt
+                    ? 'Delivered'
+                    : 'Sent'
+            const statusColor =
+              complained || bounced || failed ? '#ef4444' : r.deliveredAt ? '#22c55e' : colors.textSecondary
+            return (
+              <XStack key={r.email} paddingHorizontal="$2" paddingVertical="$1.5" borderBottomWidth={1} borderBottomColor={colors.border} alignItems="center">
+                <Text flex={2} fontSize="$2" color={colors.textPrimary} numberOfLines={1}>
+                  {r.ecclesia ?? '—'}
+                </Text>
+                <Text flex={3} fontSize="$2" color={colors.textPrimary} numberOfLines={1}>
+                  {r.email}
+                </Text>
+                <Text flex={2} fontSize="$2" color={colors.textSecondary} numberOfLines={1}>
+                  {fmtEventDate(r.deliveredAt)}
+                </Text>
+                <Text flex={1} fontSize="$2" color={colors.textPrimary} textAlign="right">
+                  {r.opens}
+                </Text>
+                <Text flex={1} fontSize="$2" color={colors.textPrimary} textAlign="right">
+                  {r.clicks}
+                </Text>
+                <Text flex={2} fontSize="$2" color={statusColor} textAlign="right" numberOfLines={1}>
+                  {statusText}
+                </Text>
+              </XStack>
+            )
+          })}
+          {rows.length === 0 ? (
+            <Text color={colors.textSecondary} fontSize="$2" padding="$2">
+              No recipients match “{filter}”.
+            </Text>
+          ) : null}
+        </YStack>
+      )}
     </Card>
   )
 }

--- a/apps/next/app/api/admin/metrics/email/[campaignId]/recipients/route.ts
+++ b/apps/next/app/api/admin/metrics/email/[campaignId]/recipients/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+import { sendRecipientRepository } from '@my/app/provider/dynamodb/repositories/send-recipient-repository'
+import { sendRecordRepository } from '@my/app/provider/dynamodb/repositories/send-record-repository'
+import { getContact } from '@/utils/email/contact'
+
+// Cap ecclesia enrichment (one SES get-contact per recipient) to campaigns of a
+// reasonable size — the inter-ecclesia audience is ~36. Large blasts (newsletter,
+// thousands) skip enrichment; the per-recipient engagement data still shows.
+const ECCLESIA_ENRICH_CAP = 250
+const ENRICH_CHUNK = 20
+
+/**
+ * GET /api/admin/metrics/email/[campaignId]/recipients
+ * Per-recipient breakdown for one campaign (Mailchimp-style drill-down):
+ * exactly who it went to + delivered/opened/clicked/bounced, with ecclesia
+ * enriched from SES contact attributes for reasonably-sized campaigns.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ campaignId: string }> }
+) {
+  const session = await auth()
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const role = (session.user as any).role
+  if (role !== ROLES.ADMIN && role !== ROLES.OWNER) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  try {
+    const { campaignId } = await params
+    const [send, recipients] = await Promise.all([
+      sendRecordRepository.getSendRecord(campaignId),
+      sendRecipientRepository.getCampaignRecipients(campaignId),
+    ])
+
+    const enrichedEcclesia = recipients.length > 0 && recipients.length <= ECCLESIA_ENRICH_CAP
+    if (enrichedEcclesia) {
+      for (let i = 0; i < recipients.length; i += ENRICH_CHUNK) {
+        const chunk = recipients.slice(i, i + ENRICH_CHUNK)
+        await Promise.all(
+          chunk.map(async (r) => {
+            try {
+              const contact = await getContact(r.email)
+              if (contact?.AttributesData) {
+                const attrs = JSON.parse(contact.AttributesData)
+                if (attrs?.ecclesia) r.ecclesia = attrs.ecclesia
+              }
+            } catch {
+              // best-effort — leave ecclesia undefined
+            }
+          })
+        )
+      }
+    }
+
+    // Sort: bounced/failed first (need attention), then by ecclesia, then email.
+    recipients.sort((a, b) => {
+      const aBad = a.bouncedAt || a.status === 'failed' ? 0 : 1
+      const bBad = b.bouncedAt || b.status === 'failed' ? 0 : 1
+      if (aBad !== bBad) return aBad - bBad
+      return (a.ecclesia ?? '~').localeCompare(b.ecclesia ?? '~') || a.email.localeCompare(b.email)
+    })
+
+    return NextResponse.json({
+      success: true,
+      data: { send, recipients, enrichedEcclesia },
+    })
+  } catch (error) {
+    console.error('Error fetching campaign recipients:', error)
+    return NextResponse.json({ error: 'Failed to fetch campaign recipients' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
Completes Phase C (#65) — the viewing layer on top of C1's data.

## What
Click any send in the metrics dashboard's **Recent Email Performance** → a drill-down opens showing **exactly who received it** and who delivered / opened / clicked / bounced.

- **New API** `GET /api/admin/metrics/email/[campaignId]/recipients` — send record + per-recipient rows (`sendRecipientRepository.getCampaignRecipients`). Enriches **ecclesia** from SES contact attributes for campaigns ≤250 recipients (e.g. the inter-ecclesia audience); larger blasts skip enrichment but still show engagement.
- **UI** — send rows are clickable; the `RecipientDrilldown` shows summary counts, an ecclesia/email filter, and a per-recipient table (ecclesia, email, delivered, opens, clicks, status/bounce). Bounced/failed sort to the top.

## Notes
- Only sends **after C1 deployed** have per-recipient rows (older ones show "no per-recipient data").
- Admin/owner only (same guard as the metrics API).

## Verification
- [x] Typecheck clean.
- [ ] After a new send: open Metrics → click the send → confirm the recipient list + statuses; for an inter-ecclesia send, confirm ecclesia column populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)