### PR TITLE
data: Toronto East subscriber source-of-truth (2026-07-04)

### DIFF
--- a/apps/next/data/toronto-east-subscribers-2026-07-04.csv
+++ b/apps/next/data/toronto-east-subscribers-2026-07-04.csv
@@ -1,0 +1,130 @@
+email,name,ecclesia,topics
+ottawachristadelphians@gmail.com,,,interEcclesia
+p.bilello@cimdata.com,,Ann Arbor,interEcclesia
+grantandhannah2002@gmail.com,,Barrie Ecclesia,interEcclesia
+pferguson8888@gmail.com,Patricia Ferguson,Barrie Ecclesia,newsletter
+geoff@readthebible.com,Geoff McKay,Brampton Ecclesia,interEcclesia
+peteresa@hotmail.com,Peter Wisniowski,Brampton Ecclesia,newsletter
+brantcountychristadelphians@gmail.com,,Brant County Ecclesia,interEcclesia
+brantfordchristadelphians@gmail.com,,Brantford Ecclesia,interEcclesia
+recordercambridge@gmail.com,,Cambridge Ecclesia,interEcclesia
+cwoodinchrist@gmail.com,,Collingwood Ecclesia,interEcclesia
+paul_styles@ameritech.net,,Detroit (Livonia),interEcclesia
+jeffnewth@sbcglobal.net,,Detroit (Milford Rd.),interEcclesia
+romi.christadelphians@gmail.com,,Detroit (Royal Oak),interEcclesia
+aremac@me.com,,Greenaway Ecclesia,interEcclesia
+markjennings224@gmail.com,,Greenaway Ecclesia,interEcclesia
+secretary@guelphchristadelphians.ca,,Guelph Ecclesia,interEcclesia
+bookrdecclesia@gmail.com,,Hamilton Book Rd Christadelphian Ecclesia,interEcclesia
+garyjanet419@gmail.com,,Hamilton MacNab Ecclesia,interEcclesia
+huntsvillechristadelphians@gmail.com,,Huntsville Ecclesia,interEcclesia
+aswebb53@gmail.com,,Kitchener Waterloo Ecclesia,interEcclesia
+martinjwebster@gmail.com,,Kitchener Waterloo Ecclesia,interEcclesia
+buxtoncarr@hotmail.com,Michael Carr,Kitchener Waterloo Ecclesia,newsletter
+david@dalefinancial.ca,,London Ecclesia,interEcclesia
+manitoulinecclesia@gmail.com,,Manitoulin Island Ecclesia,interEcclesia
+misswestchristadelphians@gmail.com,,Mississauga Ecclesia,interEcclesia
+george.ruth.jackson@gmail.com,George Jackson,Mississauga Ecclesia,newsletter
+dmcnjs@yahoo.com,Daniel Archibald,Montreal Ecclesia,bibleClass+interEcclesia+memorial+newsletter
+secretary@biblehope.ca,,Mountain Grove Ecclesia,interEcclesia
+janet.v.r.archibald@gmail.com,Janet Archibald,Mountain Grove Ecclesia,bibleClass+memorial+newsletter
+alchussey@gmail.com,,Niagara Ecclesia,interEcclesia
+husseyal@yahoo.ca,,Niagara Ecclesia,interEcclesia
+imstonell@hotmail.ca,,North Bay Ecclesia,interEcclesia
+pierresimard34@gmail.com,,North Bay Ecclesia,interEcclesia
+dkmiles1967@outlook.com,Kim Miles,North Bay Ecclesia,newsletter
+elpis@sympatico.ca,,Ottawa Ecclesia,interEcclesia+newsletter
+art.houghton@gmail.com,,Peterborough Ecclesia,interEcclesia
+rga49.hill@gmail.com,,Picton Ecclesia,interEcclesia
+julieannedawes44@gmail.com,Julie Winfree,Richmond Chapel,newsletter
+shelburne.announce@outlook.com,,Shelburne Ecclesia,interEcclesia
+alexkolver@gmail.com,Alex Kolver,Toronto East,bibleClass+memorial+newsletter
+ruthpatrong@gmail.com,Alice Patrong,Toronto East,bibleClass+memorial+newsletter
+acurry95@icloud.com,Amanda Curry,Toronto East,bibleClass+memorial+newsletter
+amyjbreau@gmail.com,Amy Breau,Toronto East,newsletter
+andreaweirlaverde@gmail.com,Andrea Weir-Laverde,Toronto East,bibleClass+memorial+newsletter
+akatsson@yahoo.ca,Anne Thomasson,Toronto East,bibleClass+memorial+newsletter
+benjstephens99@gmail.com,Benjamin Stephens,Toronto East,bibleClass+memorial+newsletter
+bjstephens@rogers.com,Brad Stephens,Toronto East,bibleClass+memorial+newsletter
+currybmc@gmail.com,Brent Curry,Toronto East,bibleClass+memorial+newsletter
+carolbustamante789@hotmail.com,Carolina Archibald,Toronto East,bibleClass+memorial+newsletter
+catherinebadger72@gmail.com,Catherine Badger,Toronto East,newsletter
+cpwestwood42@gmail.com,Chris Westwood,Toronto East,bibleClass+memorial+newsletter
+keating_connie@hotmail.com,Connie Keating,Toronto East,bibleClass+memorial+newsletter
+davidboyleonmac@gmail.com,David Boyle,Toronto East,bibleClass+memorial+newsletter
+d.gabriel.morrell@gmail.com,David Morrell,Toronto East,bibleClass+memorial+newsletter
+emackinnon.em@gmail.com,Elizabeth (Liz) MacKinnon,Toronto East,bibleClass+memorial+newsletter
+elliot_cullen@yahoo.ca,Elliot Cullen,Toronto East,bibleClass+memorial+newsletter
+emilyvpalmer@gmail.com,Emily Palmer,Toronto East,bibleClass+memorial+newsletter
+esmaeelfarzaneh@yahoo.com,Esmaeel Farzaneh,Toronto East,bibleClass+memorial+newsletter
+lddawes@hotmail.ca,Esther Dawes,Toronto East,bibleClass+memorial+newsletter
+fraserpdunn@gmail.com,Fraser Dunn,Toronto East,bibleClass+memorial+newsletter
+carter4975@rogers.com,Georges Carter,Toronto East,bibleClass+memorial+newsletter
+bgrosewood@gmail.com,Georgina Rose,Toronto East,bibleClass+memorial+newsletter
+gcastroleano@hotmail.com,Gladys Castro,Toronto East,bibleClass+memorial+newsletter
+flswag@yahoo.com,Gord Easson,Toronto East,bibleClass+memorial+newsletter
+haileyrachelle@gmail.com,Hailey Rachelle,Toronto East,bibleClass+memorial+newsletter
+ian.browning@lcbo.com,Ian Browning,Toronto East,bibleClass+memorial+newsletter
+ianneblett@hotmail.com,Ian Neblett,Toronto East,bibleClass+memorial+newsletter
+jimsam4jm@gmail.com,James Samuels,Toronto East,bibleClass+memorial+newsletter
+krystaljazz2479@gmail.com,Jazz Easson,Toronto East,bibleClass+memorial+newsletter
+jlbell48@mail.com,Jennifer Bell,Toronto East,bibleClass+memorial+newsletter
+jnarjes@branksome.on.ca,Jennifer Narjes,Toronto East,bibleClass+memorial+newsletter
+cramer2je@gmail.com,Jim Cramer,Toronto East,bibleClass+memorial+newsletter
+jperks1@live.com,Jim Perks,Toronto East,bibleClass+memorial+newsletter
+joanncameron@hotmail.com,Jo Ann Cameron,Toronto East,bibleClass+memorial+newsletter
+joancurry@bell.net,Joan Curry,Toronto East,bibleClass+memorial+newsletter
+jonthepuny@gmail.com,Jonathan White,Toronto East,bibleClass+memorial+newsletter
+joshua_narjes@hotmail.com,Joshua Narjes,Toronto East,bibleClass+memorial+newsletter
+judymackinnon85@gmail.com,Judy MacKinnon,Toronto East,bibleClass+memorial+newsletter
+jsmacdougall2021@gmail.com,Julia MacDougall,Toronto East,bibleClass+memorial+newsletter
+juneavrilneblett@hotmail.com,June Neblett,Toronto East,bibleClass+memorial+newsletter
+katie.b.dawes@gmail.com,Katie Dawes,Toronto East,bibleClass+memorial+newsletter
+kayfinner@live.ca,Kay Finner,Toronto East,bibleClass+memorial+newsletter
+keithgdawes@gmail.com,Keith Dawes,Toronto East,bibleClass+memorial+newsletter
+krcurry@sympatico.ca,Ken Curry,Toronto East,bibleClass+memorial+newsletter
+ken.easson@gmail.com,Ken Easson,Toronto East,bibleClass+memorial+newsletter
+l.nyberg@rogers.com,Linda Cooper-Nyberg,Toronto East,bibleClass+memorial+newsletter
+lin.susan.lh@gmail.com,Linda Higgs,Toronto East,bibleClass+memorial+newsletter
+linds.thompson88@gmail.com,Lindsay Morrell,Toronto East,bibleClass+memorial+newsletter
+laverde15@yahoo.com,Livia Weir-Laverde,Toronto East,bibleClass+memorial+newsletter
+maribella@yahoo.com,Maribel Archibald,Toronto East,bibleClass+memorial+newsletter
+mlcurry@bell.net,Marie-Lynn Curry,Toronto East,bibleClass+memorial+newsletter
+marilynlambg@gmail.com,Marilyn Grant,Toronto East,bibleClass+memorial+newsletter
+marycromie@gmail.com,Mary Cromie,Toronto East,bibleClass+memorial+newsletter
+mia@personalchef.ca,Mia Atkin,Toronto East,bibleClass+memorial+newsletter
+michael@atkin.com,Michael Atkin,Toronto East,bibleClass+memorial+newsletter
+ngsharp@comcast.net,Nancy Sharp,Toronto East,bibleClass+memorial+newsletter
+naomi.atkin_17@hotmail.com,Naomi Atkin,Toronto East,bibleClass+memorial+newsletter
+neilthomasson@gmail.com,Neil Thomasson,Toronto East,bibleClass+memorial+newsletter
+nipuneasson@gmail.com,Nipun Easson,Toronto East,bibleClass+memorial+newsletter
+lathania18@gmail.com,Nishla Neblett,Toronto East,bibleClass+memorial+newsletter
+phil@phildwyer.ca,Phil Dwyer,Toronto East,bibleClass+memorial+newsletter
+rachelyumbe1@gmail.com,Rachel Yumbe,Toronto East,bibleClass+memorial+newsletter
+kamosa176@rogers.com,Radica Amos,Toronto East,bibleClass+memorial+newsletter
+sandycyncora@hotmail.com,Rick Cyncora,Toronto East,bibleClass+memorial+newsletter
+grantr830@gmail.com,Rick Grant,Toronto East,bibleClass+memorial+newsletter
+rsldawes90@gmail.com,Russell Dawes,Toronto East,bibleClass+memorial+newsletter
+ruth.patrong@gmail.com,Ruth Patrong,Toronto East,bibleClass+memorial+newsletter
+stephanieruth@yahoo.com,Ruth Thomson,Toronto East,bibleClass+memorial+newsletter
+saljamog@outlook.com,Sally Mogenson,Toronto East,bibleClass+memorial+newsletter
+sarahkat.thomson@gmail.com,Sarah Song,Toronto East,bibleClass+memorial+newsletter
+ecclesia93@ashlar-stone.com,Sharon Moore,Toronto East,bibleClass+memorial+newsletter
+sharon.tribble@gmail.com,Sharon Tribble,Toronto East,bibleClass+memorial+newsletter
+skoens@gmail.com,Sonia Koens,Toronto East,bibleClass+memorial+newsletter
+sstephens0928@yahoo.ca,Stephanie Stephens,Toronto East,bibleClass+memorial+newsletter
+wash.steph@gmail.com,Stephanie Washington,Toronto East,bibleClass+memorial+newsletter
+steve@wideport.com,Steve Curry,Toronto East,bibleClass+memorial+newsletter
+stevehiggs@live.ca,Steve Higgs,Toronto East,bibleClass+memorial+newsletter
+steve_keating@hotmail.com,Steve Keating,Toronto East,bibleClass+memorial+newsletter
+sylvia.leane@gmail.com,Sylvia Leane,Toronto East,bibleClass+memorial+newsletter
+timnarjes@hotmail.com,Timothy Narjes,Toronto East,bibleClass+memorial+newsletter
+zaideneasson9779@gmail.com,Zaiden Easson,Toronto East,bibleClass+memorial+newsletter
+teerecbro@gmail.com,,Toronto East Ecclesia,interEcclesia
+aghent@mac.com,Allan Ghent,Toronto North Ecclesia,interEcclesia
+condodweller@hotmail.ca,Barb Davies,Toronto North Ecclesia,newsletter
+ecclesia39@ashlar-stone.com,Stuart Moore,Toronto North Ecclesia,newsletter
+24langside@gmail.com,,Toronto West Ecclesia,interEcclesia
+devram@rogers.com,,Toronto West Ecclesia,interEcclesia
+spetrou_2000@yahoo.com,Steve Petrou,Toronto West Ecclesia,newsletter
+philwalker12@hotmail.com,,Woodstock Ecclesia,interEcclesia

--- a/apps/next/data/toronto-east-subscribers-2026-07-04.csv
+++ b/apps/next/data/toronto-east-subscribers-2026-07-04.csv
@@ -128,3 +128,32 @@ ecclesia39@ashlar-stone.com,Stuart Moore,Toronto North Ecclesia,newsletter
 devram@rogers.com,,Toronto West Ecclesia,interEcclesia
 spetrou_2000@yahoo.com,Steve Petrou,Toronto West Ecclesia,newsletter
 philwalker12@hotmail.com,,Woodstock Ecclesia,interEcclesia
+brentonandjudy@bigpond.com,,,newsletter
+carose@rogers.com,,,newsletter
+danieldarchibald@gmail.com,,,newsletter
+dawnesemple@gmail.com,,,newsletter
+ema.nymton.3102@gmail.com,,,newsletter
+jabrowning@rogers.com,,,newsletter
+jennarjes@hotmail.com,,,newsletter
+jeremiah1105@gmail.com,,,newsletter
+justanotherguy80@hotmail.com,,,newsletter
+karancmc@yahoo.com,,,newsletter
+ledukes@golden.net,,,newsletter
+madison.narjes@gmail.com,,,newsletter
+marshahuff@ymail.com,,,newsletter
+marymansoori3@gmail.com,,,newsletter
+mcanuffc@gmail.com,,,newsletter
+mduke@gto.net,,,newsletter
+mtbkingdom@gmail.com,,,newsletter
+ppratt2@hotmail.com,,,newsletter
+rga49hill@icloud.com,,,newsletter
+sanjaymondol80@gmail.com,,,newsletter
+sherylthegospelmessage@gmail.com,,,newsletter
+susieqdarley@gmail.com,,,newsletter
+teeannounce@gmail.com,,,newsletter
+tessy_123@hotmail.com,,,newsletter
+thestephens@rogers.com,,,newsletter
+timothy.narjes@opg.com,,,newsletter
+wkandrews@cogeco.ca,,,newsletter
+davemarlene@rogers.com,,,newsletter
+juneneblett@outlook.com,,,newsletter


### PR DESCRIPTION
The directory-derived, owner-reviewed Toronto East mailing list, rebuilt after the SES `TopicPreferences` wipe (topic-list edit cleared per-contact subscriptions). Replaces the stale **2024** `contact-subscribers*.json` snapshots as the reference for who's subscribed to which topic.

`apps/next/data/toronto-east-subscribers-2026-07-04.csv` — columns `email,name,ecclesia,topics`.

Live SES opt-in counts after restore: **newsletter 94, memorial 82, bibleClass 82, interEcclesia 37** (0 write errors).

Note: contains member email addresses (consistent with the existing `contact-subscribers*.json` files). Fold into the directory-as-source-of-truth sync when that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)