### PR TITLE
fix(pii): redact reader/prayer/AV person columns in schedules

### DIFF
--- a/apps/next/tests/redact-schedule.test.ts
+++ b/apps/next/tests/redact-schedule.test.ts
@@ -26,7 +26,8 @@ describe('redactScheduleData — anon (public web)', () => {
         {
           date: '2026-07-26', Preside: 'Brad Stephens', Exhort: 'Desmond Amos', Organist: 'Joan Curry',
           Steward: 'Zaiden Easson', Doorkeeper: 'Ken Easson', Lunch: 'The Smith family',
-          Reading1: 'Genesis 1', Reading2: 'Matthew 5', 'Hymn-opening': '158',
+          'Reader 1': 'Peter Skariah', 'Reader 2': 'John Vance', 'Prayer - Wine': 'Gord Easson',
+          'Reading 1': 'Genesis 1', 'Reading 2': 'Matthew 5', 'Hymn-opening': '158',
         },
       ],
       bibleClass: [
@@ -48,10 +49,17 @@ describe('redactScheduleData — anon (public web)', () => {
     expect(b.Speaker).toBe('John')
   })
 
-  it('leaves non-name fields (readings, hymns, topic, date) untouched', () => {
+  it('first-names the reader + prayer roles (people)', () => {
     const m = r.data.memorial[0] as any
-    expect(m.Reading1).toBe('Genesis 1')
-    expect(m.Reading2).toBe('Matthew 5')
+    expect(m['Reader 1']).toBe('Peter')
+    expect(m['Reader 2']).toBe('John')
+    expect(m['Prayer - Wine']).toBe('Gord')
+  })
+
+  it('leaves non-name fields (readings passages, hymns, topic, date) untouched', () => {
+    const m = r.data.memorial[0] as any
+    expect(m['Reading 1']).toBe('Genesis 1') // passage, NOT a person
+    expect(m['Reading 2']).toBe('Matthew 5')
     expect(m['Hymn-opening']).toBe('158')
     expect(m.date).toBe('2026-07-26')
     expect((r.data.bibleClass[0] as any).Topic).toBe('Daily readings')

--- a/packages/app/utils/redact-schedule.ts
+++ b/packages/app/utils/redact-schedule.ts
@@ -15,7 +15,11 @@
 import { canRevealPii, firstNameOf, type Viewer, type Channel } from './viewer-pii'
 
 // Keys whose value is a person's full-name string (across memorial/bibleClass/
-// sundaySchool/cyc rows). Verified against live schedule data.
+// sundaySchool/cyc rows). Verified against the live raw sheet data (tee-schedules).
+// NB: 'Reader 1/2' are PEOPLE; 'Reading 1/2' are Bible passages — do NOT add those.
+// (Reader/Prayer roles are usually filled live at the service, so often blank — but
+// they still carry a full name when set, hence redacted.) This denylist is
+// inherently sheet-specific; the name→member resolver will make it structural.
 const PERSON_KEYS = new Set([
   'Preside',
   'Exhort',
@@ -28,6 +32,13 @@ const PERSON_KEYS = new Set([
   'Speaker',
   'Refreshments',
   'speaker', // cyc
+  'Reader 1',
+  'Reader 2',
+  'Prayer - Bread',
+  'Prayer - Wine',
+  'Prayer - closing',
+  'Organize slides',
+  'Hall Sound (Youtube)',
 ])
 
 // Precise-location keys → dropped for anon (host ecclesia street address / map link).


### PR DESCRIPTION
Phase 0 follow-up. The schedule redactor's `PERSON_KEYS` was derived from the TS type, but the **live memorial sheet has more person-name columns** than the type declares — `Reader 1/2`, `Prayer - Bread/Wine/closing`, `Organize slides`, `Hall Sound (Youtube)`. Those leaked full names to anon when filled. (They're usually filled *live at the service*, so often blank — but redacted for when set.)

- Added those keys to first-name redaction.
- **Careful:** `Reading 1/2` are Bible passages, not people → left untouched (test asserts this).
- Noted: this denylist is inherently sheet-specific; the upcoming name→member resolver will make redaction structural (redact by resolved identity, not by guessing column names).

8 unit tests green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)