### PR TITLE
fix(metrics): stop send-path clobbering webhook delivery/bounce events + inline drill-down

### DIFF
--- a/apps/next/app/admin/(admin-plus)/metrics/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/metrics/page.tsx
@@ -16,7 +16,7 @@ import {
 } from '@my/ui'
 import { useHydrated } from '@my/app/hooks/use-hydrated'
 import { brandColors } from '@my/ui/src/branding/brand-colors'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, Fragment } from 'react'
 import { RefreshCw, X } from '@tamagui/lucide-icons'
 import type {
   WebMetricsSummary,
@@ -400,22 +400,14 @@ function EmailMetricsView({
         </Card>
       ) : null}
 
-      {/* Recent Email Performance (per-send tracking) */}
+      {/* Recent Email Performance (per-send tracking). The per-recipient drill-down
+          renders inline beneath the clicked row, inside this component. */}
       {metrics.recentSends && metrics.recentSends.length > 0 ? (
         <RecentSendsTable
           sends={metrics.recentSends}
           colors={colors}
           selectedCampaign={selectedCampaign}
           onSelect={(id) => setSelectedCampaign((cur) => (cur === id ? null : id))}
-        />
-      ) : null}
-
-      {/* Per-recipient drill-down for the selected campaign */}
-      {selectedCampaign ? (
-        <RecipientDrilldown
-          campaignId={selectedCampaign}
-          colors={colors}
-          onClose={() => setSelectedCampaign(null)}
         />
       ) : null}
     </YStack>
@@ -490,10 +482,12 @@ function RecentSendsTable({
           </Text>
         </XStack>
 
-        {/* Data rows */}
+        {/* Data rows — each row renders its per-recipient drill-down inline
+            directly beneath it when selected (so the result appears at the cursor,
+            not off-screen at the bottom of the page). */}
         {sends.map((send) => (
+          <Fragment key={send.campaignId}>
           <XStack
-            key={send.campaignId}
             paddingHorizontal="$3"
             paddingVertical="$2"
             borderBottomWidth={1}
@@ -558,6 +552,14 @@ function RecentSendsTable({
               {send.bounces}
             </Text>
           </XStack>
+          {selectedCampaign === send.campaignId ? (
+            <RecipientDrilldown
+              campaignId={send.campaignId}
+              colors={colors}
+              onClose={() => onSelect(send.campaignId)}
+            />
+          ) : null}
+          </Fragment>
         ))}
       </YStack>
     </Card>

--- a/apps/next/utils/email/email-send.tsx
+++ b/apps/next/utils/email/email-send.tsx
@@ -232,6 +232,29 @@ export const emailSend = async function ({
 
     const sendChunks = chunkArray(senderEmails, SES_RATE_LIMIT)
     const replyTo = senders[reason].replyTo
+
+    // Create the send record BEFORE the send loop. SES Delivery/Bounce events fire
+    // within seconds of each send — i.e. before the loop finishes — so the record
+    // must exist for the webhook to increment against. createSendRecord is a
+    // non-destructive upsert that never writes the engagement counters, so an event
+    // that still races ahead survives. Final sent/failed tallies are written after
+    // the loop via finalizeSendCounts. Best-effort; never fail the send.
+    try {
+      await sendRecordRepository.createSendRecord({
+        campaignId,
+        reason,
+        subReason,
+        subject,
+        description,
+        recipientCount: senderEmails.length,
+        sentCount: 0,
+        failedCount: 0,
+        sentBy,
+      })
+    } catch (recordError) {
+      console.error('Failed to create send record (non-fatal):', recordError)
+    }
+
     let allSent: Sends = { sends: [], skips: [] }
     for (let i = 0; i < sendChunks.length; i++) {
       const sends = await sendDeferred({
@@ -255,21 +278,15 @@ export const emailSend = async function ({
 
     console.log('total sent', allSent.sends.length)
 
-    // Create send record for per-email tracking (best-effort, don't fail the send)
+    // Finalize the sent/failed tallies now the loop is done. Targeted update of
+    // those two counts only — never touches the webhook-owned engagement counters.
     try {
-      await sendRecordRepository.createSendRecord({
-        campaignId,
-        reason,
-        subReason,
-        subject,
-        description,
-        recipientCount: senderEmails.length,
+      await sendRecordRepository.finalizeSendCounts(campaignId, {
         sentCount: allSent.sends.length,
         failedCount: allSent.skips.length,
-        sentBy,
       })
     } catch (recordError) {
-      console.error('Failed to create send record (non-fatal):', recordError)
+      console.error('Failed to finalize send counts (non-fatal):', recordError)
     }
 
     // Per-recipient roster snapshot — the send-time record of exactly who this

--- a/packages/app/provider/dynamodb/repositories/send-recipient-repository.ts
+++ b/packages/app/provider/dynamodb/repositories/send-recipient-repository.ts
@@ -30,27 +30,73 @@ class SendRecipientRepository extends BaseRepository<EmailRecipientRecord> {
     return `RECIPIENT#${email.toLowerCase()}`
   }
 
-  /** Persist the intended-recipient roster for a campaign (best-effort, batched). */
+  /**
+   * Persist the intended-recipient roster for a campaign (best-effort).
+   *
+   * **Non-destructive upsert**, NOT a batch put. Each row is written with
+   * `if_not_exists` on identity/status/sentAt, and `opens`/`clicks`/`deliveredAt`
+   * are never set here. This is critical: SES Delivery/Open events for early
+   * recipients arrive (via the webhook's `recordDelivery/Open`) *before or during*
+   * this snapshot. The previous `batchWrite` PutRequest overwrote those rows —
+   * erasing `deliveredAt` and resetting `opens` to 0 (the write-ordering bug that
+   * made deliveries under-count). An `if_not_exists` upsert leaves any
+   * event-written fields intact regardless of ordering.
+   *
+   * Runs one UpdateItem per recipient (bounded concurrency). For very large lists
+   * this is more writes than a batch; the `RECIPIENT_TRACKING_ENABLED=false` kill
+   * switch remains the escape hatch for thousands-of-recipients sends.
+   */
   async snapshotRoster(
     campaignId: string,
     recipients: Array<{ email: string; status: 'sent' | 'failed'; ecclesia?: string }>
   ): Promise<void> {
     if (recipients.length === 0) return
-    const sentAt = new Date().toISOString()
+    const now = new Date().toISOString()
     const ttl = Math.floor(Date.now() / 1000) + TTL_SECONDS
-    const items: EmailRecipientRecord[] = recipients.map((r) => ({
-      pkey: `SEND#${campaignId}`,
-      skey: SendRecipientRepository.skey(r.email),
-      campaignId,
-      email: r.email.toLowerCase(),
-      ...(r.ecclesia ? { ecclesia: r.ecclesia } : {}),
-      status: r.status,
-      sentAt,
-      opens: 0,
-      clicks: 0,
-      ttl,
-    }))
-    await this.batchWrite(items)
+
+    const writeOne = (r: { email: string; status: 'sent' | 'failed'; ecclesia?: string }) => {
+      const setParts = [
+        'campaignId = if_not_exists(campaignId, :cid)',
+        'email = if_not_exists(email, :em)',
+        '#status = if_not_exists(#status, :st)',
+        'sentAt = if_not_exists(sentAt, :now)',
+        '#ttl = if_not_exists(#ttl, :ttl)',
+      ]
+      const values: Record<string, any> = {
+        ':cid': campaignId,
+        ':em': r.email.toLowerCase(),
+        ':st': r.status,
+        ':now': now,
+        ':ttl': ttl,
+      }
+      if (r.ecclesia) {
+        setParts.push('ecclesia = if_not_exists(ecclesia, :ecc)')
+        values[':ecc'] = r.ecclesia
+      }
+      return docClient.send(
+        new UpdateCommand({
+          TableName: this.tableName,
+          Key: { pkey: `SEND#${campaignId}`, skey: SendRecipientRepository.skey(r.email) },
+          UpdateExpression: `SET ${setParts.join(', ')}`,
+          ExpressionAttributeNames: { '#status': 'status', '#ttl': 'ttl' },
+          ExpressionAttributeValues: values,
+        })
+      )
+    }
+
+    // Bounded concurrency so a large roster doesn't fan out unboundedly.
+    const CHUNK = 25
+    for (let i = 0; i < recipients.length; i += CHUNK) {
+      const results = await Promise.allSettled(recipients.slice(i, i + CHUNK).map(writeOne))
+      const failed = results.filter((r) => r.status === 'rejected') as PromiseRejectedResult[]
+      if (failed.length > 0) {
+        // Best-effort roster — log but never throw (never fail a send over tracking).
+        console.error(
+          `snapshotRoster: ${failed.length} recipient write(s) failed for ${campaignId}:`,
+          failed[0].reason
+        )
+      }
+    }
   }
 
   /** Shared upsert: ensures identity fields exist, then applies event-specific changes. */

--- a/packages/app/provider/dynamodb/repositories/send-record-repository.ts
+++ b/packages/app/provider/dynamodb/repositories/send-record-repository.ts
@@ -44,7 +44,18 @@ class SendRecordRepository extends BaseRepository<SendRecordItem> {
   }
 
   /**
-   * Create a new send record when an email batch is sent
+   * Create the send record. **Non-destructive by design** — this is an UpdateItem
+   * (upsert) that writes ONLY metadata + roster counts, and NEVER the engagement
+   * counters (opens/clicks/bounces/deliveries/complaints).
+   *
+   * Why: SES fires Delivery/Bounce events within seconds of each send — before the
+   * send loop finishes. Those land via the webhook's `incrementMetric`
+   * (`if_not_exists(:zero) + amount`), creating/updating the counters first. A full
+   * `put()` here would reset them to 0 (the original write-ordering bug). By never
+   * touching the counter attributes — and because reads default missing counters to
+   * 0 — an early event survives regardless of ordering. Call this BEFORE the send
+   * loop (see email-send.tsx) so the record exists when events arrive, then call
+   * `finalizeSendCounts` after the loop for the final sent/failed tallies.
    */
   async createSendRecord(data: {
     campaignId: string
@@ -57,14 +68,11 @@ class SendRecordRepository extends BaseRepository<SendRecordItem> {
     failedCount: number
     sentBy?: string
   }): Promise<void> {
-    const now = new Date()
-    const sentAt = now.toISOString()
+    const sentAt = new Date().toISOString()
     // 180-day TTL for send records
-    const ttl = Math.floor(now.getTime() / 1000) + 180 * 24 * 60 * 60
+    const ttl = Math.floor(Date.now() / 1000) + 180 * 24 * 60 * 60
 
-    const record: SendRecordItem = {
-      pkey: `SEND#${data.campaignId}`,
-      skey: 'METADATA',
+    await this.update(`SEND#${data.campaignId}`, 'METADATA', {
       gsi1pk: `SENDS#${data.reason}`,
       gsi1sk: sentAt,
       gsi2pk: 'SENDS#ALL',
@@ -73,23 +81,29 @@ class SendRecordRepository extends BaseRepository<SendRecordItem> {
       reason: data.reason,
       subReason: data.subReason,
       subject: data.subject,
-      ...(data.description && { description: data.description }),
+      ...(data.description ? { description: data.description } : {}),
       recipientCount: data.recipientCount,
       sentCount: data.sentCount,
       failedCount: data.failedCount,
       sentAt,
-      ...(data.sentBy && { sentBy: data.sentBy }),
-      opens: 0,
-      clicks: 0,
-      bounces: 0,
-      deliveries: 0,
-      complaints: 0,
+      ...(data.sentBy ? { sentBy: data.sentBy } : {}),
       ttl,
-      lastUpdated: sentAt,
-      version: 0,
-    }
+    } as Partial<SendRecordItem>)
+  }
 
-    await this.put(record)
+  /**
+   * Update just the sent/failed tallies after the send loop completes. Targeted
+   * SET of `sentCount`/`failedCount` only — never touches the webhook-owned
+   * engagement counters, so events that arrived during the send are preserved.
+   */
+  async finalizeSendCounts(
+    campaignId: string,
+    counts: { sentCount: number; failedCount: number }
+  ): Promise<void> {
+    await this.update(`SEND#${campaignId}`, 'METADATA', {
+      sentCount: counts.sentCount,
+      failedCount: counts.failedCount,
+    } as Partial<SendRecordItem>)
   }
 
   /**


### PR DESCRIPTION
## What & why

Two metrics bugs surfaced after PR #90 (which fixed the SES webhook `eventType` read):

### 1. Delivery/Bounce events under-counted (write-ordering race)
A 124-recipient newsletter recorded `deliveries=6` while `opens=18` — impossible, since you can't open an undelivered email. Root cause: SES fires Delivery/Bounce events **within seconds of each send — before the send loop finishes**. The webhook recorded them, then the *post-loop* writes clobbered them:
- `createSendRecord` did a full `put()` that reset `opens/clicks/bounces/deliveries` to 0.
- `snapshotRoster` did a `batchWrite` `put()` that erased `deliveredAt` / reset `opens`.

Only late events (arriving after those writes) survived. Opens/clicks arrive minutes–hours later, so they were never hit — which is why they looked fine. Proven via CloudWatch `AWS/SNS`: ~160 messages published **and delivered, 0 failed** — nothing lost in transit; the openers had **no `deliveredAt`** (their delivery events were erased).

**Fix (pre-create + non-destructive):**
- `createSendRecord` → non-destructive `update()` upsert that writes metadata + roster counts only, **never** the engagement counters. Called **before** the send loop so the record exists when events arrive. Reads default missing counters to 0, so an event that still races ahead survives.
- New `finalizeSendCounts()` writes the final `sentCount`/`failedCount` after the loop (targeted SET, doesn't touch counters).
- `snapshotRoster` → per-recipient `if_not_exists` upsert (was a clobbering `batchWrite`); never overwrites `deliveredAt`/`opens`. Bounded concurrency (chunks of 25); logs per-item failures.

### 2. Drill-down "does nothing"
The per-recipient drill-down was fully wired but rendered at the very bottom of the page, below both charts and the whole table — so clicking a row appeared to do nothing. Now renders **inline directly beneath the clicked row**.

## How verified
- `yarn workspace next-app typecheck` clean (only 2 pre-existing `occurrenceDate` errors in `get-upcoming-program.tsx`, unrelated).
- Root cause proven against live prod data (DynamoDB send/recipient records + CloudWatch SNS metrics).
- **Runtime validation:** this race is invisible to typecheck/build — it will be validated against the next real send (today's memorial recap ~2pm), confirming `deliveries` tracks ~1:1 with sends and bounces count.

## Self-review notes
- Reserved-word-safe: reuses the proven `applyEvent` `#status`/`#ttl` aliasing and `BaseRepository.update()`'s attribute aliasing.
- Follows CLAUDE.md JSX rule (ternary, not `&&`).
- Bounded DB concurrency (no unbounded `Promise.all` fan-out).
- Tracking stays best-effort — never fails a send.

## Follow-up (not in this PR)
`DELIVERY_DELAY` is not on the SNS event destination, so transient soft-failures never reach the webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)