### PR TITLE
fix(metrics): align email table columns (minWidth:0 on flex cells)

### DIFF
--- a/apps/next/app/admin/(admin-plus)/metrics/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/metrics/page.tsx
@@ -500,10 +500,10 @@ function RecentSendsTable({
             hoverStyle={{ backgroundColor: colors.backgroundSecondary }}
             onPress={() => onSelect(send.campaignId)}
           >
-            <Text flex={2} color={colors.textPrimary} fontSize="$2" numberOfLines={1}>
+            <Text flex={2} minWidth={0} color={colors.textPrimary} fontSize="$2" numberOfLines={1}>
               {formatDate(send.sentAt)}
             </Text>
-            <XStack flex={1} gap="$1" flexWrap="wrap">
+            <XStack flex={1} minWidth={0} gap="$1" flexWrap="wrap">
               <Text
                 fontSize="$1"
                 fontWeight="600"
@@ -526,7 +526,7 @@ function RecentSendsTable({
                 </Text>
               ) : null}
             </XStack>
-            <Text flex={3} color={colors.textPrimary} fontSize="$2" numberOfLines={1}>
+            <Text flex={3} minWidth={0} color={colors.textPrimary} fontSize="$2" numberOfLines={1}>
               {send.subject}
             </Text>
             <Text flex={1} color={colors.textPrimary} fontSize="$2" textAlign="right">
@@ -689,13 +689,13 @@ function RecipientDrilldown({
               complained || bounced || failed ? '#ef4444' : r.deliveredAt ? '#22c55e' : colors.textSecondary
             return (
               <XStack key={r.email} paddingHorizontal="$2" paddingVertical="$1.5" borderBottomWidth={1} borderBottomColor={colors.border} alignItems="center">
-                <Text flex={2} fontSize="$2" color={colors.textPrimary} numberOfLines={1}>
+                <Text flex={2} minWidth={0} fontSize="$2" color={colors.textPrimary} numberOfLines={1}>
                   {r.ecclesia ?? '—'}
                 </Text>
-                <Text flex={3} fontSize="$2" color={colors.textPrimary} numberOfLines={1}>
+                <Text flex={3} minWidth={0} fontSize="$2" color={colors.textPrimary} numberOfLines={1}>
                   {r.email}
                 </Text>
-                <Text flex={2} fontSize="$2" color={colors.textSecondary} numberOfLines={1}>
+                <Text flex={2} minWidth={0} fontSize="$2" color={colors.textSecondary} numberOfLines={1}>
                   {fmtEventDate(r.deliveredAt)}
                 </Text>
                 <Text flex={1} fontSize="$2" color={colors.textPrimary} textAlign="right">
@@ -704,7 +704,7 @@ function RecipientDrilldown({
                 <Text flex={1} fontSize="$2" color={colors.textPrimary} textAlign="right">
                   {r.clicks}
                 </Text>
-                <Text flex={2} fontSize="$2" color={statusColor} textAlign="right" numberOfLines={1}>
+                <Text flex={2} minWidth={0} fontSize="$2" color={statusColor} textAlign="right" numberOfLines={1}>
                   {statusText}
                 </Text>
               </XStack>


### PR DESCRIPTION
## What
The Recent Email Performance table and the per-recipient drill-down had columns drifting right of their headers — e.g. the `Sent` value rendered under the `Opens` header.

## Why
Flex text cells (`Subject`, `Date`, `Email`, `Ecclesia`, `Delivered`, `Status`) used `numberOfLines={1}` but no `minWidth={0}`. On web, flex items default to `min-width: auto` (content-based), so a long Subject/email refuses to shrink to its flex slot and pushes every following column right. The classic flexbox min-width trap.

## Fix
Add `minWidth={0}` to those cells so each respects its flex basis and truncates (ellipsis) instead of overflowing. Headers unchanged (short text, never overflowed).

## Verified
`yarn workspace next-app typecheck` clean (only the 2 pre-existing `occurrenceDate` errors). Visual: confirmed on the deployed metrics page after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)