### PR TITLE
feat(pii): anon PII scrub on /api/events/public (Phase 0, slice 1)

### DIFF
--- a/apps/next/app/api/events/public/route.ts
+++ b/apps/next/app/api/events/public/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { unstable_cache } from 'next/cache'
 import { getPublishedEvents } from '@my/app/services/event-service'
+import { redactEventsForViewer } from '@my/app/utils/redact-event'
+import { ANONYMOUS_VIEWER } from '@my/app/utils/viewer-pii'
 import { CACHE_TAGS } from '@/utils/cache'
 
 // Cache duration: revalidate daily at midnight (86400 seconds = 24 hours)
@@ -11,7 +13,13 @@ const CACHE_DURATION = process.env.NODE_ENV === 'production' ? 86400 : false
 const getCachedPublishedEvents = unstable_cache(
   async () => {
     console.log('🔄 Cache miss - fetching fresh events from DynamoDB')
-    return await getPublishedEvents()
+    const events = await getPublishedEvents()
+    // This endpoint is unauthenticated → anonymous tier. Redact PII server-side
+    // BEFORE it enters the response cache, so the cache literally cannot hold (and
+    // this route cannot leak) last names, street addresses, bios, or contact
+    // details. Full data is served to members via authenticated endpoints; the
+    // newsletter EMAIL renders member-tier via its own channel (see redact-event).
+    return redactEventsForViewer(events, ANONYMOUS_VIEWER, 'public-web')
   },
   ['published-events'],
   {

--- a/apps/next/tests/redact-event.test.ts
+++ b/apps/next/tests/redact-event.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { redactEventForViewer } from '@my/app/utils/redact-event'
+import { ANONYMOUS_VIEWER, type Viewer } from '@my/app/utils/viewer-pii'
+import type { Event } from '@my/app/types/events'
+
+const member: Viewer = { assurance: 'authenticated', role: 'member', tenant: 'Toronto East', email: 'm@x.z' }
+const recognized: Viewer = { assurance: 'recognized', role: 'member', tenant: 'Toronto East', email: 'r@x.z' }
+
+// A PII-dense event (baptism + funeral + wedding fields on one object for coverage).
+const event = {
+  id: 'e1',
+  title: 'Test',
+  type: 'baptism',
+  candidate: { firstName: 'Joshua', lastName: 'Archibald', testimony: 'secret', baptismStatement: 'secret' },
+  aboutCandidate: 'A long private bio',
+  candidatePhoto: { url: 'http://x/p.jpg', fileName: 'p.jpg', originalName: 'p.jpg' },
+  sponsors: [{ firstName: 'Gord', lastName: 'Easson', role: 'proposer' }],
+  deceased: { firstName: 'Tom', lastName: 'Perks', obituary: 'obit text' },
+  aboutDeceased: 'tribute text',
+  couple: { bride: { firstName: 'Jess', lastName: 'Millar' }, groom: { firstName: 'Gord', lastName: 'Easson' } },
+  weddingParty: [{ firstName: 'Sam', lastName: 'Jones', role: 'best man' }],
+  speakers: [
+    { firstName: 'Pete', lastName: 'Skariah', ecclesia: 'Toronto West' },
+    { firstName: 'Jo', lastName: 'Vance', ecclesia: { name: 'Verdugo Hills', city: 'LA', province: 'CA', country: 'US', address: '10210 Commerce Ave', postalCode: '91042' } },
+  ],
+  engagementProposed: 'Brother Gord Easson',
+  engagementTo: 'Sister Jessica Millar',
+  engagementAnnouncement: 'We are pleased to announce…',
+  location: { name: 'TE Hall', city: 'Toronto', province: 'ON', address: '123 Main St', postalCode: 'M1 1M1', lat: 43.7, lng: -79.3 },
+  registration: { required: true, contactEmail: 'sue@x.z', contactPhone: '416-555-1212', registrationUrl: 'http://reg' },
+} as unknown as Event
+
+describe('redactEventForViewer — anonymous (public web)', () => {
+  const r = redactEventForViewer(event, ANONYMOUS_VIEWER)
+
+  it('keeps first names, drops last names everywhere', () => {
+    expect(r.candidate).toEqual({ firstName: 'Joshua' })
+    expect((r.candidate as any).lastName).toBeUndefined()
+    expect(r.deceased).toEqual({ firstName: 'Tom' })
+    expect(r.sponsors).toEqual([{ firstName: 'Gord', role: 'proposer' }])
+    expect(r.couple).toEqual({ bride: { firstName: 'Jess' }, groom: { firstName: 'Gord' } })
+    expect(r.weddingParty).toEqual([{ firstName: 'Sam', role: 'best man' }])
+    expect(r.speakers![0]).toEqual({ firstName: 'Pete', ecclesia: 'Toronto West' })
+  })
+
+  it('floors an object-valued ecclesia to venue (drops its street address)', () => {
+    const ec = (r.speakers![1] as any).ecclesia
+    expect(ec).toEqual({ name: 'Verdugo Hills', city: 'LA', province: 'CA', country: 'US' })
+    expect(ec).not.toHaveProperty('address')
+    expect(ec).not.toHaveProperty('postalCode')
+    expect((r.speakers![1] as any).lastName).toBeUndefined()
+  })
+
+  it('drops all bio / free-text / photo fields', () => {
+    expect((r.candidate as any).testimony).toBeUndefined()
+    expect((r.candidate as any).baptismStatement).toBeUndefined()
+    expect((r as any).aboutCandidate).toBeUndefined()
+    expect((r.deceased as any).obituary).toBeUndefined()
+    expect((r as any).aboutDeceased).toBeUndefined()
+    expect((r as any).engagementProposed).toBeUndefined()
+    expect((r as any).engagementTo).toBeUndefined()
+    expect((r as any).engagementAnnouncement).toBeUndefined()
+    expect((r as any).candidatePhoto).toBeUndefined()
+  })
+
+  it('location floor = venue + city + province, no street/postal/geo', () => {
+    expect(r.location).toEqual({ name: 'TE Hall', city: 'Toronto', province: 'ON' })
+    expect((r.location as any).address).toBeUndefined()
+    expect((r.location as any).postalCode).toBeUndefined()
+    expect((r.location as any).lat).toBeUndefined()
+  })
+
+  it('drops registration contact details, keeps non-PII', () => {
+    expect((r.registration as any).contactEmail).toBeUndefined()
+    expect((r.registration as any).contactPhone).toBeUndefined()
+    expect((r.registration as any).registrationUrl).toBe('http://reg')
+  })
+
+  it('does not mutate the original event', () => {
+    expect((event.candidate as any).lastName).toBe('Archibald')
+    expect((event.location as any).address).toBe('123 Main St')
+  })
+})
+
+describe('redactEventForViewer — reveal tiers pass through unchanged', () => {
+  it('authenticated member sees everything', () => {
+    expect(redactEventForViewer(event, member)).toBe(event)
+  })
+  it('recognized recipient via newsletter-email sees everything', () => {
+    expect(redactEventForViewer(event, recognized, 'newsletter-email')).toBe(event)
+  })
+  it('recognized on public web is redacted (first-name-only)', () => {
+    const r = redactEventForViewer(event, recognized, 'public-web')
+    expect(r.candidate).toEqual({ firstName: 'Joshua' })
+  })
+})

--- a/apps/next/tests/viewer-pii.test.ts
+++ b/apps/next/tests/viewer-pii.test.ts
@@ -2,13 +2,17 @@ import { describe, it, expect } from 'vitest'
 import {
   effectiveRole,
   canRevealFullName,
+  canRevealPii,
   renderName,
   shapePersonName,
+  shapeLocation,
+  revealBio,
   roleAtLeast,
   ANONYMOUS_VIEWER,
   type Assurance,
   type Role,
   type Viewer,
+  type LocationLike,
 } from '@my/app/utils/viewer-pii'
 
 const peter = { firstName: 'Peter', lastName: 'Skariah', ecclesia: 'Toronto East' }
@@ -91,5 +95,64 @@ describe('renderName / shapePersonName — server-side redaction', () => {
   it('two Peters stay indistinguishable in the public view (no initial)', () => {
     const peter2 = { firstName: 'Peter', lastName: 'Thomas' }
     expect(renderName(peter, ANONYMOUS_VIEWER)).toBe(renderName(peter2, ANONYMOUS_VIEWER))
+  })
+})
+
+describe('canRevealPii — channel-aware (design §8.2)', () => {
+  it('public-web follows the viewer tier', () => {
+    expect(canRevealPii(ANONYMOUS_VIEWER, 'public-web')).toBe(false)
+    expect(canRevealPii(viewer('recognized', 'member'), 'public-web')).toBe(false)
+    expect(canRevealPii(viewer('authenticated', 'member'), 'public-web')).toBe(true)
+  })
+  it('newsletter-email always reveals — curated member audience', () => {
+    expect(canRevealPii(ANONYMOUS_VIEWER, 'newsletter-email')).toBe(true)
+    expect(canRevealPii(viewer('recognized', 'member'), 'newsletter-email')).toBe(true)
+  })
+  it('defaults to public-web when channel omitted', () => {
+    expect(canRevealPii(viewer('recognized', 'member'))).toBe(false)
+  })
+})
+
+describe('name/bio via the newsletter-email channel show full', () => {
+  it('full name in the newsletter even for a recognized recipient', () => {
+    const v = viewer('recognized', 'member')
+    expect(renderName(peter, v, 'newsletter-email')).toBe('Peter Skariah')
+    expect(shapePersonName(peter, v, 'newsletter-email')).toEqual({ firstName: 'Peter', lastName: 'Skariah' })
+  })
+  it('bio shown in newsletter, hidden on public web', () => {
+    const v = viewer('recognized', 'member')
+    expect(revealBio('An obituary', v, 'newsletter-email')).toBe('An obituary')
+    expect(revealBio('An obituary', v, 'public-web')).toBeUndefined()
+    expect(revealBio('An obituary', viewer('authenticated', 'member'), 'public-web')).toBe('An obituary')
+  })
+})
+
+describe('shapeLocation — anon floor is venue + city (design §8.1)', () => {
+  const hall: LocationLike = {
+    venueName: 'Toronto East Hall', city: 'Toronto', province: 'ON',
+    address: '123 Main St', postalCode: 'M1M 1M1', lat: 43.7, lng: -79.3,
+  }
+  it('anon gets venue + city + province only, no street/postal/geo', () => {
+    expect(shapeLocation(hall, ANONYMOUS_VIEWER)).toEqual({
+      venueName: 'Toronto East Hall', city: 'Toronto', province: 'ON',
+    })
+  })
+  it('redacted shape NEVER carries address/postal/geo (no ship-then-hide)', () => {
+    const shaped = shapeLocation(hall, ANONYMOUS_VIEWER)!
+    expect(shaped).not.toHaveProperty('address')
+    expect(shaped).not.toHaveProperty('postalCode')
+    expect(shaped).not.toHaveProperty('lat')
+    expect(shaped).not.toHaveProperty('lng')
+  })
+  it('authenticated member gets the full location', () => {
+    expect(shapeLocation(hall, viewer('authenticated', 'member'))).toEqual(hall)
+  })
+  it('newsletter-email gets the full location even for a recognized recipient', () => {
+    expect(shapeLocation(hall, viewer('recognized', 'member'), 'newsletter-email')).toEqual(hall)
+  })
+  it('a private residence is hidden entirely for anon, shown for member+', () => {
+    const home: LocationLike = { venueName: 'The Smith residence', city: 'Toronto', address: '5 Elm St', privateResidence: true }
+    expect(shapeLocation(home, ANONYMOUS_VIEWER)).toBeUndefined()
+    expect(shapeLocation(home, viewer('authenticated', 'member'))).toEqual(home)
   })
 })

--- a/packages/app/utils/redact-event.ts
+++ b/packages/app/utils/redact-event.ts
@@ -1,0 +1,162 @@
+/**
+ * Server-side PII redaction for the legacy `Event` shape (Phase 0 of the unified
+ * post model — see docs/UNIFIED_POST_MODEL_DESIGN.md). Maps each PII-bearing field
+ * to a PiiClass and shapes it for the (viewer, channel):
+ *   - name            → first-name-only for anon (never carries lastName)
+ *   - bio / free-text → dropped for anon (obituary, testimony, about*, engagement blurb)
+ *   - location-precise→ venue + city/province only for anon (drop street/postal/geo);
+ *                       private residence dropped whole
+ *   - contact         → dropped for anon (registration email/phone, contact person)
+ *
+ * Reveal tier (full PII) = verified member+ OR the curated `newsletter-email`
+ * channel. Sanitation happens HERE, before serialization — a redacted event
+ * literally cannot carry a surname / street address (no ship-then-hide leak).
+ */
+import type { Event, LocationInfo, FuneralLocations } from '../types/events'
+import { canRevealPii, revealBio, type Viewer, type Channel } from './viewer-pii'
+
+type Person = { firstName: string; lastName?: string; [k: string]: unknown }
+
+/** Strip lastName unless the viewer/channel may see it. Preserves other fields (role, ecclesia). */
+function redactPerson<T extends Person>(p: T, reveal: boolean): T {
+  if (reveal) return p
+  const { lastName, ...rest } = p
+  // Some records denormalize `ecclesia` as an object that can carry a full street
+  // address; keep only the venue floor (name/city/province/country).
+  const ec = (rest as Record<string, unknown>).ecclesia
+  if (ec && typeof ec === 'object') {
+    const e = ec as Record<string, unknown>
+    const floor: Record<string, unknown> = {}
+    if (e.name) floor.name = e.name
+    if (e.city) floor.city = e.city
+    if (e.province) floor.province = e.province
+    if (e.country) floor.country = e.country
+    ;(rest as Record<string, unknown>).ecclesia = floor
+  }
+  return rest as unknown as T
+}
+
+function redactPeople<T extends Person>(people: T[] | undefined, reveal: boolean): T[] | undefined {
+  if (!people) return people
+  return people.map((p) => redactPerson(p, reveal))
+}
+
+/**
+ * Anon location floor: venue name(s) + city/province/country + mode + online
+ * meeting; drop street/postal/geo/maps/directions. A private residence is dropped
+ * whole. Returns a NEW object carrying only the safe fields.
+ */
+function redactLocationInfo(loc: LocationInfo | undefined, reveal: boolean): LocationInfo | undefined {
+  if (!loc) return undefined
+  if (reveal) return loc
+  if ((loc as { privateResidence?: boolean }).privateResidence) return undefined
+  const safe: LocationInfo = {}
+  if (loc.mode) safe.mode = loc.mode
+  if (loc.name) safe.name = loc.name
+  if (loc.placeName) safe.placeName = loc.placeName
+  if (loc.city) safe.city = loc.city
+  if (loc.province) safe.province = loc.province
+  if (loc.country) safe.country = loc.country
+  if (loc.onlineMeeting) safe.onlineMeeting = loc.onlineMeeting
+  return safe
+}
+
+function redactLocations(
+  locations: FuneralLocations | LocationInfo[] | undefined,
+  reveal: boolean
+): FuneralLocations | LocationInfo[] | undefined {
+  if (!locations) return locations
+  if (reveal) return locations
+  if (Array.isArray(locations)) {
+    return locations.map((l) => redactLocationInfo(l, reveal)).filter(Boolean) as LocationInfo[]
+  }
+  const out: FuneralLocations = {}
+  for (const [key, val] of Object.entries(locations)) {
+    const r = redactLocationInfo(val as LocationInfo, reveal)
+    if (r) (out as Record<string, LocationInfo>)[key] = r
+  }
+  return out
+}
+
+/**
+ * Redact a single event for the given viewer + channel. Returns a shallow-rebuilt
+ * event; when `reveal` is true (member+ or newsletter-email) it is returned
+ * unchanged.
+ */
+export function redactEventForViewer(
+  event: Event,
+  viewer: Viewer,
+  channel: Channel = 'public-web'
+): Event {
+  const reveal = canRevealPii(viewer, channel)
+  if (reveal) return event
+
+  const e = event as Event & Record<string, unknown>
+  const out: Event = { ...event }
+  const o = out as Event & Record<string, unknown>
+
+  // --- name-class (structured) ---
+  if (e.speakers) out.speakers = redactPeople(e.speakers as Person[], reveal) as Event['speakers']
+  if (e.weddingParty) out.weddingParty = redactPeople(e.weddingParty as Person[], reveal) as Event['weddingParty']
+  if (e.sponsors) out.sponsors = redactPeople(e.sponsors as Person[], reveal) as Event['sponsors']
+  if (e.couple) {
+    const c = e.couple as { bride: Person; groom: Person }
+    out.couple = { bride: redactPerson(c.bride, reveal), groom: redactPerson(c.groom, reveal) } as Event['couple']
+  }
+  if (e.candidate) {
+    // name shaped; testimony/baptismStatement are bio → dropped for anon
+    const c = redactPerson(e.candidate as Person, reveal) as Record<string, unknown>
+    delete c.testimony
+    delete c.baptismStatement
+    out.candidate = c as Event['candidate']
+  }
+  if (e.deceased) {
+    const d = redactPerson(e.deceased as Person, reveal) as Record<string, unknown>
+    delete d.obituary // bio
+    out.deceased = d as Event['deceased']
+  }
+
+  // --- bio / free-text (dropped for anon; members-only per design §8.3) ---
+  delete o.aboutCandidate
+  delete o.aboutDeceased
+  delete o.engagementProposed
+  delete o.engagementTo
+  delete o.engagementAnnouncement
+  // personal photos are visual PII
+  delete o.candidatePhoto
+  delete o.deceasedPhoto
+
+  // --- location-class ---
+  if (e.location) out.location = redactLocationInfo(e.location as LocationInfo, reveal)
+  if (e.ceremonyLocation) out.ceremonyLocation = redactLocationInfo(e.ceremonyLocation as LocationInfo, reveal)
+  if (e.locations) out.locations = redactLocations(e.locations as FuneralLocations | LocationInfo[], reveal)
+  if (e.reception) {
+    const r = e.reception as { location?: LocationInfo }
+    out.reception = { ...r, location: redactLocationInfo(r.location, reveal) } as Event['reception']
+  }
+  if (e.sections) {
+    out.sections = (e.sections as Array<{ location?: LocationInfo }>).map((s) => ({
+      ...s,
+      location: redactLocationInfo(s.location, reveal),
+    })) as Event['sections']
+  }
+
+  // --- contact-class ---
+  if (e.registration) {
+    const r = { ...(e.registration as Record<string, unknown>) }
+    delete r.contactEmail
+    delete r.contactPhone
+    out.registration = r as Event['registration']
+  }
+
+  return out
+}
+
+/** Redact a list of events. */
+export function redactEventsForViewer(
+  events: Event[],
+  viewer: Viewer,
+  channel: Channel = 'public-web'
+): Event[] {
+  return events.map((e) => redactEventForViewer(e, viewer, channel))
+}

--- a/packages/app/utils/viewer-pii.ts
+++ b/packages/app/utils/viewer-pii.ts
@@ -86,12 +86,43 @@ export interface NamedPerson {
 }
 
 /**
- * A full name is revealed only to a *verified* member-or-greater. `target` is
- * accepted for a future tenant-relative refinement (e.g. same-ecclesia only) but
- * the baseline gate is assurance + effective role.
+ * PII classification for a field. The unified post model tags every PII-bearing
+ * field with one of these so redaction is a single pass over typed fields rather
+ * than an audit of every interpolation site. See docs/UNIFIED_POST_MODEL_DESIGN.md.
  */
-export function canRevealFullName(viewer: Viewer, _target?: NamedPerson): boolean {
+export type PiiClass = 'none' | 'name' | 'bio' | 'location-precise' | 'contact'
+
+/**
+ * Delivery channel. Redaction is channel-aware (design §8.2, decided 2026-07-20):
+ * the curated newsletter email goes to an opted-in member audience, so it renders
+ * at member tier (full names + full location) even though recipients are only
+ * `recognized`. Every other surface (the public web page, the anonymous
+ * "view in browser") uses the viewer's real tier.
+ */
+export type Channel = 'public-web' | 'newsletter-email'
+
+/**
+ * THE gate: may this (viewer, channel) see un-redacted PII (full names, precise
+ * location, bios)? True for a verified member-or-greater, OR for anything sent
+ * through the curated `newsletter-email` channel. Name/location/bio shaping all
+ * key off this one predicate.
+ */
+export function canRevealPii(viewer: Viewer, channel: Channel = 'public-web'): boolean {
+  if (channel === 'newsletter-email') return true
   return viewer.assurance === 'authenticated' && roleAtLeast(viewer.role, 'member')
+}
+
+/**
+ * A full name is revealed only to a *verified* member-or-greater (or via the
+ * newsletter-email channel). `target` is accepted for a future tenant-relative
+ * refinement (e.g. same-ecclesia only).
+ */
+export function canRevealFullName(
+  viewer: Viewer,
+  _target?: NamedPerson,
+  channel: Channel = 'public-web'
+): boolean {
+  return canRevealPii(viewer, channel)
 }
 
 /**
@@ -99,8 +130,8 @@ export function canRevealFullName(viewer: Viewer, _target?: NamedPerson): boolea
  * disambiguating initial. Two "Peter"s must stay indistinguishable in the
  * public view; that ambiguity is the privacy feature, not a bug.
  */
-export function renderName(target: NamedPerson, viewer: Viewer): string {
-  if (canRevealFullName(viewer, target)) {
+export function renderName(target: NamedPerson, viewer: Viewer, channel: Channel = 'public-web'): string {
+  if (canRevealFullName(viewer, target, channel)) {
     return [target.firstName, target.lastName].filter(Boolean).join(' ')
   }
   return target.firstName
@@ -114,9 +145,62 @@ export function renderName(target: NamedPerson, viewer: Viewer): string {
  */
 export function shapePersonName<T extends NamedPerson>(
   target: T,
-  viewer: Viewer
+  viewer: Viewer,
+  channel: Channel = 'public-web'
 ): { firstName: string; lastName?: string } {
-  return canRevealFullName(viewer, target)
+  return canRevealFullName(viewer, target, channel)
     ? { firstName: target.firstName, lastName: target.lastName }
     : { firstName: target.firstName }
+}
+
+/**
+ * A location as the model reasons about it. `venueName`/`city`/`province` are the
+ * anon-safe floor; `address`/`postalCode`/`lat`/`lng` are `location-precise`.
+ */
+export interface LocationLike {
+  venueName?: string
+  city?: string
+  province?: string
+  address?: string
+  postalCode?: string
+  lat?: number
+  lng?: number
+  /** A private residence (e.g. a funeral visitation at a home) is hidden entirely for anon. */
+  privateResidence?: boolean
+}
+
+/**
+ * Server-side location shape. Full location for a reveal-tier viewer/channel;
+ * otherwise the anon floor — `venueName` + `city` (+ `province`) ONLY, with the
+ * precise street/postal/geo dropped from the object entirely (no View-Source
+ * leak). A private-residence location is omitted whole for non-reveal viewers.
+ * Decision 2026-07-20 (design §8.1).
+ */
+export function shapeLocation(
+  loc: LocationLike | undefined,
+  viewer: Viewer,
+  channel: Channel = 'public-web'
+): LocationLike | undefined {
+  if (!loc) return undefined
+  if (canRevealPii(viewer, channel)) return loc
+  if (loc.privateResidence) return undefined
+  const shaped: LocationLike = {}
+  if (loc.venueName) shaped.venueName = loc.venueName
+  if (loc.city) shaped.city = loc.city
+  if (loc.province) shaped.province = loc.province
+  return shaped
+}
+
+/**
+ * Bio-class text (obituary, testimony, "about the candidate") — shown only to a
+ * reveal-tier viewer/channel, otherwise dropped. Returns `undefined` when hidden
+ * so the field is simply absent from the serialized response.
+ */
+export function revealBio(
+  value: string | undefined,
+  viewer: Viewer,
+  channel: Channel = 'public-web'
+): string | undefined {
+  if (!value) return undefined
+  return canRevealPii(viewer, channel) ? value : undefined
 }


### PR DESCRIPTION
First slice of **Phase 0** — stop leaking PII to anonymous visitors — from `docs/UNIFIED_POST_MODEL_DESIGN.md`. A redactor over the legacy `Event` shape; no data migration, no new UI.

## Problem
`/api/events/public` is unauthenticated and shipped **full PII to anyone**: baptism candidate first+last name + `aboutCandidate` bio, obituaries, and street addresses/geo (observed live).

## What
- **`viewer-pii.ts`** — extends the merged primitive (#89) with:
  - `PiiClass` taxonomy + `Channel` (`public-web` | `newsletter-email`).
  - `canRevealPii(viewer, channel)` — the single reveal gate. **Channel-aware** (decision §8.2): the curated `newsletter-email` renders member-tier (full names) even for `recognized` recipients; every other surface uses the viewer's tier.
  - `shapeLocation` — anon floor = **venue + city** (drop street/postal/geo); a **private residence** is hidden entirely (§8.1). `revealBio` — bios dropped for anon.
- **`redact-event.ts`** — `redactEventForViewer` classifies every PII field on `Event` (names → first-name-only; testimony/obituary/about*/engagement blurb/personal photos → dropped; locations → venue+city; registration contact → dropped; object-valued `speaker.ecclesia` → venue floor). Member+/newsletter passes through unchanged; **never mutates the input**; sanitation happens before serialization (no ship-then-hide).
- **`/api/events/public`** — redacts to anonymous tier **inside the cache**, so the response cache literally cannot hold last names/addresses/bios.

## Verified
- 49 unit tests (viewer-pii + event redaction), all green. `typecheck` clean.
- **Live**: `GET /api/events/public` now returns **0 PII leaks** (scanned the whole payload for lastName/address/postal/geo/bio/contact), while keeping titles, venue names, city, and first names intact.

## Follow-ups (remaining Phase 0 boundaries)
`/api/news`, `/api/schedule/[type]`, and the public web newsletter render path — same pattern, separate slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)