### PR TITLE
feat(auth): assurance levels — recognized vs authenticated (#80 A1+A2)

### DIFF
--- a/apps/next/app/(public)/ecclesia-contact/page.tsx
+++ b/apps/next/app/(public)/ecclesia-contact/page.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
-import { signIn, useSession } from 'next-auth/react'
 import { useHydrated } from '@my/app/hooks/use-hydrated'
 import { Loading } from '@my/app/provider/loading'
 import { YStack, XStack, Text, Button, Input, Card, H2, H3, Paragraph, Checkbox, Separator, View } from 'tamagui'
@@ -28,7 +27,6 @@ interface ContactInfo {
 export default function EcclesiaContactPage() {
   const isHydrated = useHydrated()
   const searchParams = useSearchParams()
-  const { data: session, status: sessionStatus } = useSession()
   const token = searchParams?.get('token') ?? null
 
   const [loading, setLoading] = useState(true)
@@ -36,8 +34,6 @@ export default function EcclesiaContactPage() {
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
   const [contactInfo, setContactInfo] = useState<ContactInfo | null>(null)
-  const [signingIn, setSigningIn] = useState(false)
-  const signInAttempted = useRef(false)
 
   // Form state
   const [firstName, setFirstName] = useState('')
@@ -52,46 +48,12 @@ export default function EcclesiaContactPage() {
   const [newMemberIsRecordingBrother, setNewMemberIsRecordingBrother] = useState(false)
   const [addingMember, setAddingMember] = useState(false)
 
-  // Auto-sign-in: When token is present and user has no session, create a session
-  useEffect(() => {
-    if (!isHydrated || !token || sessionStatus === 'loading' || signInAttempted.current) return
-
-    // Only attempt sign-in if no active session
-    if (sessionStatus === 'unauthenticated') {
-      signInAttempted.current = true
-      setSigningIn(true)
-
-      // First fetch contact info to get the email, then sign in
-      const autoSignIn = async () => {
-        try {
-          const res = await fetch(`/api/ecclesia-contact?token=${encodeURIComponent(token)}`)
-          const data = await res.json()
-
-          if (data.error || !data.email) {
-            setSigningIn(false)
-            return
-          }
-
-          // Sign in via OTP provider with ecclesia token
-          const result = await signIn('otp', {
-            email: data.email,
-            ecclesiaToken: token,
-            redirect: false,
-          })
-
-          if (result?.error) {
-            console.error('Ecclesia auto-sign-in failed:', result.error)
-          }
-        } catch (err) {
-          console.error('Ecclesia auto-sign-in error:', err)
-        } finally {
-          setSigningIn(false)
-        }
-      }
-
-      autoSignIn()
-    }
-  }, [isHydrated, token, sessionStatus])
+  // NOTE (#80): This page deliberately does NOT sign the visitor in. The
+  // `?token=` is a forwardable bearer credential embedded in bulk email —
+  // possession proves *recognition*, not *authority*. It authorizes only the
+  // token-scoped contact edits below; it must never mint an app session. To
+  // actually sign in, the visitor uses the OTP flow (link sent to the on-file
+  // address, which a forward recipient cannot receive).
 
   const fetchContactInfo = async () => {
     if (!token) {
@@ -207,15 +169,6 @@ export default function EcclesiaContactPage() {
 
   if (!isHydrated) {
     return <Loading />
-  }
-
-  if (signingIn) {
-    return (
-      <YStack flex={1} justifyContent="center" alignItems="center" padding="$4">
-        <Loading />
-        <Text marginTop="$4">Setting up your session...</Text>
-      </YStack>
-    )
   }
 
   if (loading) {

--- a/apps/next/types/next-auth.d.ts
+++ b/apps/next/types/next-auth.d.ts
@@ -10,6 +10,10 @@ declare module 'next-auth' {
       /** The user's postal address. */
       role?: string
       ecclesia?: string
+      /** Assurance tier (#80): a forwardable token confers only 'recognized'. */
+      assuranceLevel?: 'recognized' | 'authenticated'
+      /** Epoch ms of the last fresh authentication (for step-up freshness checks). */
+      authTime?: number
     } & DefaultSession['user']
   }
 

--- a/apps/next/utils/auth-trust.ts
+++ b/apps/next/utils/auth-trust.ts
@@ -47,11 +47,11 @@ export function meetsAssurance(trust: Trust, min: Trust): boolean {
 export async function getTrust(opts?: { ecclesiaToken?: string | null }): Promise<TrustContext> {
   const session = await auth()
   if (session?.user?.email) {
-    const level = ((session.user as any).assuranceLevel as Trust) || 'authenticated'
+    const level: Trust = session.user.assuranceLevel ?? 'authenticated'
     return {
       trust: level === 'recognized' ? 'recognized' : 'authenticated',
       email: session.user.email.toLowerCase(),
-      authTime: ((session.user as any).authTime as number) ?? null,
+      authTime: session.user.authTime ?? null,
       session,
     }
   }

--- a/apps/next/utils/auth-trust.ts
+++ b/apps/next/utils/auth-trust.ts
@@ -1,0 +1,123 @@
+import { NextResponse } from 'next/server'
+import { auth } from './auth'
+import { verifyEcclesiaToken } from './email/ecclesia-token'
+
+/**
+ * Authentication assurance levels (Epic #80).
+ *
+ *  - `anonymous`     — no session, no valid token.
+ *  - `recognized`    — identity asserted by a long-lived, forwardable bearer
+ *                      credential (the ecclesia-token embedded in bulk email).
+ *                      Proves *recognition*, never *authority*: the holder may
+ *                      be a forward recipient, not the addressee. Read-only /
+ *                      low-sensitivity (e.g. view own opt-ins, one-click
+ *                      unsubscribe) — never a mutation that matters.
+ *  - `authenticated` — a freshly-proven, cookie-bound credential (password,
+ *                      Google OAuth, or a just-completed single-use OTP). Can
+ *                      act, subject to role.
+ *
+ * Rule: a bearer token can raise you to `recognized` but never to
+ * `authenticated`. Stepping up requires an OTP sent to the on-file address —
+ * which a forwarder cannot receive.
+ */
+export type Trust = 'anonymous' | 'recognized' | 'authenticated'
+
+const RANK: Record<Trust, number> = { anonymous: 0, recognized: 1, authenticated: 2 }
+
+export interface TrustContext {
+  trust: Trust
+  email: string | null
+  authTime: number | null
+  session: Awaited<ReturnType<typeof auth>>
+}
+
+/** True when `trust` is at least as strong as `min`. */
+export function meetsAssurance(trust: Trust, min: Trust): boolean {
+  return RANK[trust] >= RANK[min]
+}
+
+/**
+ * Resolve the caller's trust tier. A live session wins; otherwise a valid
+ * ecclesia-token (passed explicitly by the route) confers `recognized` only.
+ *
+ * Sessions minted before #80 carry no `assuranceLevel` — they're treated as
+ * `authenticated` (grandfathered), consistent with the JWT callback, since the
+ * only path that now mints `recognized` is the ecclesia-token exchange.
+ */
+export async function getTrust(opts?: { ecclesiaToken?: string | null }): Promise<TrustContext> {
+  const session = await auth()
+  if (session?.user?.email) {
+    const level = ((session.user as any).assuranceLevel as Trust) || 'authenticated'
+    return {
+      trust: level === 'recognized' ? 'recognized' : 'authenticated',
+      email: session.user.email.toLowerCase(),
+      authTime: ((session.user as any).authTime as number) ?? null,
+      session,
+    }
+  }
+
+  const token = opts?.ecclesiaToken
+  if (token) {
+    const res = await verifyEcclesiaToken(token)
+    if (res.valid && res.email) {
+      return { trust: 'recognized', email: res.email.toLowerCase(), authTime: null, session: null }
+    }
+  }
+
+  return { trust: 'anonymous', email: null, authTime: null, session: null }
+}
+
+export type AssuranceGuard =
+  | { ok: true; ctx: TrustContext }
+  | { ok: false; response: NextResponse }
+
+/**
+ * Route guard. Returns the trust context when the caller meets `min`, or a
+ * ready-to-return NextResponse otherwise:
+ *   - `anonymous`  → 401 (must sign in / present a token)
+ *   - below `min`  → 403 with `stepUpRequired: true` (recognized but needs auth)
+ *
+ * Usage:
+ *   const gate = await requireAssurance('authenticated', { ecclesiaToken })
+ *   if (!gate.ok) return gate.response
+ *   // gate.ctx.email is safe to act as
+ */
+export async function requireAssurance(
+  min: Trust,
+  opts?: { ecclesiaToken?: string | null }
+): Promise<AssuranceGuard> {
+  const ctx = await getTrust(opts)
+  if (meetsAssurance(ctx.trust, min)) return { ok: true, ctx }
+
+  if (ctx.trust === 'anonymous') {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Authentication required', trust: ctx.trust, required: min },
+        { status: 401 }
+      ),
+    }
+  }
+
+  return {
+    ok: false,
+    response: NextResponse.json(
+      {
+        error: "Please confirm it's you to continue.",
+        trust: ctx.trust,
+        required: min,
+        stepUpRequired: true,
+      },
+      { status: 403 }
+    ),
+  }
+}
+
+/**
+ * Recency gate for the highest-risk operations (role changes, sending, editing
+ * others). Requires `authenticated` AND a login no older than `maxAgeMs`.
+ * Callers that fail this should trigger a step-up re-challenge (A5).
+ */
+export function isRecentlyAuthenticated(ctx: TrustContext, maxAgeMs: number): boolean {
+  return ctx.trust === 'authenticated' && ctx.authTime != null && Date.now() - ctx.authTime <= maxAgeMs
+}

--- a/apps/next/utils/auth.ts
+++ b/apps/next/utils/auth.ts
@@ -78,6 +78,8 @@ export const authOptions: NextAuthConfig = {
             name: user.name,
             role: user.role,
             provider: 'credentials',
+            // Password is a freshly-proven credential → full authority.
+            assurance: 'authenticated',
           }
         }
 
@@ -141,6 +143,10 @@ export const authOptions: NextAuthConfig = {
             name: person.displayName || person.primaryEmail,
             role,
             provider: 'otp',
+            // Ecclesia token is a long-lived, forwardable bearer credential
+            // embedded in bulk email. It proves recognition, NOT authority —
+            // the holder may be a forward recipient, not the addressee. See #80.
+            assurance: 'recognized',
           }
         }
 
@@ -163,6 +169,9 @@ export const authOptions: NextAuthConfig = {
             name: person.displayName || person.primaryEmail,
             role,
             provider: 'otp',
+            // A completed OTP (single-use, 10-min, sent to the on-file address)
+            // is a fresh proof of inbox control → full authority.
+            assurance: 'authenticated',
           }
         }
 
@@ -183,6 +192,21 @@ export const authOptions: NextAuthConfig = {
         if (userRole) {
           token.role = userRole
         }
+
+        // Assurance level (#80). Fresh sign-in stamps the trust tier + auth time.
+        // Credentials/OTP/ecclesia paths set `assurance` explicitly; Google (no
+        // authorize step) and any credential that omits it default to
+        // 'authenticated' — only the forwardable ecclesia-token path is
+        // downgraded to 'recognized'.
+        const userAssurance = (user as User & { assurance?: string }).assurance
+        ;(token as JWT & { assuranceLevel?: string }).assuranceLevel =
+          userAssurance === 'recognized' ? 'recognized' : 'authenticated'
+        ;(token as JWT & { authTime?: number }).authTime = Date.now()
+      } else if (!(token as JWT & { assuranceLevel?: string }).assuranceLevel) {
+        // Grandfather sessions minted before #80: treat as authenticated so we
+        // don't lock out anyone currently signed in. Going forward, only the
+        // ecclesia-token path mints 'recognized', so this default is safe.
+        ;(token as JWT & { assuranceLevel?: string }).assuranceLevel = 'authenticated'
       }
 
       // Always refresh name, role, and RB designation from PersonRecord.
@@ -430,7 +454,7 @@ export const authOptions: NextAuthConfig = {
       // Safely add role and RB designation to the Session.User
       try {
         const userWithRole = user as (User & { role?: string }) | undefined
-        const tokenWithRole = token as (JWT & { role?: string; isRecordingBrother?: boolean; ecclesia?: string }) | undefined
+        const tokenWithRole = token as (JWT & { role?: string; isRecordingBrother?: boolean; ecclesia?: string; assuranceLevel?: string; authTime?: number }) | undefined
         const finalRole = userWithRole?.role || tokenWithRole?.role || ROLES.GUEST
         console.log('📋 Session callback - Final role:', finalRole, 'for user:', session.user?.email)
         ;(session.user as User & { role: string }).role = finalRole
@@ -438,6 +462,10 @@ export const authOptions: NextAuthConfig = {
         ;(session.user as any).isRecordingBrother = tokenWithRole?.isRecordingBrother || false
         // Home ecclesia: sourced from JWT (set during jwt callback from PersonRecord)
         ;(session.user as any).ecclesia = tokenWithRole?.ecclesia || null
+        // Assurance level + auth time (#80). 'recognized' = forwardable bearer
+        // token; 'authenticated' = a freshly-proven credential.
+        ;(session.user as any).assuranceLevel = tokenWithRole?.assuranceLevel || 'authenticated'
+        ;(session.user as any).authTime = tokenWithRole?.authTime ?? null
         return session
       } catch (error) {
         const msg = error instanceof Error ? error.message : error


### PR DESCRIPTION
First slices of the assurance-level epic (#80). Establishes the trust-tier primitive and closes the concrete "forwarded email link logs you in" hole.

## Why
The `?token=` in our bulk emails is a **30-day, multi-use, forwardable bearer credential**. Possession proves *"someone who can read an email we sent to X"* — not *"is X"*. Today `ecclesia-contact/page.tsx` auto-calls `signIn('otp', { ecclesiaToken })`, so a forwarded link **mints a full authenticated session** as the addressee. We also stored **no assurance level and no `authTime`**, so no route could tell a bearer identity from a real login.

## A1 — Foundation (additive, no route behavior change)
- `assuranceLevel` + `authTime` stamped on the JWT (`jwt` callback) and surfaced on the session (`session` callback).
- Provider mapping: **password / Google / completed-OTP → `authenticated`**; **ecclesia-token → `recognized`**.
- Existing sessions (no level) are **grandfathered as `authenticated`** — nobody is logged out.
- `apps/next/utils/auth-trust.ts`: `getTrust()`, `requireAssurance(min)`, `meetsAssurance()`, `isRecentlyAuthenticated()`. Nothing calls these yet — they're the primitive A3 will adopt.

## A2 — Close the practical hole
- `ecclesia-contact/page.tsx` **no longer auto-signs-in** from the token. The token still authorizes its own scoped contact edits (unchanged); it just never mints a session. Real sign-in = OTP link to the **on-file address**, which a forward recipient can't receive.

## Deferred (tracked in #80)
- **A3** assert `requireAssurance('authenticated')` on sensitive routes (set-role, content write/delete, sends).
- **A4** shared "recognized → read-only + Confirm-it's-you step-up" UI; apply to subscribe (opt-out stays token-only; opt-in steps up) + profile.
- **A5** recency gate + `POST /api/auth/step-up`.

## Test
- [ ] Sign in with password/Google → `session.user.assuranceLevel === 'authenticated'`, `authTime` set.
- [ ] Open an `ecclesia-contact?token=…` link while signed out → you are **not** signed in afterward; contact edits still save via the token.
- [ ] Existing logged-in session keeps working (grandfathered).

Part of #80. Relates to #63, #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)