### PR TITLE
fix: redact SSR schedule PII (public /schedule) + prominent Sign-In nav CTA

### DIFF
--- a/apps/next/utils/schedule-data.ts
+++ b/apps/next/utils/schedule-data.ts
@@ -6,6 +6,8 @@ import { getEcclesiaByName } from './dynamodb/locations'
 import type { GoogleSheetTypes, GoogleSheetData } from '@my/app/types'
 import type { EnhancedScheduleEvent } from '@my/ui/src/data-table/enhanced-schedule-responsive'
 import { CACHE_TAGS } from './cache'
+import { redactScheduleData } from '@my/app/utils/redact-schedule'
+import { ANONYMOUS_VIEWER } from '@my/app/utils/viewer-pii'
 
 // ── Helpers ──
 
@@ -183,7 +185,14 @@ async function fetchScheduleTab(tab: string): Promise<{
   const futureEvents = events.filter((e) => e.date >= todayStr)
   const hasOlder = futureEvents.length < events.length
 
-  return { events: futureEvents, hasOlder, lastUpdated: data.lastUpdated || new Date().toISOString() }
+  // The public /schedule page SERVER-RENDERS these events (the only consumer of
+  // getScheduleData). Redact to anonymous tier — first-name-only role assignments,
+  // drop host addresses — BEFORE they enter the unstable_cache wrapper, so the
+  // SSR'd HTML an anonymous visitor sees can't leak full names. (The /api/enhanced
+  // -schedule client re-fetch is already redacted; this closes the SSR path.)
+  const safeEvents = redactScheduleData(futureEvents, ANONYMOUS_VIEWER, 'public-web')
+
+  return { events: safeEvents, hasOlder, lastUpdated: data.lastUpdated || new Date().toISOString() }
 }
 
 // ── Cached variants — one per tab for independent invalidation ──

--- a/packages/app/features/simple-enhanced-navigation.tsx
+++ b/packages/app/features/simple-enhanced-navigation.tsx
@@ -8,7 +8,7 @@ import { brandColors } from '@my/ui/src/branding/brand-colors'
 import { NavitemLogout } from '@my/app/provider/auth/navItem-logout'
 import { ThemeToggle } from './theme-toggle'
 import { NotificationBell } from '@my/ui/src/notifications/notification-bell'
-import { Menu, X } from '@tamagui/lucide-icons'
+import { Menu, X, LogIn } from '@tamagui/lucide-icons'
 import { getBrand } from '@my/app/config/brand'
 
 type UserSession = {
@@ -170,14 +170,20 @@ export const SimpleEnhancedNavigation: React.FC<SimpleEnhancedNavigationProps> =
         </Button> : <Button
           onPress={navigateTo('/auth/signin')}
           backgroundColor={colors.primary}
-          padding="$2"
-          borderRadius="$2"
-          justifyContent="flex-start"
+          paddingVertical="$3"
+          paddingHorizontal="$3"
+          borderRadius="$3"
+          justifyContent="center"
+          gap="$2"
+          icon={<LogIn color={colors.primaryForeground} size={20} />}
           hoverStyle={{
             backgroundColor: colors.primaryHover,
           }}
+          pressStyle={{
+            backgroundColor: colors.primaryHover,
+          }}
         >
-          <Text fontSize="$3" fontWeight="600" color={colors.primaryForeground}>
+          <Text fontSize="$5" fontWeight="700" color={colors.primaryForeground}>
             Sign In
           </Text>
         </Button>}


### PR DESCRIPTION
Two fixes (bundled — small + safe):

## 1. Schedule SSR PII leak (the priority)
**Live leak** caught on https://www.tee-admin.com/schedule as an anon user: full last names in the schedules. Phase 0 redacted the `/api/enhanced-schedule` **endpoint** (works — prod returns `Preside: "Brad"`), but the public `/schedule` page is a **server component** that SSRs its initial data via `getScheduleData()` (`schedule-data.ts`) — a separate path reading raw data, bypassing the redacted API. So the server-rendered HTML (what anon + crawlers see) still had full names; only the client re-fetch was redacted.
**Fix:** redact `futureEvents` to anonymous tier inside `fetchScheduleTab`, before the `unstable_cache` wrapper. `getScheduleData`'s only consumer is the public (anon) schedule page.
Also confirmed the directory pages are NOT leaking — they're client-rendered behind auth and `/api/people` returns 401 to anon.

## 2. Sign-In nav visibility
The signed-out Sign In was a small left-aligned nav-item-looking link — easy to miss. Now a clear full-width centered CTA button (LogIn icon, larger bold text) at the top of the nav.

## Verified
`typecheck` clean. Nav screenshotted (prominent CTA confirmed). Schedule SSR redaction verified post-deploy.

## Lesson
Phase 0 verified the API endpoints but not the rendered pages — `/schedule` SSRs via a separate util. Verify rendered pages, not just APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)