### PR TITLE
feat(subscribe): canonical /subscribe entry point for #75

### DIFF
--- a/apps/next/app/(public)/subscribe/page.tsx
+++ b/apps/next/app/(public)/subscribe/page.tsx
@@ -1,0 +1,19 @@
+import { redirect } from 'next/navigation'
+
+/**
+ * Canonical public subscription URL from issue #75 ("/subscribe").
+ *
+ * The self-serve preference UI ships at `/email-preferences` (the footer link
+ * target); `/subscribe` is the friendly, memorable public entry point named in
+ * the issue — e.g. a cold "find your ecclesia → pick Newsletter" visitor typing
+ * it in. It forwards to the real page, preserving the one-click-login `token`
+ * so an emailed link that lands here still identifies the recipient.
+ */
+export default async function SubscribePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ token?: string }>
+}) {
+  const { token } = await searchParams
+  redirect(token ? `/email-preferences?token=${encodeURIComponent(token)}` : '/email-preferences')
+}


### PR DESCRIPTION
## Context — most of #75 is already on `main`

Issue #75 (custom scoped self-serve subscription page replacing the SES hosted preference link) is **substantively already implemented and merged** on `main`, shipped as **`/email-preferences`** (the owner confirmed manual verification in the issue thread). That existing implementation already satisfies the issue's scope and its critical SES-safety rules:

- **Scoped, allow-listed topics only.** `apps/next/utils/email/public-topics.ts` defines `PUBLIC_TOPICS = ['newsletter','memorial','bibleClass','sundaySchool']`. The page and API expose only these — `interEcclesia` (Recording-Brother office), `members`, and `testList` are never shown or writable.
- **Server-side allow-list on write.** `apps/next/app/api/subscribe/route.ts` `POST` starts from the contact's existing `TopicPreferences` and mutates **only** keys in `PUBLIC_TOPICS`, preserving every office/membership topic verbatim.
- **SES-safe.** Uses per-contact `UpdateContactCommand` only — no `update-contact-list` / `create-contact` / `delete-contact` (the destructive list-level ops). Account-level suppression is untouched.
- **Token-authenticated + public.** Reuses the `/ecclesia-contact` ecclesia-token pattern (`verifyEcclesiaToken`) for recognized identity, plus a live session for authenticated identity, plus a cold "email me a link" path. Recognized (token-only) callers get masked email and read-only toggles until they step up (sign in) before any write.
- **Footer link swapped.** Email footer now points at `{{emailPreferencesUrl}}` → `/email-preferences` (`apps/next/utils/email/email-send.tsx`, `apps/email-builder/components/FooterContent.tsx`), not `{{amazonSESUnsubscribeUrl}}`.

## What this PR changes

The only literal gap versus the issue was its **named canonical URL, `/subscribe`**. This PR adds a single server component, `apps/next/app/(public)/subscribe/page.tsx`, that redirects to `/email-preferences`, preserving the `token` query param. It gives cold "find your ecclesia → pick Newsletter" visitors the memorable URL the issue specified without duplicating any of the preference logic.

## Why a redirect, not a new page

Building a second full preference page would duplicate already-merged, owner-verified functionality (and risk the two drifting on the security-critical allow-list). A thin alias keeps one source of truth.

## How verified

- `yarn workspace next-app typecheck` — no new errors; only the pre-existing, unrelated `occurrenceDate` errors in `utils/get-upcoming-program.tsx` remain.
- Reviewed the existing `/email-preferences` page + `/api/subscribe` route to confirm they already meet #75's scope and SES-safety rules (see above).

## NOT verified

- **UI not exercised** — did not run the app or click through `/subscribe` → `/email-preferences` in a browser. The redirect is a standard Next.js `redirect()` server component preserving `?token=`.
- Did not re-verify the owner's end-to-end SES round-trip (send → click footer → toggle → save); that was manually validated by the owner per the issue thread.

Refs #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)