### PR TITLE
fix(profile): label ecclesia field + stop 'Unknown' sentinel leaking to UI

### DIFF
--- a/packages/app/features/banner.tsx
+++ b/packages/app/features/banner.tsx
@@ -10,7 +10,10 @@ type BannerProps = {
 export const Banner: React.FC<BannerProps> = ({ pageTitle }) => {
   const media = useMedia()
   const brand = getBrand()
-  const ecclesia = useHeaderEcclesia()
+  const rawEcclesia = useHeaderEcclesia()
+  // 'Unknown' is the stored sentinel for "no ecclesia set" (see person-repository);
+  // treat it as unset so it never surfaces as a title.
+  const ecclesia = rawEcclesia && rawEcclesia !== 'Unknown' ? rawEcclesia : null
   // Signed-in user's home ecclesia wins; otherwise the brand's default title
   // (Toronto East Ecclesia for tee, Echad Hub for the generic hub).
   const title = ecclesia || brand.headerTitle

--- a/packages/app/features/profile/user-profile.tsx
+++ b/packages/app/features/profile/user-profile.tsx
@@ -72,6 +72,10 @@ interface ContactRequest {
   createdAt: string
 }
 
+/** 'Unknown' is the stored placeholder for an unset ecclesia; treat it as empty. */
+const normalizeEcclesia = (value?: string): string =>
+  value && value !== 'Unknown' ? value : ''
+
 export const UserProfile: React.FC<UserProfileProps> = ({
   userEmail,
   userName,
@@ -92,7 +96,10 @@ export const UserProfile: React.FC<UserProfileProps> = ({
   const [contactRequests, setContactRequests] = useState<ContactRequest[]>([])
   const [activeTab, setActiveTab] = useState('contact')
   const [displayName, setDisplayName] = useState<string>(userName || '')
-  const [ecclesia, setEcclesia] = useState<string>(userEcclesia || '')
+  // 'Unknown' is the stored sentinel for "no ecclesia set" — normalize it (and
+  // any empty value) to '' everywhere so it never renders as a real ecclesia in
+  // the header, the display card, or the edit field.
+  const [ecclesia, setEcclesia] = useState<string>(normalizeEcclesia(userEcclesia))
   const [editingEcclesia, setEditingEcclesia] = useState(false)
   const [ecclesiaInput, setEcclesiaInput] = useState('')
   const [ecclesiaSuggestions, setEcclesiaSuggestions] = useState<Array<{ name: string; city: string; province: string }>>([])
@@ -178,7 +185,7 @@ export const UserProfile: React.FC<UserProfileProps> = ({
           setLastName(data.user.lastName)
         }
         if (data.user?.ecclesia) {
-          setEcclesia(data.user.ecclesia)
+          setEcclesia(normalizeEcclesia(data.user.ecclesia))
         }
       }
     } catch (error) {
@@ -602,18 +609,26 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                 <YStack gap="$3">
                   {editingName ? (
                     <Card padding="$3" backgroundColor="$backgroundHover">
-                      <YStack gap="$2">
-                        <Input
-                          value={firstNameInput}
-                          onChangeText={(text) => { setFirstNameInput(text); setNameError('') }}
-                          placeholder="First name"
-                          autoFocus
-                        />
-                        <Input
-                          value={lastNameInput}
-                          onChangeText={(text) => { setLastNameInput(text); setNameError('') }}
-                          placeholder="Last name"
-                        />
+                      <YStack gap="$3">
+                        <YStack gap="$1">
+                          <Text fontSize="$2" fontWeight="600">First name</Text>
+                          <Input
+                            value={firstNameInput}
+                            onChangeText={(text) => { setFirstNameInput(text); setNameError('') }}
+                            placeholder="e.g. Jane"
+                            aria-label="First name"
+                            autoFocus
+                          />
+                        </YStack>
+                        <YStack gap="$1">
+                          <Text fontSize="$2" fontWeight="600">Last name</Text>
+                          <Input
+                            value={lastNameInput}
+                            onChangeText={(text) => { setLastNameInput(text); setNameError('') }}
+                            placeholder="e.g. Smith"
+                            aria-label="Last name"
+                          />
+                        </YStack>
                         {nameError ? (
                           <Text fontSize="$2" color="$red10">{nameError}</Text>
                         ) : null}
@@ -653,12 +668,17 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                   {editingEcclesia ? (
                     <Card padding="$3" backgroundColor="$backgroundHover">
                       <YStack gap="$2" position="relative">
+                        <YStack gap="$1">
+                          <Text fontSize="$2" fontWeight="600">Home ecclesia</Text>
+                          <Text fontSize="$2" theme="alt2">Start typing to search the directory and select your ecclesia.</Text>
+                        </YStack>
                         <XStack position="relative">
                           <Input
                             flex={1}
                             value={ecclesiaInput}
                             onChangeText={handleEcclesiaInput}
-                            placeholder="Type ecclesia name..."
+                            placeholder="e.g. Toronto East"
+                            aria-label="Home ecclesia"
                             autoComplete="off"
                             autoFocus
                             onFocus={() => {


### PR DESCRIPTION
## What / why

On the **My Profile → Contact Info** tab (screenshot from the reporter):

1. **Unlabeled field (a11y).** The magnifying-glass autocomplete had *no label* — a placeholder-as-label WCAG violation, and users had no idea it edits their **ecclesia**.
2. **"Unknown" everywhere.** The literal word "Unknown" showed in the banner title, the "Role: member · Unknown" line, the display card, and inside the edit field. Root cause: `'Unknown'` is the backend sentinel for an *unset* ecclesia (see `person-repository`), and it was being rendered as if it were a real value.

## Changes

- **Ecclesia field** now has a visible **"Home ecclesia"** label + helper text (*"Start typing to search the directory…"*) + `aria-label`.
- **Name fields** (same card) get real **"First name" / "Last name"** labels + `aria-label`s; placeholders become examples (*"e.g. Jane"*) instead of standing in for labels.
- **`normalizeEcclesia()`** treats `'Unknown'`/empty as unset at the state boundary → edit field shows its placeholder, display card shows **"No ecclesia set"**, and the "Role" chip hides.
- **Banner** (`banner.tsx`): `'Unknown'` no longer wins over the brand default — falls back to **"Toronto East Ecclesia"** on tee-admin / **"Echad Hub"** on echadhub.

## Verification

- `yarn workspace next-app typecheck` — clean.
- `eslint` on both files — clean (`jsx-no-leaked-render` etc.).
- `yarn workspace next-app build` — **exit 0** (Tamagui static extraction of the shared `packages/app` component succeeds).
- ⚠️ **Not exercised in a live authed session** — this screen is gated to the reporter's account (`teerecbro@gmail.com`, no ecclesia set), which I can't log in as. Please click through the **preview deploy** to confirm the labels render and the "Unknown"s are gone. The logic is pure display normalization, so risk is low.

## Self-review notes
- Sentinel normalization is centralized in one helper and applied at both the initial state and the profile-fetch setter, so a later `'Unknown'` from the API can't re-introduce it.
- Banner guard mirrors the same sentinel check; covers web + Expo (shared component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)