### PR TITLE
feat(auth): reusable Verify step-up + requireVerified guard (#85)

### DIFF
--- a/apps/next/components/verify/verify.tsx
+++ b/apps/next/components/verify/verify.tsx
@@ -1,0 +1,381 @@
+'use client'
+
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { signIn, useSession } from 'next-auth/react'
+import { YStack, XStack, Text, Heading, Button, Paragraph, Input } from '@my/ui'
+
+/**
+ * <Verify> — the reusable step-up challenge (Epic #84, slice B).
+ *
+ * Elevates a `recognized` (or stale `authenticated`) viewer to a freshly-proven
+ * `authenticated` session at the moment a sensitive action or page demands it.
+ * Offers, in order of convenience:
+ *   1. Google re-auth   — one tap if they're a Google account (redirects out and
+ *      back; the return re-stamps `authTime`).
+ *   2. Password         — re-enter the on-file password (no redirect).
+ *   3. OTP              — a 6-digit code to the ON-FILE address only. This is the
+ *      forward-safety anchor: a forwarder holding the email link can VIEW, but
+ *      only the true addressee receives the code, so only they can ACT.
+ *
+ * On success the caller's `onVerified` fires — the caller then retries whatever
+ * triggered the challenge. The server is the real boundary (`requireVerified`);
+ * this component only drives the re-auth. Mount it in response to a
+ * `403 { stepUpRequired: true }`.
+ */
+export interface VerifyProps {
+  /**
+   * The on-file address the OTP is sent to. Defaults to the current session's
+   * email (the recognized identity). Pass explicitly when challenging for a
+   * specific address (e.g. from a token flow).
+   */
+  email?: string
+  /** Short reason shown under the heading — e.g. "to change your role". */
+  reason?: string
+  /** Fired once the session has been raised to a fresh `authenticated`. */
+  onVerified: () => void
+  /** Optional cancel affordance (e.g. close the modal). */
+  onCancel?: () => void
+  /** Restrict the offered methods. Default: all three, availability-aware. */
+  methods?: Array<'google' | 'password' | 'otp'>
+  /** Where Google re-auth returns to. Default: the current URL. */
+  returnTo?: string
+}
+
+type View = 'main' | 'otp'
+
+export function Verify({
+  email,
+  reason,
+  onVerified,
+  onCancel,
+  methods = ['google', 'password', 'otp'],
+  returnTo,
+}: VerifyProps) {
+  const { data: session } = useSession()
+  // The address we challenge: explicit prop → session email. Lower-cased so the
+  // OTP lookup matches how addresses are stored.
+  const targetEmail = (email ?? session?.user?.email ?? '').trim().toLowerCase()
+
+  const [view, setView] = useState<View>('main')
+  const [password, setPassword] = useState('')
+  const [otpDigits, setOtpDigits] = useState(['', '', '', '', '', ''])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [resendCooldown, setResendCooldown] = useState(0)
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([])
+
+  useEffect(() => {
+    if (resendCooldown <= 0) return
+    const t = setTimeout(() => setResendCooldown(resendCooldown - 1), 1000)
+    return () => clearTimeout(t)
+  }, [resendCooldown])
+
+  const clearError = () => {
+    if (error) setError('')
+  }
+
+  const showGoogle = methods.includes('google')
+  const showPassword = methods.includes('password')
+  const showOtp = methods.includes('otp')
+
+  // --- Google re-auth: redirects out; the return re-stamps authTime. ---
+  const handleGoogle = useCallback(() => {
+    const callbackUrl =
+      returnTo ?? (typeof window !== 'undefined' ? window.location.href : '/')
+    signIn('google', { callbackUrl })
+  }, [returnTo])
+
+  // --- Password re-entry: no redirect; onVerified on success. ---
+  const handlePassword = async () => {
+    if (!targetEmail) {
+      setError('We could not determine your account email.')
+      return
+    }
+    if (!password) {
+      setError('Please enter your password.')
+      return
+    }
+    setLoading(true)
+    setError('')
+    try {
+      const res = await signIn('credentials', {
+        email: targetEmail,
+        password,
+        redirect: false,
+      })
+      if (res?.error) {
+        setError(res.error === 'CredentialsSignin' ? 'Incorrect password.' : 'Verification failed.')
+        return
+      }
+      if (res?.ok) onVerified()
+    } catch {
+      setError('Something went wrong. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // --- OTP to the on-file address. ---
+  const sendOtp = async () => {
+    if (!targetEmail) {
+      setError('We could not determine your account email.')
+      return
+    }
+    setLoading(true)
+    setError('')
+    try {
+      // Anti-enumeration: the endpoint always 200s. We surface a generic success
+      // by advancing to the code view regardless.
+      await fetch('/api/auth/send-otp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: targetEmail }),
+      })
+      setView('otp')
+      setOtpDigits(['', '', '', '', '', ''])
+      setResendCooldown(60)
+    } catch {
+      setError('Could not send a code. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleOtpChange = useCallback(
+    (index: number, value: string) => {
+      if (value.length > 1) {
+        const digits = value.replace(/\D/g, '').slice(0, 6).split('')
+        const next = [...otpDigits]
+        digits.forEach((d, i) => {
+          if (index + i < 6) next[index + i] = d
+        })
+        setOtpDigits(next)
+        inputRefs.current[Math.min(index + digits.length, 5)]?.focus()
+        return
+      }
+      if (value && !/^\d$/.test(value)) return
+      const next = [...otpDigits]
+      next[index] = value
+      setOtpDigits(next)
+      if (value && index < 5) inputRefs.current[index + 1]?.focus()
+    },
+    [otpDigits]
+  )
+
+  const handleOtpKeyDown = useCallback(
+    (index: number, e: React.KeyboardEvent) => {
+      if (e.key === 'Backspace' && !otpDigits[index] && index > 0) {
+        inputRefs.current[index - 1]?.focus()
+      }
+    },
+    [otpDigits]
+  )
+
+  const verifyOtp = async () => {
+    const code = otpDigits.join('')
+    if (code.length !== 6) {
+      setError('Enter all 6 digits.')
+      return
+    }
+    setLoading(true)
+    setError('')
+    try {
+      const vr = await fetch('/api/auth/verify-otp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: targetEmail, code }),
+      })
+      if (!vr.ok) {
+        const j = await vr.json().catch(() => ({}))
+        setError(j.error || 'That code didn’t work — check it and try again.')
+        return
+      }
+      // Mint the fresh authenticated session (re-stamps authTime).
+      const res = await signIn('otp', { email: targetEmail, otpToken: code, redirect: false })
+      if (res?.error) {
+        setError('Verification failed. Please try again.')
+        return
+      }
+      onVerified()
+    } catch {
+      setError('Something went wrong. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const resend = async () => {
+    if (resendCooldown > 0) return
+    await sendOtp()
+  }
+
+  // ============ OTP VIEW ============
+  if (view === 'otp') {
+    return (
+      <YStack maxWidth={400} margin="auto" padding="$4" gap="$4">
+        <YStack gap="$2" alignItems="center">
+          <Heading size="$7">Enter your code</Heading>
+          <Paragraph color="$gray11" textAlign="center">
+            We sent a 6-digit code to <Text fontWeight="bold">{targetEmail}</Text>.
+          </Paragraph>
+        </YStack>
+
+        <YStack gap="$4">
+          <XStack justifyContent="center" gap="$2">
+            {otpDigits.map((digit, index) => (
+              <input
+                key={index}
+                ref={(el) => {
+                  inputRefs.current[index] = el
+                }}
+                type="text"
+                inputMode="numeric"
+                maxLength={index === 0 ? 6 : 1}
+                value={digit}
+                onChange={(e) => handleOtpChange(index, e.target.value)}
+                onKeyDown={(e) => handleOtpKeyDown(index, e)}
+                autoFocus={index === 0}
+                style={{
+                  width: '48px',
+                  height: '56px',
+                  textAlign: 'center',
+                  fontSize: '24px',
+                  fontFamily: 'monospace',
+                  fontWeight: 'bold',
+                  border: '2px solid #ccc',
+                  borderRadius: '8px',
+                  outline: 'none',
+                }}
+                onFocus={(e) => {
+                  e.target.style.borderColor = '#007bff'
+                }}
+                onBlur={(e) => {
+                  e.target.style.borderColor = '#ccc'
+                }}
+              />
+            ))}
+          </XStack>
+
+          {error ? (
+            <Paragraph color="$red10" textAlign="center">
+              {error}
+            </Paragraph>
+          ) : null}
+
+          <Button onPress={verifyOtp} size="$4" disabled={loading} theme="blue">
+            {loading ? 'Verifying…' : 'Verify'}
+          </Button>
+
+          <XStack justifyContent="center">
+            {resendCooldown > 0 ? (
+              <Text fontSize="$3" color="$gray11">
+                Resend code in {resendCooldown}s
+              </Text>
+            ) : (
+              <Text
+                fontSize="$3"
+                color="$blue10"
+                textDecorationLine="underline"
+                cursor="pointer"
+                onPress={resend}
+              >
+                Didn’t receive it? Resend
+              </Text>
+            )}
+          </XStack>
+
+          <XStack justifyContent="center">
+            <Text
+              fontSize="$3"
+              color="$gray11"
+              textDecorationLine="underline"
+              cursor="pointer"
+              onPress={() => {
+                setView('main')
+                setError('')
+                setOtpDigits(['', '', '', '', '', ''])
+              }}
+            >
+              Use another method
+            </Text>
+          </XStack>
+        </YStack>
+      </YStack>
+    )
+  }
+
+  // ============ MAIN VIEW ============
+  return (
+    <YStack maxWidth={400} margin="auto" padding="$4" gap="$4">
+      <YStack gap="$2" alignItems="center">
+        <Heading size="$7">Confirm it’s you</Heading>
+        <Paragraph color="$gray11" textAlign="center">
+          {reason ? reason : 'Please confirm your identity to continue.'}
+        </Paragraph>
+      </YStack>
+
+      <YStack gap="$4">
+        {showGoogle ? (
+          <Button onPress={handleGoogle} size="$4" variant="outlined">
+            Continue with Google
+          </Button>
+        ) : null}
+
+        {showPassword ? (
+          <YStack gap="$2">
+            <Text fontWeight="600">Password</Text>
+            <Input
+              value={password}
+              onChangeText={(val: string) => {
+                setPassword(val)
+                clearError()
+              }}
+              placeholder="Enter your password"
+              autoComplete="current-password"
+              secureTextEntry
+              size="$4"
+            />
+            <Button onPress={handlePassword} size="$4" disabled={loading} theme="blue">
+              {loading ? 'Confirming…' : 'Confirm with password'}
+            </Button>
+          </YStack>
+        ) : null}
+
+        {showOtp ? (
+          <>
+            {showGoogle || showPassword ? (
+              <XStack justifyContent="center" paddingVertical="$1">
+                <Text fontSize="$3" color="$gray11">
+                  --- OR ---
+                </Text>
+              </XStack>
+            ) : null}
+            <Button onPress={sendOtp} size="$4" disabled={loading} variant="outlined">
+              {loading ? 'Sending…' : 'Email me a 6-digit code'}
+            </Button>
+          </>
+        ) : null}
+
+        {error ? (
+          <Paragraph color="$red10" textAlign="center">
+            {error}
+          </Paragraph>
+        ) : null}
+
+        {onCancel ? (
+          <XStack justifyContent="center">
+            <Text
+              fontSize="$3"
+              color="$gray11"
+              textDecorationLine="underline"
+              cursor="pointer"
+              onPress={onCancel}
+            >
+              Cancel
+            </Text>
+          </XStack>
+        ) : null}
+      </YStack>
+    </YStack>
+  )
+}

--- a/apps/next/utils/auth-trust.ts
+++ b/apps/next/utils/auth-trust.ts
@@ -121,3 +121,44 @@ export async function requireAssurance(
 export function isRecentlyAuthenticated(ctx: TrustContext, maxAgeMs: number): boolean {
   return ctx.trust === 'authenticated' && ctx.authTime != null && Date.now() - ctx.authTime <= maxAgeMs
 }
+
+/**
+ * Verify guard (Epic #84, slice B). The one call a sensitive *action* makes:
+ * require `authenticated`, and — when `maxAgeMs` is given — require the login to
+ * be fresh. Any failure returns a ready-to-send response the client can detect:
+ *
+ *   - anonymous          → 401
+ *   - recognized         → 403 `{ stepUpRequired: true }`      (never verified)
+ *   - authenticated+stale→ 403 `{ stepUpRequired: true, stale: true }`
+ *
+ * The client mounts `<Verify>` on any `stepUpRequired` 403, then retries.
+ *
+ *   const gate = await requireVerified({ maxAgeMs: 15 * 60_000 })
+ *   if (!gate.ok) return gate.response
+ *   // gate.ctx.email is freshly proven — safe to mutate as
+ */
+export async function requireVerified(opts?: {
+  ecclesiaToken?: string | null
+  maxAgeMs?: number
+}): Promise<AssuranceGuard> {
+  const gate = await requireAssurance('authenticated', opts)
+  if (!gate.ok) return gate
+
+  if (opts?.maxAgeMs != null && !isRecentlyAuthenticated(gate.ctx, opts.maxAgeMs)) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        {
+          error: "Please confirm it's you to continue.",
+          trust: gate.ctx.trust,
+          required: 'authenticated',
+          stepUpRequired: true,
+          stale: true,
+        },
+        { status: 403 }
+      ),
+    }
+  }
+
+  return gate
+}


### PR DESCRIPTION
Slice B of the assurance/Verify epic (#84). Draft — this is the reusable primitive; **slice C (#86)** wires it to real sensitive pages/actions.

## What

Generalizes the inline OTP step-up that already works in `/email-preferences` into two reusable pieces.

### `requireVerified()` — server guard (`apps/next/utils/auth-trust.ts`)
The one call a sensitive **action** makes:
```ts
const gate = await requireVerified({ maxAgeMs: 15 * 60_000 })
if (!gate.ok) return gate.response
// gate.ctx.email is freshly proven — safe to mutate as
```
Returns a response the client can detect:
| viewer | response |
|---|---|
| anonymous | `401` |
| recognized (token, never verified) | `403 { stepUpRequired: true }` |
| authenticated but stale (> maxAgeMs) | `403 { stepUpRequired: true, stale: true }` |

Builds on the existing `requireAssurance('authenticated')` + `isRecentlyAuthenticated()`.

### `<Verify>` — client challenge (`apps/next/components/verify/verify.tsx`)
Mount on any `stepUpRequired` 403. Offers, in order of convenience:
1. **Google re-auth** — redirects out and back (the return re-stamps `authTime`).
2. **Password** — re-enter the on-file password (no redirect).
3. **OTP** — a 6-digit code to the **on-file address only** — the forward-safety anchor: a forwarder holding the link can *view*, but only the true addressee receives the code, so only they can *act*.

On success `onVerified()` fires and the caller retries. Modeled directly on the proven `/auth/signin` + `/email-preferences` idioms (same endpoints: `send-otp` / `verify-otp` / `signIn('otp')`).

## Why it's safe
- Every provider sign-in already re-stamps `authTime` (`auth.ts` jwt callback L204), so a step-up resets the recency clock.
- The server (`requireVerified`) is the real boundary; `<Verify>` only drives the re-auth UI.
- **No call sites changed** — nothing behaves differently until slice C consumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)