### PR TITLE
fix(pii): redact schedule/events per viewer, not always-anonymous

### DIFF
--- a/apps/next/app/api/enhanced-schedule/route.ts
+++ b/apps/next/app/api/enhanced-schedule/route.ts
@@ -8,7 +8,8 @@ import { resolveServiceTime } from '@my/app/config/service-time-resolver'
 import type { ScheduleTypeKey } from '@my/app/config/schedule-fields'
 import { getEcclesiaByName } from '../../../utils/dynamodb/locations'
 import { redactScheduleData } from '@my/app/utils/redact-schedule'
-import { ANONYMOUS_VIEWER } from '@my/app/utils/viewer-pii'
+import { resolveViewer } from '../../../utils/resolve-viewer'
+import { piiAwareCacheControl } from '../../../utils/pii-response'
 
 // Map Google Sheet type names to schedule type keys
 const SHEET_TO_SCHEDULE_KEY: Record<string, ScheduleTypeKey> = {
@@ -492,13 +493,17 @@ export async function GET(request: NextRequest) {
     
     // Public (CDN-cached) schedule endpoint → anonymous tier. Reduce role-assignment
     // names to first-name-only and drop precise host addresses BEFORE caching, so the
-    // shared cache can't serve full names to anon. Member-tier schedule (full names)
-    // is rendered into the newsletter email via the server-side path, not this route.
-    const safeData = redactScheduleData(responseData, ANONYMOUS_VIEWER, 'public-web')
+    // Redact per viewer: a signed-in member sees full names; anonymous visitors get
+    // first-name-only role assignments and no precise host addresses. PII-bearing
+    // (authenticated) responses are private/no-store so the shared/CDN cache only
+    // ever holds the anonymous-safe copy.
+    const viewer = await resolveViewer()
+    const safeData = redactScheduleData(responseData, viewer, 'public-web')
 
     // Set cache headers
     const response = NextResponse.json(safeData)
-    response.headers.set('Cache-Control', 'public, max-age=300, s-maxage=600') // 5min client, 10min CDN
+    response.headers.set('Cache-Control', piiAwareCacheControl(viewer, 'public, max-age=300, s-maxage=600')) // anon: 5min client, 10min CDN
+    response.headers.set('Vary', 'Cookie')
     response.headers.set('X-Data-Source', 'enhanced-schedule-api')
     response.headers.set('X-Schedule-Source', 'dynamodb-only')
     

--- a/apps/next/app/api/events/public/route.ts
+++ b/apps/next/app/api/events/public/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { unstable_cache } from 'next/cache'
 import { getPublishedEvents } from '@my/app/services/event-service'
 import { redactEventsForViewer } from '@my/app/utils/redact-event'
-import { ANONYMOUS_VIEWER } from '@my/app/utils/viewer-pii'
+import { resolveViewer } from '@/utils/resolve-viewer'
+import { piiAwareCacheControl } from '@/utils/pii-response'
 import { CACHE_TAGS } from '@/utils/cache'
 
 // Cache duration: revalidate daily at midnight (86400 seconds = 24 hours)
@@ -13,15 +14,16 @@ const CACHE_DURATION = process.env.NODE_ENV === 'production' ? 86400 : false
 const getCachedPublishedEvents = unstable_cache(
   async () => {
     console.log('🔄 Cache miss - fetching fresh events from DynamoDB')
-    const events = await getPublishedEvents()
-    // This endpoint is unauthenticated → anonymous tier. Redact PII server-side
-    // BEFORE it enters the response cache, so the cache literally cannot hold (and
-    // this route cannot leak) last names, street addresses, bios, or contact
-    // details. Full data is served to members via authenticated endpoints; the
-    // newsletter EMAIL renders member-tier via its own channel (see redact-event).
-    return redactEventsForViewer(events, ANONYMOUS_VIEWER, 'public-web')
+    // Cache the RAW events; redaction is applied PER REQUEST in the handler so a
+    // signed-in member sees full names while anonymous visitors are scrubbed. The
+    // shared Data Cache holds full data (server-side only, never served directly),
+    // and every response goes through redactEventsForViewer before it leaves. PII-
+    // bearing (authenticated) responses are marked private/no-store so the CDN
+    // never caches a full-name copy. Key bumped to 'raw-v1' to abandon the old
+    // pre-redacted entries that Vercel's Data Cache persists across deploys.
+    return getPublishedEvents()
   },
-  ['published-events'],
+  ['published-events', 'raw-v1'],
   {
     tags: [
       CACHE_TAGS.EVENTS_PUBLIC,
@@ -46,7 +48,13 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams
     const eventId = searchParams.get('id')
 
-    const events = await getCachedPublishedEvents()
+    // Redact per viewer: signed-in members see full names, anonymous visitors are
+    // scrubbed. `Vary: Cookie` + private/no-store on PII responses keeps the shared
+    // cache anonymous-only.
+    const viewer = await resolveViewer()
+    const rawEvents = await getCachedPublishedEvents()
+    const events = redactEventsForViewer(rawEvents, viewer, 'public-web')
+    const publicCache = `public, max-age=${CACHE_DURATION}, stale-while-revalidate=300`
 
     if (eventId) {
       const event = events.find(e => e.id === eventId)
@@ -55,7 +63,8 @@ export async function GET(request: NextRequest) {
       }
       return NextResponse.json(event, {
         headers: {
-          'Cache-Control': `public, max-age=${CACHE_DURATION}, stale-while-revalidate=300`,
+          'Cache-Control': piiAwareCacheControl(viewer, publicCache),
+          'Vary': 'Cookie',
           'X-Data-Source': 'dynamodb-cache',
           'X-Cache-Tags': [CACHE_TAGS.EVENTS_PUBLIC, CACHE_TAGS.EVENTS_ALL].join(','),
         }
@@ -66,7 +75,8 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(events, {
       headers: {
-        'Cache-Control': `public, max-age=${CACHE_DURATION}, stale-while-revalidate=300`,
+        'Cache-Control': piiAwareCacheControl(viewer, publicCache),
+        'Vary': 'Cookie',
         'X-Data-Source': 'dynamodb-cache',
         'X-Event-Count': events.length.toString(),
         'X-Cache-Tags': [CACHE_TAGS.EVENTS_PUBLIC, CACHE_TAGS.EVENTS_ALL].join(','),

--- a/apps/next/app/api/upcoming-program/route.ts
+++ b/apps/next/app/api/upcoming-program/route.ts
@@ -5,7 +5,8 @@ import { ProgramTypeKeys } from '@my/app/types'
 import { CACHE_TAGS } from '../../../utils/cache'
 import { getEcclesiaByName } from '../../../utils/dynamodb/locations'
 import { redactScheduleData } from '@my/app/utils/redact-schedule'
-import { ANONYMOUS_VIEWER } from '@my/app/utils/viewer-pii'
+import { resolveViewer } from '../../../utils/resolve-viewer'
+import { piiAwareCacheControl } from '../../../utils/pii-response'
 
 // Cache for 15 minutes in production (shorter for faster updates when debugging)
 const CACHE_DURATION = process.env.NODE_ENV === 'production' ? 900 : 0
@@ -113,15 +114,18 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Only live consumer is the anonymous web newsletter screen → anonymous tier.
-    // First-name-only role assignments, drop host addresses, BEFORE the shared
-    // `public` cache. The member-tier newsletter EMAIL sources full names via the
-    // server-side get_upcoming_program() path, not this route (see get-email-content).
-    const safeData = redactScheduleData(responseData, ANONYMOUS_VIEWER, 'public-web')
+    // Redact per viewer: a signed-in member sees full names, anonymous visitors get
+    // first-name-only role assignments and no host addresses. The unstable_cache
+    // above holds RAW data; redaction happens here per request. PII-bearing
+    // (authenticated) responses are marked private/no-store so the shared/CDN cache
+    // only ever holds the anonymous-safe copy.
+    const viewer = await resolveViewer()
+    const safeData = redactScheduleData(responseData, viewer, 'public-web')
 
     return NextResponse.json(safeData, {
       headers: {
-        'Cache-Control': `public, max-age=${CACHE_DURATION}, stale-while-revalidate=300`,
+        'Cache-Control': piiAwareCacheControl(viewer, `public, max-age=${CACHE_DURATION}, stale-while-revalidate=300`),
+        'Vary': 'Cookie',
         'X-Data-Source': 'dynamodb-cache',
         'X-Event-Count': upcomingEvents.length.toString(),
         'X-Cache-Tags': [CACHE_TAGS.UPCOMING_PROGRAM, CACHE_TAGS.ALL_SCHEDULE_DATA, CACHE_TAGS.ALL_API_RESPONSES].join(','),

--- a/apps/next/utils/pii-response.ts
+++ b/apps/next/utils/pii-response.ts
@@ -1,0 +1,22 @@
+import { canRevealPii, type Viewer, type Channel } from '@my/app/utils/viewer-pii'
+
+/**
+ * Cache-Control for a per-viewer, PII-redacted API response.
+ *
+ * When the viewer can see PII (authenticated member+), the payload carries full
+ * names / addresses and MUST NOT land in any shared or CDN cache — otherwise a
+ * later ANONYMOUS request could be served the cached full-name copy (cache
+ * poisoning → the exact PII leak the redaction exists to prevent). Anonymous and
+ * recognized responses are already redacted, so they stay publicly cacheable.
+ *
+ * Pass the `publicValue` you'd use for an anonymous response; a PII-bearing
+ * viewer gets `private, no-store` instead. Keep this the single source of truth
+ * for that decision so every viewer-aware endpoint stays consistent.
+ */
+export function piiAwareCacheControl(
+  viewer: Viewer,
+  publicValue: string,
+  channel: Channel = 'public-web'
+): string {
+  return canRevealPii(viewer, channel) ? 'private, no-store' : publicValue
+}


### PR DESCRIPTION
## Problem

A signed-in member was seeing **first-name-only** role assignments and speaker names on the home / newsletter / schedule surfaces (reported: Bible School speakers "Jochem, Christian" with last names stripped, while logged in). The three public API routes hardcoded `ANONYMOUS_VIEWER` for redaction, so **everyone** — even authenticated members — got the anonymous tier.

## Fix

Redact against the **actual viewer** via the existing `resolveViewer()` (session → `authenticated` + real role; ecclesia token → `recognized`; neither → `anonymous`). Members get full names; anonymous visitors stay scrubbed.

### Cache safety (the important part)
These are `Cache-Control: public` routes. Naively returning full names to a member would let the **CDN cache the full-name response and serve it to anonymous users** — re-introducing the exact PII leak. New `piiAwareCacheControl()` marks any PII-bearing (authenticated) response **`private, no-store`** while anonymous responses stay `public`; every response also sends `Vary: Cookie`. Net: the shared cache only ever holds the anonymous-safe copy.

- **events/public**: redaction moved OUT of `unstable_cache` (cache RAW events, redact per request). Cache key bumped to `raw-v1` to abandon the stale pre-redacted entries Vercel's Data Cache persists across deploys.
- **upcoming-program / enhanced-schedule**: cache already held raw data — swapped the hardcoded `ANONYMOUS_VIEWER` for `resolveViewer()` + viewer-aware `Cache-Control`.

## Verification (end-to-end on the running dev server, all three endpoints)

Drove real requests via the `DEV_AUTH_SERVER_KEY` bearer hook (owner session):

| Endpoint | Anonymous | Authenticated (owner) |
|---|---|---|
| events/public | `Jochem`, `Christian` + `public` | `Jochem Hale`, `Christian Russell` + **`private, no-store`** |
| upcoming-program | `Brad`, `Ken`, `Esther` + `public` | `Brad Stephens`, `Ken Easson`, `Esther Dawes` + **`private, no-store`** |
| enhanced-schedule | `Brad`, `Dennis`, `Ken` + `public` | `Brad Stephens`, `Dennis Dawes`, `Ken Easson` + **`private, no-store`** |

Typecheck clean. The anonymous no-leak direction (the safety-critical one) was confirmed on the running app **before** the authenticated path.

## Self-review notes
- Single source of truth for the cache decision (`piiAwareCacheControl`) so no endpoint can get it subtly wrong.
- `resolveViewer()` short-circuits to `ANONYMOUS_VIEWER` before any DB lookup for anon requests, so the common public path adds no PersonRecord read.
- Not touched: the `/schedule` **SSR** page still renders anonymous-tier server-side (safe default) and the client re-fetches `enhanced-schedule` (now viewer-aware) after hydration — so an authed user gets full names post-hydration. Can make the SSR viewer-aware in a follow-up if the brief flash matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)