### PR TITLE
fix(email): render Newsletter server-safe for App Router (scheduler)

### DIFF
--- a/apps/email-builder/emails/Newsletter.tsx
+++ b/apps/email-builder/emails/Newsletter.tsx
@@ -16,8 +16,9 @@ import React from 'react'
 import { BibleClassType, MemorialServiceType, ProgramsTypes, SundaySchoolType } from '@my/app/types'
 import { Event } from '@my/app/types/events'
 import type { NewsItem } from '@my/app/types/news'
-import { Footer } from '../components/Footer'
-import { EmailBrandLink } from '../components/EmailBrandLink'
+import { FooterContent } from '../components/FooterContent'
+import { EmailBrandLinkContent } from '../components/EmailBrandLinkContent'
+import type { EmailIdentity } from '@my/app/types/brand-profile'
 import { AutoLinkText } from '../components/AutoLinkText'
 import { ReplacementEventCard, findReplacementEvent } from '../components/ReplacementEventCard'
 
@@ -689,6 +690,12 @@ interface EmailNewsletterProps {
     memorial?: ServiceTimeDisplay
     bibleClass?: ServiceTimeDisplay
   }
+  /**
+   * Brand identity for the footer/header links. Passed as a PROP (not via the
+   * `'use client'` EmailIdentityProvider context) so this template renders from an
+   * App Router server route (the email-queue cron processor) — mirrors NewsAlert.
+   */
+  identity?: EmailIdentity
 }
 
 const Newsletter: React.FC<EmailNewsletterProps> = ({
@@ -698,6 +705,7 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
   note,
   newsItems = [],
   serviceTimes,
+  identity,
 }) => {
   const todaysDate = new Date().toLocaleDateString('en-US', {
     weekday: 'short',
@@ -841,7 +849,7 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
             <br />
             All plans are subject to God's will.
           </Text>
-          <EmailBrandLink />
+          <EmailBrandLinkContent identity={identity} />
         </Section>
 
         {/* Optional Note Section */}
@@ -2361,7 +2369,7 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
           </Container>
         )}
 
-        <Footer />
+        <FooterContent identity={identity} />
       </Body>
     </Html>
   )

--- a/apps/next/utils/email/get-email-content.tsx
+++ b/apps/next/utils/email/get-email-content.tsx
@@ -261,31 +261,21 @@ export const getEmailContent = async (
         },
       }
 
-      const newsletterHtmlContent = await render(
-        withIdentity(
-          <Newsletter
-            scheduleEvents={scheduleData as (MemorialServiceType | BibleClassType | SundaySchoolType)[]}
-            upcomingEvents={upcomingEvents}
-            readings={readingsData}
-            note={note}
-            newsItems={newsletterNewsItems}
-            serviceTimes={newsletterServiceTimes}
-          />
-        )
+      // Identity passed as a PROP (not the client EmailIdentityProvider context) so
+      // this renders from an App Router server route (the email-queue cron processor).
+      const newsletterEl = (
+        <Newsletter
+          scheduleEvents={scheduleData as (MemorialServiceType | BibleClassType | SundaySchoolType)[]}
+          upcomingEvents={upcomingEvents}
+          readings={readingsData}
+          note={note}
+          newsItems={newsletterNewsItems}
+          serviceTimes={newsletterServiceTimes}
+          identity={emailIdentity}
+        />
       )
-      const newsletterTextContent = await render(
-        withIdentity(
-          <Newsletter
-            scheduleEvents={scheduleData as (MemorialServiceType | BibleClassType | SundaySchoolType)[]}
-            upcomingEvents={upcomingEvents}
-            readings={readingsData}
-            note={note}
-            newsItems={newsletterNewsItems}
-            serviceTimes={newsletterServiceTimes}
-          />
-        ),
-        { plainText: true }
-      )
+      const newsletterHtmlContent = await render(newsletterEl)
+      const newsletterTextContent = await render(newsletterEl, { plainText: true })
       return [newsletterHtmlContent, newsletterTextContent]
     case 'business-meeting':
       // If meetingId is provided, use the new MeetingEmail template


### PR DESCRIPTION
Found while testing the DB email scheduler end-to-end: the App-Router cron processor (`/api/cron/email-queue`) renders the newsletter via `getEmailContent`, which failed at runtime:

> `Attempted to call EmailIdentityProvider() from the server but EmailIdentityProvider is on the client.`

The `Newsletter` template used the **hook-based** `Footer`/`EmailBrandLink` (which read the `'use client'` `EmailIdentityProvider` context). An App-Router **server** route can't invoke a client component, so **every scheduled newsletter would silently fail**. (The existing Wed/Sat crons go through the *Pages* router, which has no RSC boundary, so they were unaffected.)

## Fix (mirrors the already-working `NewsAlert`)
- `Newsletter` now takes `identity?: EmailIdentity` as a **prop** and uses the server-safe `FooterContent` / `EmailBrandLinkContent` instead of the hook-based components.
- `get-email-content` passes `identity={emailIdentity}` as a prop for the newsletter render instead of wrapping in the client `EmailIdentityProvider`.

## Verified
Typecheck clean; no hook-based footer refs remain in `Newsletter`. Runtime confirmation to follow post-deploy: re-run the scheduler processor against a seeded test-mode schedule and confirm `sent: 1` (was `errors: 1` with the above message).

Context: the EventBridge scheduler (rule → API destination → processor) is now live and verified delivering; this render fix is the last blocker to scheduled newsletters actually sending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)