### PR TITLE
fix(auth): tokenized email links are recognized, not anonymous

### DIFF
--- a/apps/next/middleware.ts
+++ b/apps/next/middleware.ts
@@ -19,13 +19,27 @@ export default auth((req: NextAuthRequest) => {
   }
   const passthrough = () => NextResponse.next({ request: { headers: forwardedHeaders } })
 
-  // Hub sign-in gate: echadhub.org has no public face yet, so require sign-in
-  // for all content pages (Facebook-style). Auth flows (/auth/*) and API routes
-  // (incl. NextAuth /api/auth) stay open; static assets are excluded by the
-  // matcher. Tenant domains with a public face (tee-admin.com) are unaffected.
+  // Assurance model (#80): a session is `authenticated`; a tokenized email link
+  // (?token=) makes the visitor `recognized` — partially verified, allowed to
+  // VIEW anything an email points them at (their preferences, "more details",
+  // etc.). Only mutations / sensitive pages step up to `authenticated` (the
+  // Verify flow), enforced at the route/data layer via getTrust().
+  //
+  // The edge can't reach DynamoDB to cryptographically verify the token, so this
+  // treats *presence* as recognized for the VIEW gate only — the page/API
+  // re-validates it before exposing any real data, so a bogus token gets past
+  // this gate but sees nothing. The middleware is a UX gate, not the auth
+  // boundary; getTrust() remains authoritative.
+  const recognized = !!req.auth || !!req.nextUrl.searchParams.get('token')
+
+  // Hub sign-in gate: echadhub.org has no public face yet, so require at least a
+  // recognized visitor for content pages (Facebook-style). Auth flows (/auth/*)
+  // and API routes (incl. NextAuth /api/auth) stay open; static assets are
+  // excluded by the matcher. Tenant domains with a public face (tee-admin.com)
+  // are unaffected.
   if (
     tenant?.id === 'echadhub' &&
-    !req.auth &&
+    !recognized &&
     !pathname.startsWith('/auth') &&
     !pathname.startsWith('/api')
   ) {


### PR DESCRIPTION
## Problem
The hub sign-in gate in `middleware.ts` does a binary `!req.auth` check, so a visitor arriving via a **tokenized email link** (`?token=`) is treated as anonymous and redirected to `/auth/signin`. This dead-ends every email link on echadhub — including the new `/email-preferences` footer link (verified: `echadhub.org/email-preferences` → `/auth/signin`).

## Fix — apply the assurance model (#80) in middleware
- **`recognized`** = session **OR** `?token=` present → may **view** anything an email links to.
- **`authenticated`** (session) still required for mutations / sensitive pages (`/profile`, admin, saves) — the Verify/step-up flow, enforced at the route/data layer via `getTrust()` (unchanged).

## Security boundary (deliberate)
Edge middleware can't reach DynamoDB, so it **cannot cryptographically verify** the token — only detect presence. This treats presence as `recognized` for the **view gate only**. Pages/APIs re-validate via `verifyEcclesiaToken`/`getTrust` before exposing any real data or allowing a mutation, so a bogus `?token=x` passes the view gate but sees nothing. **The middleware is a UX gate; `getTrust()` stays the authoritative auth boundary.**

- `/profile` and sensitive routes still require a real session (token is not sufficient).
- tee-admin (public face) is unaffected — it has no hub gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)