### PR TITLE
feat(resolver): name↔member resolver — increment 2 (read-only directory adapter + admin diagnostic) (#109)

### DIFF
--- a/apps/next/app/api/admin/name-resolution/route.ts
+++ b/apps/next/app/api/admin/name-resolution/route.ts
@@ -1,0 +1,183 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '../../../../utils/auth'
+import { personRepository } from '@my/app/provider/dynamodb/repositories/person-repository'
+import { GoogleSheetsService } from '@my/app/provider/sync/google-sheets-service'
+import {
+  resolveNames,
+  toDirectoryPerson,
+  type DirectoryPerson,
+} from '@my/app/utils/name-resolver-directory'
+import { getTeeServicesConfig } from '../../../../utils/tee-services-config'
+
+/**
+ * READ-ONLY admin diagnostic for the schedule name↔member resolver
+ * (keystone — issue #109, increment 2).
+ *
+ * Loads the directory as candidates, harvests the free-text names from the
+ * memorial schedule (inline role columns + the "Visiting Speakers" tab), runs
+ * the pure resolver, and returns a grouped match report so a human can eyeball
+ * match quality and tune the typo threshold BEFORE any write path is built.
+ *
+ * ZERO mutations: no PersonRecord writes, no SES, no notifications.
+ *
+ * // NEXT INCREMENT: the auto-create-visiting-speaker + RB/Rep notification
+ * // paths are deliberately NOT here. They are gated on a schema decision:
+ * // personRepository.create() currently REQUIRES an email, but visiting
+ * // speakers harvested from the sheet have none. That must be resolved
+ * // (nullable email / synthetic placeholder / separate record kind) before
+ * // the not-found group can be turned into created records or notifications.
+ */
+
+// Memorial schedule columns whose cells hold a person's name (case-insensitive
+// header match). Readings/hymns/collection amounts etc. are intentionally excluded.
+const MEMORIAL_NAME_COLUMNS = ['Preside', 'Exhort', 'Organist', 'Steward', 'Doorkeeper']
+
+// On the "Visiting Speakers" tab we don't control the layout, so harvest cells
+// from any column whose header looks like it holds a person's name.
+const VISITING_NAME_HEADER_RE = /(name|speaker|exhort|brother|visitor|preside)/i
+
+const MAX_SAMPLES = 50
+
+/** Pick the string values from a sheet under headers matching a predicate. */
+function harvestColumn(
+  headers: string[],
+  rows: any[][],
+  matches: (header: string) => boolean
+): string[] {
+  const cols = headers.reduce<number[]>((acc, h, i) => {
+    if (typeof h === 'string' && matches(h)) acc.push(i)
+    return acc
+  }, [])
+  const out: string[] = []
+  for (const row of rows) {
+    for (const col of cols) {
+      const cell = row[col]
+      if (typeof cell === 'string' && cell.trim()) out.push(cell)
+    }
+  }
+  return out
+}
+
+export async function GET(_request: NextRequest) {
+  try {
+    // --- Auth gate: owner/admin only (matches other admin routes) ---
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+    }
+    const userRole = (session.user as any).role || 'guest'
+    if (!['admin', 'owner'].includes(userRole)) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+    }
+
+    // --- Load directory candidates (all PROFILE records, paginated) ---
+    const candidates: DirectoryPerson[] = []
+    let lastEvaluatedKey: Record<string, any> | undefined
+    do {
+      const page = await personRepository.listAll({ lastEvaluatedKey })
+      for (const record of page.items) {
+        candidates.push(toDirectoryPerson(record))
+      }
+      lastEvaluatedKey = page.lastEvaluatedKey
+    } while (lastEvaluatedKey)
+
+    // --- Resolve the memorial sheet id from the Google config ---
+    const config = getTeeServicesConfig()
+    const memorial = config.sheet_ids?.['memorial']
+    if (!memorial?.key) {
+      return NextResponse.json(
+        { error: 'Memorial sheet is not configured (sheet_ids.memorial missing)' },
+        { status: 500 }
+      )
+    }
+    const sheetId = memorial.key
+    const sheets = new GoogleSheetsService()
+
+    // --- Harvest names from the main schedule's inline role columns ---
+    const main = await sheets.getSheetDataWithHeaders(sheetId, 'A:Z')
+    const roleColumnsFound = main.headers.filter(
+      (h) => typeof h === 'string' && MEMORIAL_NAME_COLUMNS.some((c) => c.toLowerCase() === h.trim().toLowerCase())
+    )
+    const roleNames = harvestColumn(main.headers, main.rows, (h) =>
+      MEMORIAL_NAME_COLUMNS.some((c) => c.toLowerCase() === h.trim().toLowerCase())
+    )
+
+    // --- Harvest names from the "Visiting Speakers" tab (may not exist) ---
+    let visitingNames: string[] = []
+    let visitingTabError: string | null = null
+    try {
+      const visiting = await sheets.getSheetDataWithHeaders(sheetId, "'Visiting Speakers'!A:Z")
+      visitingNames = harvestColumn(visiting.headers, visiting.rows, (h) => VISITING_NAME_HEADER_RE.test(h))
+      // Fallback: no header matched (unknown layout) — take the first column,
+      // which is conventionally the speaker's name. Placeholders/non-names are
+      // filtered downstream by the resolver.
+      if (visitingNames.length === 0) {
+        visitingNames = visiting.rows
+          .map((r) => r[0])
+          .filter((c): c is string => typeof c === 'string' && !!c.trim())
+      }
+    } catch (error) {
+      visitingTabError = error instanceof Error ? error.message : 'Failed to read Visiting Speakers tab'
+    }
+
+    const allNames = [...roleNames, ...visitingNames]
+    const report = resolveNames(allNames, candidates)
+
+    return NextResponse.json({
+      success: true,
+      timestamp: new Date().toISOString(),
+      requestedBy: session.user.email,
+      sources: {
+        directoryCandidates: candidates.length,
+        roleColumnsFound,
+        roleNameCells: roleNames.length,
+        visitingSpeakerCells: visitingNames.length,
+        visitingTabError,
+      },
+      counts: {
+        uniqueNames:
+          report.matched.length + report.typos.length + report.ambiguous.length + report.notFound.length,
+        matched: report.matched.length,
+        typos: report.typos.length,
+        ambiguous: report.ambiguous.length,
+        notFound: report.notFound.length,
+      },
+      samples: {
+        matched: report.matched.slice(0, MAX_SAMPLES).map((m) => ({
+          input: m.input,
+          personId: m.person.personId,
+          displayName: m.person.displayName,
+          ecclesia: m.person.ecclesia,
+        })),
+        typos: report.typos.slice(0, MAX_SAMPLES).map((t) => ({
+          input: t.input,
+          suggestions: t.suggestions.map((s) => ({
+            personId: s.person.personId,
+            displayName: s.person.displayName,
+            ecclesia: s.person.ecclesia,
+            distance: s.distance,
+          })),
+        })),
+        ambiguous: report.ambiguous.slice(0, MAX_SAMPLES).map((a) => ({
+          input: a.input,
+          candidates: a.candidates.map((c) => ({
+            personId: c.personId,
+            displayName: c.displayName,
+            ecclesia: c.ecclesia,
+          })),
+        })),
+        notFound: report.notFound.slice(0, MAX_SAMPLES).map((n) => n.input),
+      },
+    })
+  } catch (error) {
+    console.error('❌ Name-resolution diagnostic failed:', error)
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to run name-resolution diagnostic',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/next/tests/name-resolver-directory.test.ts
+++ b/apps/next/tests/name-resolver-directory.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import {
+  toDirectoryPerson,
+  resolveNames,
+} from '@my/app/utils/name-resolver-directory'
+import type { PersonRecord } from '@my/app/provider/dynamodb/types'
+import type { DirectoryPerson } from '@my/app/utils/name-resolver'
+
+// Real-shaped PersonRecord fixture (only the fields the adapter reads matter,
+// but we include the full key set to stay honest about the record shape).
+function personRecord(over: Partial<PersonRecord> & Pick<PersonRecord, 'personId' | 'firstName' | 'lastName' | 'ecclesia'>): PersonRecord {
+  const { personId, firstName, lastName, ecclesia } = over
+  return {
+    pkey: `PERSON#${personId}`,
+    skey: 'PROFILE',
+    gsi1pk: `EMAIL#${firstName}.${lastName}@example.com`.toLowerCase(),
+    gsi1sk: 'PERSON',
+    gsi2pk: `ECCLESIA#${ecclesia}`,
+    gsi2sk: `${lastName}#${firstName}#${personId}`.toLowerCase(),
+    gsi3pk: `NAME#${lastName}`.toLowerCase(),
+    gsi3sk: `${firstName}#${personId}`.toLowerCase(),
+    primaryEmail: `${firstName}.${lastName}@example.com`.toLowerCase(),
+    displayName: `${firstName} ${lastName}`,
+    memberStatus: 'member' as PersonRecord['memberStatus'],
+    ...over,
+  } as PersonRecord
+}
+
+const records: PersonRecord[] = [
+  personRecord({ personId: 'p1', firstName: 'Ken', lastName: 'Easson', ecclesia: 'Toronto East' }),
+  personRecord({ personId: 'p2', firstName: 'Alan', lastName: 'Markwith', ecclesia: 'Greenaway Hamilton' }),
+  personRecord({ personId: 'p3', firstName: 'Brad', lastName: 'Stephens', ecclesia: 'Toronto East' }),
+  personRecord({ personId: 'p4', firstName: 'John', lastName: 'Smith', ecclesia: 'Toronto East' }),
+  personRecord({ personId: 'p5', firstName: 'John', lastName: 'Smith', ecclesia: 'Toronto West' }),
+]
+
+describe('toDirectoryPerson', () => {
+  it('projects a PersonRecord down to the minimal DirectoryPerson shape', () => {
+    const dp = toDirectoryPerson(records[0])
+    expect(dp).toEqual({
+      personId: 'p1',
+      firstName: 'Ken',
+      lastName: 'Easson',
+      ecclesia: 'Toronto East',
+      displayName: 'Ken Easson',
+    })
+    // Must not leak auth/PII fields from the record.
+    expect((dp as unknown as Record<string, unknown>).primaryEmail).toBeUndefined()
+    expect((dp as unknown as Record<string, unknown>).hashedPassword).toBeUndefined()
+  })
+})
+
+describe('resolveNames', () => {
+  const candidates: DirectoryPerson[] = records.map(toDirectoryPerson)
+
+  it('groups matched / typo / ambiguous / not-found across a batch', () => {
+    const names = [
+      'Brad Stephens', // exact -> matched
+      'Bro. Alan Markwith', // honorific + visitor -> matched
+      'kent easson', // typo -> Ken Easson
+      'John Smith', // ambiguous -> p4/p5
+      'Zebediah Farquharson', // not-found (visitor to add)
+    ]
+    const r = resolveNames(names, candidates)
+
+    expect(r.matched.map((m) => m.person.personId).sort()).toEqual(['p2', 'p3'])
+    expect(r.typos).toHaveLength(1)
+    expect(r.typos[0].suggestions[0].person.personId).toBe('p1')
+    expect(r.ambiguous).toHaveLength(1)
+    expect(r.ambiguous[0].candidates.map((c) => c.personId).sort()).toEqual(['p4', 'p5'])
+    expect(r.notFound.map((n) => n.input)).toEqual(['Zebediah Farquharson'])
+  })
+
+  it('dedupes repeated names and skips placeholders + blanks', () => {
+    const names = ['Brad Stephens', 'Brad Stephens', 'BRAD STEPHENS', 'TBD', '', '   ', 'attendees']
+    const r = resolveNames(names, candidates)
+    expect(r.matched).toHaveLength(1)
+    expect(r.matched[0].person.personId).toBe('p3')
+    expect(r.typos).toHaveLength(0)
+    expect(r.ambiguous).toHaveLength(0)
+    expect(r.notFound).toHaveLength(0)
+  })
+
+  it('keeps the first raw spelling of a deduped name as the reported input', () => {
+    const r = resolveNames(['Zebediah Farquharson', 'zebediah farquharson'], candidates)
+    expect(r.notFound).toHaveLength(1)
+    expect(r.notFound[0].input).toBe('Zebediah Farquharson')
+  })
+})

--- a/apps/next/tests/name-resolver.test.ts
+++ b/apps/next/tests/name-resolver.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeName,
+  isPlaceholderName,
+  editDistance,
+  resolveScheduleName,
+  type DirectoryPerson,
+} from '@my/app/utils/name-resolver'
+
+const people: DirectoryPerson[] = [
+  { personId: 'p1', firstName: 'Ken', lastName: 'Easson', ecclesia: 'Toronto East' },
+  { personId: 'p2', firstName: 'Alan', lastName: 'Markwith', ecclesia: 'Greenaway Hamilton' },
+  { personId: 'p3', firstName: 'Brad', lastName: 'Stephens', ecclesia: 'Toronto East' },
+  { personId: 'p4', firstName: 'John', lastName: 'Smith', ecclesia: 'Toronto East' },
+  { personId: 'p5', firstName: 'John', lastName: 'Smith', ecclesia: 'Toronto West' }, // duplicate name
+]
+
+describe('normalizeName', () => {
+  it('lowercases, strips honorifics + punctuation, splits first/last', () => {
+    expect(normalizeName('Bro. Alan Markwith')).toMatchObject({ first: 'alan', last: 'markwith', full: 'alan markwith' })
+    expect(normalizeName('Brad Stephens')).toMatchObject({ first: 'brad', last: 'stephens' })
+    expect(normalizeName('  Sister  Jane   Doe ')).toMatchObject({ first: 'jane', last: 'doe' })
+  })
+  it('handles a single name (first === last)', () => {
+    expect(normalizeName('Hakime')).toMatchObject({ first: 'hakime', last: 'hakime', tokens: ['hakime'] })
+  })
+  it('drops a middle name for first/last but keeps all tokens', () => {
+    const n = normalizeName('John Michael Smith')
+    expect(n.first).toBe('john')
+    expect(n.last).toBe('smith')
+    expect(n.tokens).toEqual(['john', 'michael', 'smith'])
+  })
+})
+
+describe('isPlaceholderName', () => {
+  it('flags non-person placeholders', () => {
+    expect(isPlaceholderName('TBD')).toBe(true)
+    expect(isPlaceholderName('attendees')).toBe(true)
+    expect(isPlaceholderName('')).toBe(true)
+    expect(isPlaceholderName('  ')).toBe(true)
+  })
+  it('does not flag real names', () => {
+    expect(isPlaceholderName('Ken Easson')).toBe(false)
+    expect(isPlaceholderName('Hakime')).toBe(false)
+  })
+})
+
+describe('editDistance', () => {
+  it('computes Levenshtein distance', () => {
+    expect(editDistance('ken', 'kent')).toBe(1)
+    expect(editDistance('kent easson', 'ken easson')).toBe(1)
+    expect(editDistance('abc', 'abc')).toBe(0)
+    expect(editDistance('', 'abc')).toBe(3)
+  })
+})
+
+describe('resolveScheduleName', () => {
+  it('exact match', () => {
+    const r = resolveScheduleName('Brad Stephens', people)
+    expect(r.status).toBe('matched')
+    if (r.status === 'matched') expect(r.person.personId).toBe('p3')
+  })
+
+  it('matches through an honorific + a visitor from another ecclesia', () => {
+    const r = resolveScheduleName('Bro. Alan Markwith', people)
+    expect(r.status).toBe('matched')
+    if (r.status === 'matched') {
+      expect(r.person.personId).toBe('p2')
+      expect(r.person.ecclesia).toBe('Greenaway Hamilton')
+    }
+  })
+
+  it('flags a typo with the likely person ("kent easson" → Ken Easson)', () => {
+    const r = resolveScheduleName('kent easson', people)
+    expect(r.status).toBe('typo')
+    if (r.status === 'typo') {
+      expect(r.suggestions[0].person.personId).toBe('p1')
+      expect(r.suggestions[0].distance).toBe(1)
+    }
+  })
+
+  it('flags ambiguity when two people share a name', () => {
+    const r = resolveScheduleName('John Smith', people)
+    expect(r.status).toBe('ambiguous')
+    if (r.status === 'ambiguous') expect(r.candidates.map((c) => c.personId).sort()).toEqual(['p4', 'p5'])
+  })
+
+  it('not-found for an unknown name (a visitor to add)', () => {
+    expect(resolveScheduleName('Zebediah Farquharson', people).status).toBe('not-found')
+  })
+
+  it('not-found (skip) for placeholders', () => {
+    expect(resolveScheduleName('TBD', people).status).toBe('not-found')
+    expect(resolveScheduleName('attendees', people).status).toBe('not-found')
+    expect(resolveScheduleName('', people).status).toBe('not-found')
+  })
+
+  it('does not false-positive a real different person as a typo', () => {
+    // "Brad Stephens" vs "John Smith" are far apart — must not match.
+    const r = resolveScheduleName('Brad Stephens', [{ personId: 'x', firstName: 'John', lastName: 'Smith' }])
+    expect(r.status).toBe('not-found')
+  })
+})

--- a/packages/app/utils/name-resolver-directory.ts
+++ b/packages/app/utils/name-resolver-directory.ts
@@ -1,0 +1,106 @@
+/**
+ * Directory adapter for the schedule name resolver (keystone — see
+ * project_name_member_resolver, increment 2).
+ *
+ * Bridges the pure matcher in `./name-resolver` to the app's real data:
+ *   - `toDirectoryPerson` maps a DynamoDB `PersonRecord` down to the minimal
+ *     `DirectoryPerson` shape the matcher needs.
+ *   - `resolveNames` takes the free-text names harvested from a schedule (role
+ *     columns + the memorial "Visiting Speakers" tab), dedupes them, drops
+ *     placeholders, resolves each against the directory, and groups the outcome.
+ *
+ * PURE + I/O-free by design: the caller supplies both the raw names and the
+ * directory candidates, so this unit-tests cleanly and can run in an admin
+ * diagnostic route, a sync hook, or a cron without touching DynamoDB or Sheets.
+ */
+import type { PersonRecord } from '../provider/dynamodb/types'
+import {
+  normalizeName,
+  isPlaceholderName,
+  resolveScheduleName,
+  type DirectoryPerson,
+  type NameMatch,
+} from './name-resolver'
+
+export type { DirectoryPerson } from './name-resolver'
+
+/** Map a full PersonRecord to the minimal shape the matcher consumes. */
+export function toDirectoryPerson(p: PersonRecord): DirectoryPerson {
+  return {
+    personId: p.personId,
+    firstName: p.firstName,
+    lastName: p.lastName,
+    ecclesia: p.ecclesia,
+    displayName: p.displayName,
+  }
+}
+
+/** One matched name and the directory person it resolved to. */
+export interface MatchedName {
+  input: string
+  person: DirectoryPerson
+}
+
+/** A name with no exact match but ≥1 close candidate (likely a typo). */
+export interface TypoName {
+  input: string
+  suggestions: Array<{ person: DirectoryPerson; distance: number }>
+}
+
+/** A name that matches more than one directory person. */
+export interface AmbiguousName {
+  input: string
+  candidates: DirectoryPerson[]
+}
+
+/** A name that matched nothing close — a visitor to add, or bad data. */
+export interface NotFoundName {
+  input: string
+}
+
+export interface ResolveNamesResult {
+  matched: MatchedName[]
+  typos: TypoName[]
+  ambiguous: AmbiguousName[]
+  notFound: NotFoundName[]
+}
+
+/**
+ * Resolve a batch of free-text schedule names against directory candidates.
+ *
+ * Dedupes on the normalized name (a person named in many cells is resolved
+ * once, keyed by their first-seen raw spelling) and skips placeholders
+ * ("TBD", "attendees", blanks) so they never surface as people to add.
+ */
+export function resolveNames(names: string[], candidates: DirectoryPerson[]): ResolveNamesResult {
+  const result: ResolveNamesResult = { matched: [], typos: [], ambiguous: [], notFound: [] }
+
+  // Dedupe by normalized full name, keeping the first raw spelling seen.
+  const seen = new Map<string, string>()
+  for (const raw of names) {
+    if (!raw || isPlaceholderName(raw)) continue
+    const key = normalizeName(raw).full
+    if (!key || seen.has(key)) continue
+    seen.set(key, raw.trim())
+  }
+
+  for (const raw of seen.values()) {
+    const match: NameMatch = resolveScheduleName(raw, candidates)
+    switch (match.status) {
+      case 'matched':
+        result.matched.push({ input: raw, person: match.person })
+        break
+      case 'typo':
+        result.typos.push({ input: raw, suggestions: match.suggestions })
+        break
+      case 'ambiguous':
+        result.ambiguous.push({ input: raw, candidates: match.candidates })
+        break
+      case 'not-found':
+        result.notFound.push({ input: raw })
+        break
+    }
+  }
+
+  return result
+}

--- a/packages/app/utils/name-resolver.ts
+++ b/packages/app/utils/name-resolver.ts
@@ -1,0 +1,133 @@
+/**
+ * Deterministic schedule-name → member resolver (keystone — see
+ * project_name_member_resolver). Schedule data arrives from Google Sheets as
+ * FREE-TEXT names ("Brad Stephens", the odd typo "kent easson", honorifics like
+ * "Bro. Alan Markwith"). This maps such a name to a directory PersonRecord, or
+ * flags it so an admin can fix it:
+ *
+ *   matched   — exactly one confident match
+ *   typo      — no exact match but ≥1 close candidate (edit distance ≤ 2)
+ *   ambiguous — multiple people share the (normalized) name
+ *   not-found — nothing close (likely a visitor to add, or a placeholder)
+ *
+ * PURE + I/O-free: callers pass the candidate people (e.g. from
+ * personRepository.listAll() / listByEcclesia()), so this unit-tests cleanly and
+ * runs anywhere (sync hook, admin review, cron). Matching across ALL people is
+ * intentional — visiting exhorters live in the directory under their OWN ecclesia.
+ */
+
+/** Minimal shape the resolver needs from a PersonRecord. */
+export interface DirectoryPerson {
+  personId: string
+  firstName: string
+  lastName: string
+  ecclesia?: string
+  displayName?: string
+}
+
+export type NameMatch =
+  | { status: 'matched'; person: DirectoryPerson; confidence: 'exact' }
+  | { status: 'typo'; input: NormalizedName; suggestions: Array<{ person: DirectoryPerson; distance: number }> }
+  | { status: 'ambiguous'; input: NormalizedName; candidates: DirectoryPerson[] }
+  | { status: 'not-found'; input: NormalizedName }
+
+export interface NormalizedName {
+  /** The full normalized name, e.g. "ken easson". */
+  full: string
+  first: string
+  last: string
+  tokens: string[]
+}
+
+const HONORIFIC_RE = /^(bro\.?|brother|bre\.?|sis\.?|sister|mr\.?|mrs\.?|ms\.?|dr\.?)$/i
+
+/** Free-text tokens that aren't people — a name-only "not a real person" guard. */
+const PLACEHOLDER_TOKENS = new Set([
+  'tbd', 'tba', 'open', 'none', 'various', 'attendees', 'all', 'n/a', 'na', 'vacant', 'visitor', 'speaker',
+])
+
+/**
+ * Normalize a free-text name: lowercase, strip honorifics + punctuation, collapse
+ * whitespace, split into tokens. First token → first name, last token → last name
+ * (single-token names have first === last === the token; middles are dropped for
+ * matching but kept in `tokens`).
+ */
+export function normalizeName(raw: string): NormalizedName {
+  const cleaned = (raw ?? '')
+    .toLowerCase()
+    .replace(/[.,]/g, ' ')
+    .replace(/[^\p{L}\p{N}\s'-]/gu, ' ') // keep letters/digits/space/'/-
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  const tokens = cleaned.split(' ').filter((t) => t && !HONORIFIC_RE.test(t))
+  const first = tokens[0] ?? ''
+  const last = tokens.length > 1 ? tokens[tokens.length - 1] : first
+  return { full: tokens.join(' '), first, last, tokens }
+}
+
+/** True when the raw value is a known non-person placeholder ("TBD", "attendees", …). */
+export function isPlaceholderName(raw: string): boolean {
+  const n = normalizeName(raw)
+  if (!n.full) return true
+  return n.tokens.every((t) => PLACEHOLDER_TOKENS.has(t))
+}
+
+/** Levenshtein edit distance (bounded is unnecessary at directory scale). */
+export function editDistance(a: string, b: string): number {
+  if (a === b) return 0
+  if (!a.length) return b.length
+  if (!b.length) return a.length
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i)
+  let curr = new Array(b.length + 1)
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost)
+    }
+    ;[prev, curr] = [curr, prev]
+  }
+  return prev[b.length]
+}
+
+const TYPO_MAX_DISTANCE = 2
+
+function personName(p: DirectoryPerson): NormalizedName {
+  return normalizeName(`${p.firstName} ${p.lastName}`)
+}
+
+/**
+ * Resolve a free-text schedule name against directory candidates.
+ * Placeholder inputs ("TBD"/"attendees"/blank) resolve to `not-found` — the caller
+ * should skip them rather than treat them as a person to add.
+ */
+export function resolveScheduleName(raw: string, candidates: DirectoryPerson[]): NameMatch {
+  const input = normalizeName(raw)
+  if (!input.full || isPlaceholderName(raw)) {
+    return { status: 'not-found', input }
+  }
+
+  const scored = candidates.map((person) => ({ person, name: personName(person) }))
+
+  // 1. Exact match on normalized first + last.
+  const exact = scored.filter((c) => c.name.first === input.first && c.name.last === input.last)
+  if (exact.length === 1) {
+    return { status: 'matched', person: exact[0].person, confidence: 'exact' }
+  }
+  if (exact.length > 1) {
+    return { status: 'ambiguous', input, candidates: exact.map((c) => c.person) }
+  }
+
+  // 2. No exact — look for close matches (typo). Distance on the full "first last".
+  const near = scored
+    .map((c) => ({ person: c.person, distance: editDistance(input.full, c.name.full) }))
+    .filter((c) => c.distance > 0 && c.distance <= TYPO_MAX_DISTANCE)
+    .sort((a, b) => a.distance - b.distance)
+
+  if (near.length > 0) {
+    return { status: 'typo', input, suggestions: near }
+  }
+
+  return { status: 'not-found', input }
+}


### PR DESCRIPTION
## Increment 2 (READ-ONLY) — refs #109

Builds on increment 1 (pure matcher). This PR carries **both increments** so they merge as one — increment 1 (`feat/name-member-resolver`) is not on `main` yet.

### What's built (read-only slice)
- **`packages/app/utils/name-resolver-directory.ts`** — pure, I/O-free adapter:
  - `toDirectoryPerson(p: PersonRecord): DirectoryPerson` — projects a full DynamoDB record down to the minimal shape the matcher needs (drops email/auth/PII).
  - `resolveNames(names, candidates)` — dedupes by normalized name, skips placeholders (`isPlaceholderName`), runs `resolveScheduleName` per name, groups into `{ matched, typos, ambiguous, notFound }`.
- **`apps/next/tests/name-resolver-directory.test.ts`** — unit tests with real-shaped `PersonRecord` fixtures (extends the increment-1 test style).
- **`apps/next/app/api/admin/name-resolution/route.ts`** — owner/admin-gated `GET` diagnostic (same auth pattern as other `/api/admin/*` routes):
  - loads directory candidates via `personRepository.listAll()` (paginated),
  - reads the memorial schedule's inline role columns (Preside/Exhort/Organist/Steward/Doorkeeper) **and** the memorial `'Visiting Speakers'` tab via `GoogleSheetsService.getSheetDataWithHeaders`,
  - returns the grouped resolution report — counts + samples for matched / typo / ambiguous / not-found — so a human can eyeball match quality and tune the typo threshold.
  - **ZERO mutations**: no writes, no record creation, no SES, no notifications.

### How verified
- Resolver unit tests: **17 passed** (13 increment-1 + 4 new adapter tests) via `yarn vitest run`.
- `yarn workspace next-app typecheck`: clean for all new files (only the two pre-existing `occurrenceDate` errors remain, unrelated to this change).
- Shared-package rules respected: the adapter imports only `import type { PersonRecord }` + the pure matcher — no `next-auth` / `next/navigation` in `packages/`.

### NOT done (deferred to later increments)
- **Auto-create visiting-speaker records** and **RB/Rep discrepancy notifications** are intentionally out of scope.
- **Gating decision (blocks the write path):** `personRepository.create()` currently **requires an email**, but visiting speakers harvested from the sheet have **none**. That schema decision (nullable email / synthetic placeholder / separate record kind) must be resolved before the not-found group can be turned into created records or notifications. A `// NEXT INCREMENT` comment in the route records this.

### Not verified
- The diagnostic route was **not exercised against live Google Sheets / DynamoDB** (no live credentials in this environment). The pure adapter is covered by unit tests; the route's data-loading path is unrun end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)