### PR TITLE
feat(pii): anon scrub /api/upcoming-program — completes Phase 0 (slice 3)

### DIFF
--- a/apps/next/app/api/upcoming-program/route.ts
+++ b/apps/next/app/api/upcoming-program/route.ts
@@ -4,6 +4,8 @@ import { ScheduleService } from '@my/app/provider/dynamodb/schedule-service'
 import { ProgramTypeKeys } from '@my/app/types'
 import { CACHE_TAGS } from '../../../utils/cache'
 import { getEcclesiaByName } from '../../../utils/dynamodb/locations'
+import { redactScheduleData } from '@my/app/utils/redact-schedule'
+import { ANONYMOUS_VIEWER } from '@my/app/utils/viewer-pii'
 
 // Cache for 15 minutes in production (shorter for faster updates when debugging)
 const CACHE_DURATION = process.env.NODE_ENV === 'production' ? 900 : 0
@@ -111,7 +113,13 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    return NextResponse.json(responseData, {
+    // Only live consumer is the anonymous web newsletter screen → anonymous tier.
+    // First-name-only role assignments, drop host addresses, BEFORE the shared
+    // `public` cache. The member-tier newsletter EMAIL sources full names via the
+    // server-side get_upcoming_program() path, not this route (see get-email-content).
+    const safeData = redactScheduleData(responseData, ANONYMOUS_VIEWER, 'public-web')
+
+    return NextResponse.json(safeData, {
       headers: {
         'Cache-Control': `public, max-age=${CACHE_DURATION}, stale-while-revalidate=300`,
         'X-Data-Source': 'dynamodb-cache',


### PR DESCRIPTION
Final Phase 0 slice. The last surface leaking PII to anonymous visitors was the **public web newsletter screen**, which pulls its schedule from `/api/upcoming-program` — that endpoint returned full presider/speaker/steward/doorkeeper names + host addresses. Now redacted to anonymous tier (first-name-only, addresses dropped), same blanket-anon pattern as the sibling schedule routes.

## Why the simple fix is correct (not viewer-aware)
An investigation of every newsletter path confirmed there's **no tier to preserve** at this endpoint:
- **No admin newsletter preview route exists.**
- The `NewsletterDataService` / `assembly-processor` system is **dead code** (unwired).
- The **only live consumer** is the anon web newsletter screen (`newsletter-screen.tsx` → `fetchUpcoming` → `/api/upcoming-program`) — which *should* be scrubbed.
- The **sent member-tier email** sources full names via `get_upcoming_program()` **server-side**, not this route — unaffected.

## The model (per Ken)
Two orthogonal booleans: **regionality = which content** (`getData`), **authorization = how much** (`scrub` = `!canRevealPii`). Anonymize only when `getData && scrub`. This endpoint's only consumer is anon → `scrub=true`.

## Verified
Typecheck clean. Live: `/api/upcoming-program` returns **0 full-name/address leaks**.

## Phase 0 complete ✅
| Surface | Status |
|---|---|
| `/api/events/public` | ✅ #97 |
| `/api/enhanced-schedule`, `/api/schedule/[type]` | ✅ #98 |
| `/api/upcoming-program` (web newsletter) | ✅ this PR |
| `/api/news` | ✅ no structured PII (no-op) |

Events, schedules, and the web newsletter no longer leak names/addresses to anonymous visitors. Member-tier email keeps full names via its server-side path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)