### PR TITLE
feat(events): make "no in-person services" email message admin-configurable (#45)

### DIFF
--- a/apps/email-builder/components/ReplacementEventCard.tsx
+++ b/apps/email-builder/components/ReplacementEventCard.tsx
@@ -11,6 +11,7 @@ import React from 'react'
 import { Column, Link, Row, Text } from '@react-email/components'
 import type { Event, LocationInfo } from '@my/app/types/events'
 import { getPlatformDisplayName } from '@my/app/types/events'
+import { resolveNoInPersonServicesMessage } from '@my/app/config/service-messages'
 import { defaultText, link } from '../styles'
 import { AutoLinkText } from './AutoLinkText'
 
@@ -142,7 +143,7 @@ export const ReplacementEventCard: React.FC<ReplacementEventCardProps> = ({
   return (
     <>
       <Text style={defaultText}>
-        <strong>There will be no IN PERSON Services at Toronto East, Zoom and YouTube will remain unchanged.</strong>
+        <strong>{resolveNoInPersonServicesMessage(event.noInPersonServicesMessage)}</strong>
         {explanation ? (
           <>
             <br />

--- a/apps/email-builder/emails/Memorial.tsx
+++ b/apps/email-builder/emails/Memorial.tsx
@@ -32,6 +32,7 @@ import { EmailBrandLinkContent } from '../components/EmailBrandLinkContent'
 import { AutoLinkText } from '../components/AutoLinkText'
 import type { EmailIdentity } from '@my/app/types/brand-profile'
 import { ReplacementEventCard, findReplacementEvent } from '../components/ReplacementEventCard'
+import { resolveNoInPersonServicesMessage } from '@my/app/config/service-messages'
 
 function getNextDayOfTheWeek(dayName: string, excludeToday = true, refDate = new Date()): Date {
   const dayOfWeek = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'].indexOf(
@@ -367,7 +368,7 @@ const MemorialServiceProgram = (event: SundayEvents, upcomingEvents?: Event[]) =
     // Fallback: no matching event found, show simple "no service" message
     return (
       <Text style={defaultText}>
-        <strong>There will be no service at our hall.</strong>
+        <strong>{resolveNoInPersonServicesMessage()}</strong>
         {explanation ? (
           <>
             <br />

--- a/apps/email-builder/emails/Newsletter.tsx
+++ b/apps/email-builder/emails/Newsletter.tsx
@@ -21,6 +21,7 @@ import { EmailBrandLinkContent } from '../components/EmailBrandLinkContent'
 import type { EmailIdentity } from '@my/app/types/brand-profile'
 import { AutoLinkText } from '../components/AutoLinkText'
 import { ReplacementEventCard, findReplacementEvent } from '../components/ReplacementEventCard'
+import { resolveNoInPersonServicesMessage } from '@my/app/config/service-messages'
 
 type SundayEvents = MemorialServiceType &
   Pick<SundaySchoolType, 'Refreshments' | 'Holidays and Special Events'>
@@ -2401,10 +2402,11 @@ const MemorialServiceProgram = (event: SundayEvents, upcomingEvents?: Event[]) =
       return <ReplacementEventCard event={replacementEvent} explanation={explanation} />
     }
 
-    // Fallback: no matching event found, show simple "no service" message
+    // Fallback: no matching event found. Use the same message source as the
+    // replacement-event path so the two can't diverge (issue #45).
     return (
       <Text style={defaultText}>
-        <strong>There will be no service at our hall.</strong>
+        <strong>{resolveNoInPersonServicesMessage()}</strong>
         {explanation ? (
           <>
             <br />

--- a/packages/app/config/service-messages.ts
+++ b/packages/app/config/service-messages.ts
@@ -1,0 +1,40 @@
+/**
+ * "No in-person services" notice — shown in the Newsletter and Memorial (recap)
+ * emails and the app UI when the in-person Sunday services are cancelled (with or
+ * without a replacement event).
+ *
+ * Previously this wording was hardcoded in the email templates (issue #45), which
+ * meant a same-day wording change required a code change + PR + deploy, and could
+ * not vary per ecclesia. The message is now DATA:
+ *   1. Primary source: the admin sets it on the replacement event in the Event
+ *      Editor (`Event.noInPersonServicesMessage`).
+ *   2. Fallback: this default constant when unset.
+ *
+ * The default lives here — a single config constant, NOT baked into the template —
+ * so both the replacement-event path and the no-replacement fallback resolve
+ * against the same source and cannot diverge. This is also the seam where a
+ * per-tenant/per-ecclesia default plugs in (pass it as `fallback`).
+ *
+ * Kept dependency-free (no Node/Next imports) so it is safe to import from the
+ * react-email server render path and from shared cross-platform UI.
+ */
+
+/** Toronto East default. Kept as the existing wording so nothing changes visually when unset. */
+export const DEFAULT_NO_IN_PERSON_SERVICES_MESSAGE =
+  'There will be no IN PERSON Services at Toronto East, Zoom and YouTube will remain unchanged.'
+
+/**
+ * Resolve the "no in-person services" message for display.
+ *
+ * @param message  Admin-set message from the replacement event (if any).
+ * @param fallback Default to use when `message` is empty/unset. Defaults to the
+ *                 Toronto East wording; callers with tenant context may pass an
+ *                 ecclesia-specific default here.
+ */
+export function resolveNoInPersonServicesMessage(
+  message?: string | null,
+  fallback: string = DEFAULT_NO_IN_PERSON_SERVICES_MESSAGE
+): string {
+  const trimmed = typeof message === 'string' ? message.trim() : ''
+  return trimmed ? trimmed : fallback
+}

--- a/packages/app/features/newsletter/memorial.tsx
+++ b/packages/app/features/newsletter/memorial.tsx
@@ -5,6 +5,7 @@ import { Accordion, Anchor, ExtLink, Paragraph, Separator, Square, Text, YStack 
 import { XStack } from 'tamagui'
 import { ChevronDown, MapPin } from '@tamagui/lucide-icons'
 import { Section } from '@my/app/features/newsletter/Section'
+import { resolveNoInPersonServicesMessage } from '@my/app/config/service-messages'
 
 /** Find an event by title (case-insensitive substring match) */
 function findReplacementEvent(
@@ -40,7 +41,9 @@ export const NextMemorial: React.FC<NextMemorialProps> = ({ event, isSameDay, up
         <Paragraph size={'$5'} fontWeight={600}>
           {event.Date.toString()}
         </Paragraph>
-        <Paragraph fontWeight={600}>There will be no service at our hall.</Paragraph>
+        <Paragraph fontWeight={600}>
+          {resolveNoInPersonServicesMessage(replacementEvent?.noInPersonServicesMessage)}
+        </Paragraph>
         {explanation ? <Paragraph>{explanation}</Paragraph> : null}
 
         {/* Replacement event details */}

--- a/packages/app/types/events.ts
+++ b/packages/app/types/events.ts
@@ -334,6 +334,15 @@ export interface Event extends BaseEvent {
   customType?: string
   hideDates?: boolean // When true, suppress date display in newsletter, events list, detail view, and emails
 
+  /**
+   * "No in-person services" notice shown in the newsletter/recap emails and app UI
+   * when this event replaces cancelled in-person Sunday services. Set by the admin
+   * in the Event Editor. When unset, templates fall back to
+   * DEFAULT_NO_IN_PERSON_SERVICES_MESSAGE (see config/service-messages.ts). Issue #45:
+   * un-hardcodes the message from the templates so wording changes need no deploy.
+   */
+  noInPersonServicesMessage?: string
+
   // Recurring event fields
   recurringConfig?: {
     startDate?: Date

--- a/packages/ui/src/data-table/enhanced-schedule-responsive.tsx
+++ b/packages/ui/src/data-table/enhanced-schedule-responsive.tsx
@@ -8,6 +8,7 @@ import { YStack, Text, XStack, useThemeName } from 'tamagui'
 import { Button } from '../Button'
 import { Copy, ExternalLink, MapPin } from '@tamagui/lucide-icons'
 import { brandColors, type ColorMode } from '../branding/brand-colors'
+import { resolveNoInPersonServicesMessage } from '@my/app/config/service-messages'
 
 // Enhanced schedule event interface matching requirements
 export interface EnhancedScheduleEvent {
@@ -413,7 +414,7 @@ export function EnhancedScheduleResponsive({
             {event.noServiceAtHall ? (
               <YStack gap="$1">
                 <Text fontSize="$4" fontWeight="700" color={colors.textPrimary}>
-                  There will be no service at our hall.
+                  {resolveNoInPersonServicesMessage(event.noInPersonServicesMessage)}
                 </Text>
                 {(event.Activities || event.activities) ? (
                   <Text fontSize="$3" color={colors.textPrimary}>

--- a/packages/ui/src/events/progressive-event-form.tsx
+++ b/packages/ui/src/events/progressive-event-form.tsx
@@ -2,6 +2,7 @@ import { Event, EventType, EventStatus, EventSharingScope } from '@my/app/types/
 import { EventValidator } from '@my/app/utils/event-validation'
 import { TIMEZONE_OPTIONS } from '@my/app/utils/timezone'
 import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
+import { DEFAULT_NO_IN_PERSON_SERVICES_MESSAGE } from '@my/app/config/service-messages'
 import {
   Calendar,
   Check,
@@ -700,6 +701,7 @@ export function ProgressiveEventForm({
       publishDate: initialData?.publishDate || undefined, // Only set explicitly — never auto-reset
       membersOnly: initialData?.membersOnly || false,
       sharingScope: initialData?.sharingScope || 'own',
+      noInPersonServicesMessage: initialData?.noInPersonServicesMessage || '',
       // Type-specific defaults
       ...(currentSelectedType === 'study-weekend' && {
         dateRange: initialData?.dateRange || {
@@ -2390,6 +2392,27 @@ export function ProgressiveEventForm({
                 />
               </YStack>
             ) : null}
+
+            {/* "No in-person services" notice — only used when this event replaces
+                cancelled Sunday services (issue #45). Leave blank to use the default. */}
+            <YStack marginTop="$5" space="$2">
+              <Text fontSize="$5" fontWeight="600">
+                "No In-Person Services" Message (Optional)
+              </Text>
+              <Text fontSize="$3" color="$gray11">
+                Shown in the newsletter and recap emails when this event replaces cancelled
+                in-person Sunday services. Leave blank to use the default:
+                {'\n'}"{DEFAULT_NO_IN_PERSON_SERVICES_MESSAGE}"
+              </Text>
+              <OptimizedTextarea
+                control={control}
+                name="noInPersonServicesMessage"
+                label=""
+                placeholder={DEFAULT_NO_IN_PERSON_SERVICES_MESSAGE}
+                rows={3}
+                maxLength={500}
+              />
+            </YStack>
 
           </YStack>
         </Card>


### PR DESCRIPTION
Closes #45.

## What changed
The "no in-person services" notice shown in the Newsletter and Memorial (recap) emails and the app UI is no longer hardcoded in the templates. It is now **data**:

- **New field** `Event.noInPersonServicesMessage` — set by the admin in the **Event Editor** (Basic Info step) on the replacement event.
- **New config module** `packages/app/config/service-messages.ts` exporting `DEFAULT_NO_IN_PERSON_SERVICES_MESSAGE` (the existing Toronto East wording, unchanged) and `resolveNoInPersonServicesMessage(message?, fallback?)`. The default now lives in config, not baked into the template.
- **All render paths resolve from the same source**, reconciling the two previously divergent hardcoded strings:
  - `apps/email-builder/components/ReplacementEventCard.tsx` (replacement-event path) → `event.noInPersonServicesMessage` or default.
  - `apps/email-builder/emails/Newsletter.tsx` + `Memorial.tsx` (no-replacement fallback, formerly "There will be no service at our hall.") → default.
  - `packages/app/features/newsletter/memorial.tsx` (app view) → replacement event's message or default.
  - `packages/ui/src/data-table/enhanced-schedule-responsive.tsx` (schedule table) → default.

## Why
Per the issue: editing a member-facing message should not require a developer, a PR, and a deploy (tonight's PR #44 was exactly that). It is also a multi-tenant blocker — the wording is ecclesia-specific. Admins can now edit the message as event data; the shared default is a config constant (the seam a per-tenant default plugs into) rather than a string compiled into the template.

## Data flow / persistence
- The event is stored as full JSON (`serializeEventData` → `record.details`), so the new field persists with no schema/allowlist change.
- The form save spreads all fields (`onSubmit` / `saveEventDraft`), and the field sits in the common Basic Info step so `stripInactiveComponentFields` does not remove it.
- PII redaction (`redact-event.ts`) is a denylist, so the (non-PII) message passes through unchanged for both anon and member viewers.

## Behavior
When the field is unset, every path renders `DEFAULT_NO_IN_PERSON_SERVICES_MESSAGE` (the current TEE wording), so **nothing changes visually** for existing content.

## Conventions
- JSX conditional rendering uses ternary + `null` (no `&&`); no new `Button` added (no hoverStyle needed).
- The config module is dependency-free (no Node/Next/`'use client'` imports), so it is safe to import from the react-email server render path and shared cross-platform UI.

## How verified
- `yarn workspace next-app typecheck` — no new errors (only the two pre-existing `occurrenceDate` errors remain).
- Traced the persistence path (JSON serialization), the form save/strip logic, and the redaction denylist by reading the code.

## NOT verified
- **UI not exercised** — the app and Event Editor were not run/loaded; the new textarea field and the rendered message were not visually confirmed in a browser or a real email preview.
- **No email was sent/rendered end-to-end** (react-email preview not run).
- **Per-tenant default not fully wired into templates** — the config constant is currently the single (TEE) default; a per-ecclesia default value would plug into `resolveNoInPersonServicesMessage`'s `fallback` param but is not threaded through the email templates yet (only TEE is live). The per-event field already gives each ecclesia full control of the displayed message.