### PR TITLE
fix(email-scheduler): send at scheduled time (not 2h early) + harden toggle

### DIFF
--- a/apps/next/app/api/cron/email-queue/route.ts
+++ b/apps/next/app/api/cron/email-queue/route.ts
@@ -34,6 +34,15 @@ export async function GET(req: NextRequest) {
 
     console.log(`🕐 Cron job running at ${currentDate} ${currentTime} (${currentDay}) Toronto time`)
 
+    // How early the queue entry may be materialized, and how late a missed/
+    // backed-up cron may still catch up. The send gate itself NEVER fires before
+    // the scheduled minute (see Step 3) — a 2:00 PM schedule sends at 2:00 PM, not
+    // 12:00 PM. The cron ticks every ~5 min, so the first tick at/after the
+    // scheduled minute sends it. SEND_GRACE_MIN bounds same-day catch-up so a late
+    // cron doesn't surprise-send hours later.
+    const QUEUE_LEAD_MIN = 120 // materialize the entry up to 2h before send time
+    const SEND_GRACE_MIN = 180 // send from the scheduled minute through +3h, then skip for the day
+
     const response = {
       processed: {
         sent: 0,
@@ -66,9 +75,12 @@ export async function GET(req: NextRequest) {
         const scheduleMinutes = scheduleHour * 60 + scheduleMinute
         const currentMinutes = torontoTime.getHours() * 60 + torontoTime.getMinutes()
 
-        // Queue if we're within 2 hours of send time and haven't queued yet
+        // Materialize the entry from QUEUE_LEAD_MIN before send time through the
+        // send-grace window, so a 'ready' entry exists whenever the send gate is
+        // open. Queuing early is harmless — the entry just waits; Step 3 gates the
+        // actual send to at/after the scheduled minute.
         const timeUntilSend = scheduleMinutes - currentMinutes
-        if (timeUntilSend <= 120 && timeUntilSend > -120) { // 2 hours before to 2 hours after (extended for testing)
+        if (timeUntilSend <= QUEUE_LEAD_MIN && timeUntilSend >= -SEND_GRACE_MIN) {
           const existing = await sendQueueRepo.getQueueEntry(
             schedule.emailType,
             currentDate,
@@ -111,9 +123,11 @@ export async function GET(req: NextRequest) {
       const emailMinutes = emailHour * 60 + emailMinute
       const currentMinutes = torontoTime.getHours() * 60 + torontoTime.getMinutes()
 
-      // Send if it's time (within 2 hours of scheduled time for testing)
-      const timeDiff = Math.abs(emailMinutes - currentMinutes)
-      return timeDiff <= 120 // Extended to 2 hours for testing
+      // Send only AT or AFTER the scheduled minute — never early. Bounded by
+      // SEND_GRACE_MIN so a missed/backed-up cron can still catch up the same day
+      // without surprise-sending hours late.
+      const minutesLate = currentMinutes - emailMinutes
+      return minutesLate >= 0 && minutesLate <= SEND_GRACE_MIN
     })
 
     console.log(`📮 Found ${emailsToSend.length} emails ready to send`)

--- a/packages/app/features/schedule-emails/index.tsx
+++ b/packages/app/features/schedule-emails/index.tsx
@@ -483,7 +483,7 @@ export const ScheduleEmails: React.FC<ScheduleEmailsProps> = () => {
                           {schedule.enabled ? 'Auto Send: On' : 'Auto Send: Off'}
                         </Text>
                         <Switch
-                          checked={schedule.enabled}
+                          checked={!!schedule.enabled}
                           onCheckedChange={() => toggleSchedule(schedule.emailType)}
                           size="$4"
                           backgroundColor={schedule.enabled ? colors.success : colors.backgroundTertiary}
@@ -494,7 +494,7 @@ export const ScheduleEmails: React.FC<ScheduleEmailsProps> = () => {
                             backgroundColor={colors.background}
                             borderWidth={1}
                             borderColor={schedule.enabled ? colors.success : colors.textSecondary}
-                            animation="bouncy"
+                            animation="quick"
                           />
                         </Switch>
                       </YStack>


### PR DESCRIPTION
## Context
Reported: the "Thursday 2:00 PM" newsletter arrived at **12:04 PM** (~2h early), and the toggle showed green but the knob didn't slide.

## 1. Timing — sent 2 hours early (the real bug)
The cron processor (`/api/cron/email-queue`) used a **±120-minute "extended for testing" window** in *both* the queue and send steps, so a 2:00 PM schedule was eligible to send from **12:00 PM**. The AWS EventBridge rule `tee-email-cron` fires every 5 minutes, so the first tick after noon sent it at ~12:04. Timezone handling (America/Toronto) was already correct — the window was the bug, exactly matching "not a UTC delta."

**Fix:** the send gate now fires only **at or after** the scheduled minute, bounded by `SEND_GRACE_MIN` (3h) for same-day catch-up if a cron tick was missed. The entry still materializes up to `QUEUE_LEAD_MIN` (2h) early and waits.

Verified by boundary check:
```
12:04 -> skip   13:59 -> skip   14:00 -> SEND   14:04 -> SEND
16:59 -> SEND   17:00 -> SEND   17:05 -> skip   19:00 -> skip
```

## 2. Auto Send toggle
Coerced `checked` to a real boolean and switched the thumb `animation` to `"quick"` (matching the proven-working toggle in `schedule-config-editor.tsx`).

**Note on repro:** I could not reproduce the stuck-thumb in dev, a local prod build of the simplified markup, **or** a local prod build of the real component (all render the knob correctly on the right). It only appears on the *deployed* site — the signature of **stale extracted CSS** in the current deployment. This change forces a fresh Tamagui extraction of the component on redeploy, which should regenerate the correct rule; a hard-refresh clears any browser-cached stylesheet.

## Not included (asked about, worth a follow-up)
The "Email Queue Status" tiles count **queue entries with no date filter**, so "Completed: 2" is cumulative all-time (today's send + a leftover Oct-2025 test), and the per-schedule "N sent" is an *entry* count, not recipients. Today's test went to **1 recipient**. Happy to scope those counts to a recent window and relabel "sent" → "runs" in a follow-up.

## Verification
- Boundary arithmetic for the send gate (above).
- `typecheck` clean (ignoring stale `.next/types` from a deleted local scratch route).
- Timing fix compiles in a full `next build` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)