### PR TITLE
fix: domain-aware sign-in title + bust stale schedule PII cache

### DIFF
--- a/apps/next/app/auth/signin/page.tsx
+++ b/apps/next/app/auth/signin/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { signIn, getSession } from 'next-auth/react'
 import { useHydrated } from '@my/app/hooks/use-hydrated'
+import { getBrand } from '@my/app/config/brand'
 import type { GestureResponderEvent } from 'react-native'
 
 import {
@@ -37,6 +38,11 @@ function SignInPageContent() {
   const [otpDigits, setOtpDigits] = useState(['', '', '', '', '', ''])
   const [resendCooldown, setResendCooldown] = useState(0)
   const inputRefs = useRef<(HTMLInputElement | null)[]>([])
+
+  // Domain-aware portal name, baked per deployment via NEXT_PUBLIC_BRAND (same
+  // source the nav uses): echadhub → "Echad Hub", tee → "TEE Portal". Build-time
+  // so there's no hydration flash.
+  const portalName = getBrand().secondary ?? getBrand().primary
 
   // Resend cooldown timer
   useEffect(() => {
@@ -325,7 +331,7 @@ function SignInPageContent() {
       <YStack gap="$2" alignItems="center">
         <Heading size="$8">Welcome Back</Heading>
         <Paragraph color="$gray11" textAlign="center">
-          Sign in to the TEE Portal
+          Sign in to {portalName}
         </Paragraph>
       </YStack>
 

--- a/apps/next/utils/schedule-data.ts
+++ b/apps/next/utils/schedule-data.ts
@@ -202,27 +202,32 @@ const cacheOptions = (tag: string) => ({
   revalidate: 300, // 5 min fallback
 })
 
+// NOTE: the `pii-v2` key suffix intentionally abandons the pre-redaction cache
+// entries. `fetchScheduleTab` now redacts to the anonymous tier, but Vercel's
+// Data Cache persists `unstable_cache` entries across deployments — the old keys
+// still held full names. Bumping the key forces a fresh, redacted entry. Bump
+// again if the cached shape ever changes in a way that could re-leak.
 export const getMemorialData = unstable_cache(
   () => fetchScheduleTab('memorial'),
-  ['schedule', 'memorial'],
+  ['schedule', 'memorial', 'pii-v2'],
   cacheOptions(CACHE_TAGS.SCHEDULES_MEMORIAL)
 )
 
 export const getBibleClassData = unstable_cache(
   () => fetchScheduleTab('bibleClass'),
-  ['schedule', 'bibleClass'],
+  ['schedule', 'bibleClass', 'pii-v2'],
   cacheOptions(CACHE_TAGS.SCHEDULES_BIBLE_CLASS)
 )
 
 export const getSundaySchoolData = unstable_cache(
   () => fetchScheduleTab('sundaySchool'),
-  ['schedule', 'sundaySchool'],
+  ['schedule', 'sundaySchool', 'pii-v2'],
   cacheOptions(CACHE_TAGS.SCHEDULES_SUNDAY_SCHOOL)
 )
 
 export const getCycData = unstable_cache(
   () => fetchScheduleTab('cyc'),
-  ['schedule', 'cyc'],
+  ['schedule', 'cyc', 'pii-v2'],
   cacheOptions(CACHE_TAGS.SCHEDULES_CYC)
 )
 


### PR DESCRIPTION
## What

Two small fixes:

1. **Sign-in title is now domain-aware.** `apps/next/app/auth/signin/page.tsx` hardcoded *"Sign in to the TEE Portal"*, which is wrong on **echadhub.org**. It now uses `getBrand()` (driven by `NEXT_PUBLIC_BRAND`, baked per deployment — the same source the nav already uses): **"TEE Portal"** on tee-admin, **"Echad Hub"** on echadhub. Build-time, so no hydration flash.

2. **Public `/schedule` PII leak (residual).** #103 added SSR redaction for anonymous visitors, but full last names were **still leaking**. Root cause: the redaction runs *inside* the events' `unstable_cache` wrapper, and Vercel's Data Cache persists those entries **across deployments** — so the pre-#103 (unredacted) entry kept being served. The `/api/enhanced-schedule` path was already fresh (uncached) and correctly redacted. Fix: bump the four `unstable_cache` keys to `pii-v2` to abandon the stale entries and force fresh, redacted ones.

## How verified

- `yarn workspace next-app typecheck` — clean.
- Confirmed live: `/api/enhanced-schedule` returns `Preside: "Brad"` (redacted) while SSR `/schedule` returned `"Brad Stephens"` (stale cache) — matches the diagnosis.
- Post-merge verification on prod (both effects need their production deployments): `tee-admin.com/schedule` → first names only; `tee-admin.com/auth/signin` → "TEE Portal"; `echadhub.org/auth/signin` → "Echad Hub".

## Self-review notes
- Redaction stays *inside* the cache (defense in depth: the public cache never holds full names). Added a comment explaining the `pii-v2` key and when to bump again.
- No behavior change for authorized viewers — the client re-fetches full data via the (authz'd) API after hydration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)