### PR TITLE
feat(pii): server-side viewer + name redaction primitive (#87)

### DIFF
--- a/apps/next/tests/viewer-pii.test.ts
+++ b/apps/next/tests/viewer-pii.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import {
+  effectiveRole,
+  canRevealFullName,
+  renderName,
+  shapePersonName,
+  roleAtLeast,
+  ANONYMOUS_VIEWER,
+  type Assurance,
+  type Role,
+  type Viewer,
+} from '@my/app/utils/viewer-pii'
+
+const peter = { firstName: 'Peter', lastName: 'Skariah', ecclesia: 'Toronto East' }
+const viewer = (assurance: Assurance, role: Role, tenant: string | null = 'Toronto East'): Viewer => ({
+  assurance,
+  role,
+  tenant,
+  email: 'x@y.z',
+})
+
+describe('effectiveRole — a token/recognized viewer is capped at member', () => {
+  it('caps above-member roles to member when not authenticated', () => {
+    expect(effectiveRole('owner', 'recognized')).toBe('member')
+    expect(effectiveRole('admin', 'recognized')).toBe('member')
+    expect(effectiveRole('rep', 'recognized')).toBe('member')
+    expect(effectiveRole('recorder', 'recognized')).toBe('member')
+    expect(effectiveRole('member', 'recognized')).toBe('member')
+  })
+  it('leaves below-member roles unchanged', () => {
+    expect(effectiveRole('guest', 'recognized')).toBe('guest')
+    expect(effectiveRole(undefined, 'recognized')).toBe('guest')
+  })
+  it('keeps the real role once authenticated', () => {
+    expect(effectiveRole('owner', 'authenticated')).toBe('owner')
+    expect(effectiveRole('admin', 'authenticated')).toBe('admin')
+    expect(effectiveRole('rep', 'authenticated')).toBe('rep')
+  })
+  it('anonymous also caps (defensive)', () => {
+    expect(effectiveRole('admin', 'anonymous')).toBe('member')
+  })
+})
+
+describe('roleAtLeast', () => {
+  it('member-or-greater', () => {
+    expect(roleAtLeast('member', 'member')).toBe(true)
+    expect(roleAtLeast('admin', 'member')).toBe(true)
+    expect(roleAtLeast('guest', 'member')).toBe(false)
+    expect(roleAtLeast(undefined, 'member')).toBe(false)
+  })
+})
+
+describe('canRevealFullName — verified member-or-greater only', () => {
+  it('hides for anonymous', () => {
+    expect(canRevealFullName(ANONYMOUS_VIEWER)).toBe(false)
+  })
+  it('hides for a recognized (unverified) member — forward-safety', () => {
+    expect(canRevealFullName(viewer('recognized', 'member'))).toBe(false)
+  })
+  it('hides for an authenticated guest (signed in, not a member)', () => {
+    expect(canRevealFullName(viewer('authenticated', 'guest'))).toBe(false)
+  })
+  it('reveals for an authenticated member', () => {
+    expect(canRevealFullName(viewer('authenticated', 'member'))).toBe(true)
+  })
+  it('reveals for an authenticated admin/owner', () => {
+    expect(canRevealFullName(viewer('authenticated', 'admin'))).toBe(true)
+    expect(canRevealFullName(viewer('authenticated', 'owner'))).toBe(true)
+  })
+})
+
+describe('renderName / shapePersonName — server-side redaction', () => {
+  it('first name only for anonymous', () => {
+    expect(renderName(peter, ANONYMOUS_VIEWER)).toBe('Peter')
+    expect(shapePersonName(peter, ANONYMOUS_VIEWER)).toEqual({ firstName: 'Peter' })
+  })
+  it('first name only for a recognized member', () => {
+    const v = viewer('recognized', 'member')
+    expect(renderName(peter, v)).toBe('Peter')
+    expect(shapePersonName(peter, v)).toEqual({ firstName: 'Peter' })
+  })
+  it('NEVER carries lastName in a redacted shape (no ship-then-hide)', () => {
+    expect(shapePersonName(peter, viewer('recognized', 'member'))).not.toHaveProperty('lastName')
+    expect(shapePersonName(peter, ANONYMOUS_VIEWER)).not.toHaveProperty('lastName')
+  })
+  it('full name for an authenticated member', () => {
+    const v = viewer('authenticated', 'member')
+    expect(renderName(peter, v)).toBe('Peter Skariah')
+    expect(shapePersonName(peter, v)).toEqual({ firstName: 'Peter', lastName: 'Skariah' })
+  })
+  it('two Peters stay indistinguishable in the public view (no initial)', () => {
+    const peter2 = { firstName: 'Peter', lastName: 'Thomas' }
+    expect(renderName(peter, ANONYMOUS_VIEWER)).toBe(renderName(peter2, ANONYMOUS_VIEWER))
+  })
+})

--- a/apps/next/utils/resolve-viewer.ts
+++ b/apps/next/utils/resolve-viewer.ts
@@ -1,0 +1,42 @@
+import { getTrust } from './auth-trust'
+import { personRepository } from '@my/app/provider/dynamodb/repositories/person-repository'
+import {
+  effectiveRole,
+  ANONYMOUS_VIEWER,
+  type Role,
+  type Viewer,
+} from '@my/app/utils/viewer-pii'
+
+/**
+ * Resolve the request's {@link Viewer} — assurance + identity in one place.
+ *
+ *  - assurance comes from getTrust(): a session → `authenticated`; a valid
+ *    ecclesia token (passed by the route) → `recognized`; neither → `anonymous`.
+ *  - identity (role + tenant) is resolved from the PersonRecord the credential
+ *    maps to, for BOTH the session and the token paths — so a `recognized`
+ *    (email-link) viewer still has a role and a tenant, which is what makes
+ *    multi-tenant routing work.
+ *  - the role is CAPPED for recognized viewers via effectiveRole(): a token can
+ *    never confer authority above `member`.
+ *
+ * I/O-bound (auth + one PersonRecord lookup), so it lives here rather than in the
+ * pure primitive (packages/app/utils/viewer-pii.ts).
+ */
+export async function resolveViewer(opts?: {
+  ecclesiaToken?: string | null
+}): Promise<Viewer> {
+  const trust = await getTrust({ ecclesiaToken: opts?.ecclesiaToken ?? null })
+  if (trust.trust === 'anonymous' || !trust.email) {
+    return ANONYMOUS_VIEWER
+  }
+
+  const person = await personRepository.getByEmailForAuth(trust.email).catch(() => null)
+  const actualRole = person?.role as Role | undefined
+
+  return {
+    assurance: trust.trust, // 'recognized' | 'authenticated'
+    role: effectiveRole(actualRole, trust.trust), // capped for recognized
+    tenant: person?.ecclesia ?? null,
+    email: trust.email,
+  }
+}

--- a/packages/app/utils/viewer-pii.ts
+++ b/packages/app/utils/viewer-pii.ts
@@ -1,0 +1,122 @@
+/**
+ * Server-side viewer authority + PII redaction primitive (Epic #84, slice D).
+ *
+ * Two axes, deliberately separate:
+ *  - identity  (WHO):     role + tenant, resolvable from an email token OR a session.
+ *  - assurance (HOW SURE): anonymous < recognized < authenticated.
+ *
+ * Confirmed rules:
+ *  - A recognized/unverified viewer is CAPPED at `member` — a token can never
+ *    exercise authority above member. Anything above member requires stepping up
+ *    to `authenticated` (so every above-member surface/action implicitly needs
+ *    Verify). Clicking a Rep/Admin's forwarded link makes you an *unverified
+ *    member* of their ecclesia, never a Rep/Admin.
+ *  - A full name is revealed ONLY to a *verified* member-or-greater
+ *    (authenticated + role >= member). Recognized viewers — even of a member —
+ *    see the first name only, so a forwarded email link never leaks full names.
+ *
+ * Pure + I/O-free so it unit-tests cleanly and runs in any context (API routes,
+ * react-email render). Resolving a Viewer from a request lives in
+ * apps/next/utils/resolve-viewer.ts.
+ */
+
+export type Role =
+  | 'owner'
+  | 'admin'
+  | 'recorder'
+  | 'rep'
+  | 'member'
+  | 'guest'
+  | 'deceased'
+  | 'suspicious'
+
+export type Assurance = 'anonymous' | 'recognized' | 'authenticated'
+
+// Higher = more authority. `recorder` is a deprecated rep-level role.
+const ROLE_RANK: Record<Role, number> = {
+  owner: 5,
+  admin: 4,
+  recorder: 3,
+  rep: 3,
+  member: 2,
+  guest: 1,
+  deceased: 0,
+  suspicious: 0,
+}
+const MEMBER_RANK = ROLE_RANK.member
+
+/** True when `role` is at least `min` in the authority hierarchy. */
+export function roleAtLeast(role: Role | undefined, min: Role): boolean {
+  return ROLE_RANK[role ?? 'guest'] >= ROLE_RANK[min]
+}
+
+/**
+ * The EFFECTIVE role for a given assurance. A recognized/anonymous viewer is
+ * never above `member`; authenticated viewers keep their real role. Below-member
+ * roles (guest/deceased/suspicious) are unchanged. This is THE cap — apply it
+ * once, when the Viewer is built.
+ */
+export function effectiveRole(actual: Role | undefined, assurance: Assurance): Role {
+  const r = actual ?? 'guest'
+  if (assurance === 'authenticated') return r
+  return ROLE_RANK[r] > MEMBER_RANK ? 'member' : r
+}
+
+export interface Viewer {
+  assurance: Assurance
+  /** Effective role — already capped for recognized/anonymous. */
+  role: Role
+  /** Ecclesia/organization the viewer belongs to (from membership). */
+  tenant: string | null
+  email: string | null
+}
+
+/** Anonymous viewer — no token, no session. */
+export const ANONYMOUS_VIEWER: Viewer = {
+  assurance: 'anonymous',
+  role: 'guest',
+  tenant: null,
+  email: null,
+}
+
+export interface NamedPerson {
+  firstName: string
+  lastName?: string
+  ecclesia?: string
+}
+
+/**
+ * A full name is revealed only to a *verified* member-or-greater. `target` is
+ * accepted for a future tenant-relative refinement (e.g. same-ecclesia only) but
+ * the baseline gate is assurance + effective role.
+ */
+export function canRevealFullName(viewer: Viewer, _target?: NamedPerson): boolean {
+  return viewer.assurance === 'authenticated' && roleAtLeast(viewer.role, 'member')
+}
+
+/**
+ * Display string: full name when allowed, else FIRST NAME ONLY — never a
+ * disambiguating initial. Two "Peter"s must stay indistinguishable in the
+ * public view; that ambiguity is the privacy feature, not a bug.
+ */
+export function renderName(target: NamedPerson, viewer: Viewer): string {
+  if (canRevealFullName(viewer, target)) {
+    return [target.firstName, target.lastName].filter(Boolean).join(' ')
+  }
+  return target.firstName
+}
+
+/**
+ * Server-side response shape for a person's name. NEVER includes `lastName`
+ * unless the full name is allowed — sanitation happens HERE, before
+ * serialization, so a redacted response literally cannot carry the surname
+ * (no ship-then-hide View-Source leak).
+ */
+export function shapePersonName<T extends NamedPerson>(
+  target: T,
+  viewer: Viewer
+): { firstName: string; lastName?: string } {
+  return canRevealFullName(viewer, target)
+    ? { firstName: target.firstName, lastName: target.lastName }
+    : { firstName: target.firstName }
+}


### PR DESCRIPTION
Slice D of #84. Pure, tested primitive encoding the confirmed assurance model — no call sites changed yet (that's slice E #88).

**The rules, in code:**
- `effectiveRole()` — recognized/unverified is **capped at member**; a token never confers authority above member (so above-member ⇒ Verify falls out for free).
- `canRevealFullName()` — full name only for **authenticated + member+**; recognized viewers see first-name-only → forwarded links never leak full names.
- `shapePersonName()` — **never** includes `lastName` in a redacted response (sanitation before serialization; no ship-then-hide leak). Non-distinguishable by design.
- `resolveViewer()` — resolves assurance (getTrust) + role/tenant (PersonRecord) for **both** session and token paths, applying the cap. Identity known at `recognized`; reveal gated on `authenticated`.

15 vitest cases pass (cap, reveal gate, redacted shape, 'two Peters' indistinguishability).

Closes #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)