### PR TITLE
feat(schedule): per-occurrence service overrides (#111)

### DIFF
--- a/apps/email-builder/components/AttendOptions.tsx
+++ b/apps/email-builder/components/AttendOptions.tsx
@@ -1,0 +1,64 @@
+import { Section, Text, Link } from '@react-email/components'
+import type { AttendOption } from '@my/app/types'
+
+/**
+ * Email "Ways to attend" list for a single service occurrence (Phase 2 of
+ * per-occurrence overrides). When present, supersedes the hardcoded single-Zoom
+ * block in the email templates.
+ */
+
+const baseText = {
+  fontFamily: 'Arial, sans-serif',
+  fontSize: '16px',
+  lineHeight: '24px',
+  color: '#333333',
+  margin: '0 0 4px 0',
+} as const
+
+const optionBox = {
+  borderLeft: '4px solid #1565C0',
+  paddingLeft: '12px',
+  marginBottom: '12px',
+} as const
+
+export const AttendOptions = ({ options }: { options?: AttendOption[] }) => {
+  if (!options || options.length === 0) return null
+
+  return (
+    <Section>
+      <Text style={{ ...baseText, fontWeight: 'bold' }}>Ways to attend:</Text>
+      {options.map((opt) => (
+        <Section key={opt.id} style={optionBox}>
+          <Text style={{ ...baseText, fontWeight: 'bold' }}>
+            {opt.label}
+            {opt.hostEcclesia ? ` — ${opt.hostEcclesia}` : ''}
+          </Text>
+
+          {opt.mode === 'in_person' ? (
+            <>
+              {opt.address ? <Text style={baseText}>{opt.address}</Text> : null}
+              {opt.mapsUrl ? (
+                <Text style={baseText}>
+                  <Link href={opt.mapsUrl}>View on Google Maps</Link>
+                </Text>
+              ) : null}
+            </>
+          ) : (
+            <>
+              {opt.url ? (
+                <Text style={baseText}>
+                  <Link href={opt.url}>
+                    {opt.mode === 'stream' ? 'Watch the stream' : 'Join online'}
+                  </Link>
+                </Text>
+              ) : null}
+              {opt.meetingId ? <Text style={baseText}>Meeting ID: {opt.meetingId}</Text> : null}
+              {opt.password ? <Text style={baseText}>Passcode: {opt.password}</Text> : null}
+              {opt.dialInNumber ? <Text style={baseText}>Dial-in: {opt.dialInNumber}</Text> : null}
+            </>
+          )}
+        </Section>
+      ))}
+    </Section>
+  )
+}

--- a/apps/email-builder/emails/BibleClass.tsx
+++ b/apps/email-builder/emails/BibleClass.tsx
@@ -29,6 +29,7 @@ import { FooterContent } from '../components/FooterContent'
 import { EmailBrandLinkContent } from '../components/EmailBrandLinkContent'
 import type { EmailIdentity } from '@my/app/types/brand-profile'
 import { AutoLinkText } from '../components/AutoLinkText'
+import { AttendOptions } from '../components/AttendOptions'
 
 const mockEvents: BibleClassType[] = [
   {
@@ -52,7 +53,11 @@ const BibleClass: React.FC<NextBibleClassProps & { identity?: EmailIdentity }> =
   const bibleClassEvents = events || mockEvents
   const currentEvent = bibleClassEvents[0]
   const nextEvent = bibleClassEvents[1]
-  const hasNoClass = currentEvent && isNoClass(currentEvent)
+  // Override precedence: 'cancelled' forces no-class; 'active' forces the class to
+  // show; otherwise fall back to the Speaker/Topic heuristic.
+  const isCancelled = currentEvent?.overrideStatus === 'cancelled'
+  const isForcedActive = currentEvent?.overrideStatus === 'active'
+  const hasNoClass = isCancelled || (!isForcedActive && !!currentEvent && isNoClass(currentEvent))
   // Find the next actual class (skipping any "no class" entries)
   const nextActualClass = hasNoClass && nextEvent && !isNoClass(nextEvent) ? nextEvent : undefined
 
@@ -66,6 +71,8 @@ const BibleClass: React.FC<NextBibleClassProps & { identity?: EmailIdentity }> =
   const showHostZoom = hasCustomZoom
   // Hide all Zoom only when InPerson is set but no custom Zoom
   const hideZoom = hasInPerson && !hasCustomZoom
+  // Per-occurrence attend-options supersede the hardcoded in-person + Zoom blocks
+  const hasAttendOptions = !!currentEvent?.attendOptions && currentEvent.attendOptions.length > 0
 
   const headingText = isJoint
     ? (currentEvent.MetaData || `Special Joint Bible Class with ${currentEvent.Host}`)
@@ -152,8 +159,11 @@ const BibleClass: React.FC<NextBibleClassProps & { identity?: EmailIdentity }> =
             <>
               <Section style={program}>
                 <Text style={{ ...defaultText, fontWeight: 'bold', fontSize: '18px' }}>
-                  There is no scheduled Bible class tonight.
+                  {currentEvent?.overrideMessage || 'There is no scheduled Bible class tonight.'}
                 </Text>
+                {currentEvent?.overrideNote ? (
+                  <Text style={defaultText}>{currentEvent.overrideNote}</Text>
+                ) : null}
               </Section>
               {nextActualClass ? (
                 <Section style={{ marginTop: '24px' }}>
@@ -193,8 +203,15 @@ const BibleClass: React.FC<NextBibleClassProps & { identity?: EmailIdentity }> =
           )}
         </Container>
 
+        {/* Per-occurrence "ways to attend" supersede the hardcoded blocks below */}
+        {!hasNoClass && hasAttendOptions ? (
+          <Container style={container} className="container">
+            <AttendOptions options={currentEvent?.attendOptions} />
+          </Container>
+        ) : null}
+
         {/* In-Person Location Section */}
-        {!hasNoClass && hasInPerson ? (
+        {!hasNoClass && !hasAttendOptions && hasInPerson ? (
           <Container style={container} className="container">
             <Section style={{
               backgroundColor: '#e8f5e9',
@@ -222,7 +239,7 @@ const BibleClass: React.FC<NextBibleClassProps & { identity?: EmailIdentity }> =
         ) : null}
 
         {/* Host Zoom Section (custom Zoom from host ecclesia) */}
-        {!hasNoClass && showHostZoom ? (
+        {!hasNoClass && !hasAttendOptions && showHostZoom ? (
           <Container style={container} className="container zoom-info">
             <Section style={{
               backgroundColor: '#e3f2fd',
@@ -260,7 +277,7 @@ const BibleClass: React.FC<NextBibleClassProps & { identity?: EmailIdentity }> =
         ) : null}
 
         {/* Default Toronto East Zoom Section */}
-        {!hasNoClass && !hideZoom && showDefaultZoom && !showHostZoom ? (
+        {!hasNoClass && !hasAttendOptions && !hideZoom && showDefaultZoom && !showHostZoom ? (
           <Container style={container} className="container zoom-info">
             <Text style={defaultText}>
               <Link

--- a/apps/email-builder/emails/Memorial.tsx
+++ b/apps/email-builder/emails/Memorial.tsx
@@ -32,6 +32,7 @@ import { EmailBrandLinkContent } from '../components/EmailBrandLinkContent'
 import { AutoLinkText } from '../components/AutoLinkText'
 import type { EmailIdentity } from '@my/app/types/brand-profile'
 import { ReplacementEventCard, findReplacementEvent } from '../components/ReplacementEventCard'
+import { AttendOptions } from '../components/AttendOptions'
 
 function getNextDayOfTheWeek(dayName: string, excludeToday = true, refDate = new Date()): Date {
   const dayOfWeek = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'].indexOf(
@@ -254,8 +255,15 @@ const MemorialService: React.FC<NextMemorialServiceProps & { identity?: EmailIde
           })()}
           <hr />
         </Container>
-        {/* Only show default Zoom info when there's a normal service at the hall */}
-        {(sundayEvents[0]?.Exhort || sundayEvents[0]?.Preside) ? (
+        {/* Per-occurrence "ways to attend" supersede the default Zoom block */}
+        {sundayEvents[0]?.attendOptions?.length ? (
+          <Container style={container} className="container">
+            <AttendOptions options={sundayEvents[0].attendOptions} />
+            <hr />
+          </Container>
+        ) : null}
+        {/* Only show default Zoom info when there's a normal service at the hall and no attend-options */}
+        {(sundayEvents[0]?.Exhort || sundayEvents[0]?.Preside) && !sundayEvents[0]?.attendOptions?.length ? (
           <Container style={container} className="container zoom-info">
             <Heading style={defaultText}>Join us on Zoom</Heading>
             <Text style={defaultText}>
@@ -351,14 +359,17 @@ const Parking = () => {
 }
 
 const MemorialServiceProgram = (event: SundayEvents, upcomingEvents?: Event[]) => {
-  // No service at hall: Both Exhort AND Preside are blank
-  const noServiceAtHall = !event.Exhort && !event.Preside
+  // Override precedence: 'cancelled' forces no-service (with optional message);
+  // 'active' forces the service to show; otherwise both Exhort AND Preside blank.
+  const isCancelled = event.overrideStatus === 'cancelled'
+  const isForcedActive = event.overrideStatus === 'active'
+  const noServiceAtHall = isCancelled || (!isForcedActive && !event.Exhort && !event.Preside)
 
   if (noServiceAtHall) {
     // If Lunch contains an event title, find the matching event and render it inline
     const eventTitle = event.Lunch?.trim()
     const replacementEvent = eventTitle ? findReplacementEvent(upcomingEvents || [], eventTitle) : undefined
-    const explanation = event.Activities || event['Holidays and Special Events']
+    const explanation = event.overrideNote || event.Activities || event['Holidays and Special Events']
 
     if (replacementEvent) {
       return <ReplacementEventCard event={replacementEvent} explanation={explanation} />
@@ -367,7 +378,7 @@ const MemorialServiceProgram = (event: SundayEvents, upcomingEvents?: Event[]) =
     // Fallback: no matching event found, show simple "no service" message
     return (
       <Text style={defaultText}>
-        <strong>There will be no service at our hall.</strong>
+        <strong>{event.overrideMessage || 'There will be no service at our hall.'}</strong>
         {explanation ? (
           <>
             <br />

--- a/apps/email-builder/emails/Newsletter.tsx
+++ b/apps/email-builder/emails/Newsletter.tsx
@@ -21,6 +21,7 @@ import { EmailBrandLinkContent } from '../components/EmailBrandLinkContent'
 import type { EmailIdentity } from '@my/app/types/brand-profile'
 import { AutoLinkText } from '../components/AutoLinkText'
 import { ReplacementEventCard, findReplacementEvent } from '../components/ReplacementEventCard'
+import { AttendOptions } from '../components/AttendOptions'
 
 type SundayEvents = MemorialServiceType &
   Pick<SundaySchoolType, 'Refreshments' | 'Holidays and Special Events'>
@@ -925,8 +926,11 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
                   /* Normal Sunday Services */
                   sundayEvents.map((event: any, index: number) => {
                     if (event.Key === 'sundaySchool') {
-                      // Only show full Sunday School section when there's class (has Refreshments)
-                      const hasSundaySchool = !!event.Refreshments
+                      // Override precedence: 'cancelled' forces no-class; 'active' forces
+                      // it to show; otherwise infer from Refreshments.
+                      const isCancelled = event.overrideStatus === 'cancelled'
+                      const isForcedActive = event.overrideStatus === 'active'
+                      const hasSundaySchool = isForcedActive || (!isCancelled && !!event.Refreshments)
 
                       return (
                         <Section key={`ss-${index}`} style={program}>
@@ -937,10 +941,19 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
                                 {'Refreshments: '}
                                 <strong>{event.Refreshments}</strong>
                               </Text>
+                              {event.overrideNote ? (
+                                <Text style={defaultText}>{event.overrideNote}</Text>
+                              ) : null}
                             </>
                           ) : (
                             <Text style={defaultText}>
-                              <strong>No Sunday school this week!</strong>
+                              <strong>{event.overrideMessage || 'No Sunday school this week!'}</strong>
+                              {event.overrideNote ? (
+                                <>
+                                  <br />
+                                  {event.overrideNote}
+                                </>
+                              ) : null}
                             </Text>
                           )}
                           {index < sundayEvents.length - 1 && (
@@ -1083,8 +1096,11 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
                 }
 
                 // Otherwise, show normal Bible Class
-                // Check if there's no class - same logic as NextBibleClass component: !event.Speaker
-                const hasClass = !!event.Speaker
+                // Override precedence: 'cancelled' forces no-class; 'active' forces it
+                // to show; otherwise infer from Speaker (same as NextBibleClass).
+                const bcIsCancelled = event.overrideStatus === 'cancelled'
+                const bcIsForcedActive = event.overrideStatus === 'active'
+                const hasClass = bcIsForcedActive || (!bcIsCancelled && !!event.Speaker)
 
                 // Joint Bible Class logic
                 const isJoint = !!event.Host
@@ -1161,8 +1177,16 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
                           <Row>
                             <Column style={columnAlignTop}>{BibleClassProgram(event)}</Column>
                           </Row>
+                          {/* Per-occurrence announcement note (shown alongside the class) */}
+                          {event.overrideNote ? (
+                            <Text style={defaultText}>{event.overrideNote}</Text>
+                          ) : null}
+                          {/* Per-occurrence "ways to attend" supersede the hardcoded blocks below */}
+                          {event.attendOptions?.length ? (
+                            <AttendOptions options={event.attendOptions} />
+                          ) : null}
                           {/* In-person location for joint Bible Class */}
-                          {hasInPerson ? (
+                          {!event.attendOptions?.length && hasInPerson ? (
                             <Section style={{
                               backgroundColor: '#e8f5e9',
                               padding: '12px 16px',
@@ -1187,7 +1211,7 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
                             </Section>
                           ) : null}
                           {/* Custom Zoom details for joint Bible Class (Zoom-only) */}
-                          {!hasInPerson && hasCustomZoom ? (
+                          {!event.attendOptions?.length && !hasInPerson && hasCustomZoom ? (
                             <Section style={{
                               backgroundColor: '#e3f2fd',
                               padding: '12px 16px',
@@ -1208,7 +1232,7 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
                             </Section>
                           ) : null}
                           {/* Hybrid: both in-person AND Zoom */}
-                          {hasInPerson && hasCustomZoom ? (
+                          {!event.attendOptions?.length && hasInPerson && hasCustomZoom ? (
                             <Section style={{
                               backgroundColor: '#e3f2fd',
                               padding: '12px 16px',
@@ -1233,8 +1257,11 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
                         <>
                           <Heading style={defaultText}>{bcHeading}</Heading>
                           <Text style={defaultText}>
-                            <strong>No Bible Class tonight</strong>
+                            <strong>{event.overrideMessage || 'No Bible Class tonight'}</strong>
                           </Text>
+                          {event.overrideNote ? (
+                            <Text style={defaultText}>{event.overrideNote}</Text>
+                          ) : null}
                         </>
                       )}
                     </Section>
@@ -2388,14 +2415,17 @@ const Lunch = ({ lunch }: { lunch: string }) => {
 }
 
 const MemorialServiceProgram = (event: SundayEvents, upcomingEvents?: Event[]) => {
-  // No service at hall: Both Exhort AND Preside are blank
-  const noServiceAtHall = !event.Exhort && !event.Preside
+  // Override precedence: 'cancelled' forces no-service (with optional message);
+  // 'active' forces the service to show; otherwise both Exhort AND Preside blank.
+  const isCancelled = event.overrideStatus === 'cancelled'
+  const isForcedActive = event.overrideStatus === 'active'
+  const noServiceAtHall = isCancelled || (!isForcedActive && !event.Exhort && !event.Preside)
 
   if (noServiceAtHall) {
     // If Lunch contains an event title, find the matching event and render it inline
     const eventTitle = event.Lunch?.trim()
     const replacementEvent = eventTitle ? findReplacementEvent(upcomingEvents || [], eventTitle) : undefined
-    const explanation = event.Activities || event['Holidays and Special Events']
+    const explanation = event.overrideNote || event.Activities || event['Holidays and Special Events']
 
     if (replacementEvent) {
       return <ReplacementEventCard event={replacementEvent} explanation={explanation} />
@@ -2404,7 +2434,7 @@ const MemorialServiceProgram = (event: SundayEvents, upcomingEvents?: Event[]) =
     // Fallback: no matching event found, show simple "no service" message
     return (
       <Text style={defaultText}>
-        <strong>There will be no service at our hall.</strong>
+        <strong>{event.overrideMessage || 'There will be no service at our hall.'}</strong>
         {explanation ? (
           <>
             <br />

--- a/apps/email-builder/emails/SundaySchool.tsx
+++ b/apps/email-builder/emails/SundaySchool.tsx
@@ -144,7 +144,13 @@ export const SundaySchoolProgram = ({ event }: EventProps) => {
       </Row>
     )
   }
-  if (event.Refreshments) {
+  // Override precedence: 'cancelled' forces no-class; 'active' forces the class to
+  // show; otherwise infer from Refreshments.
+  const isCancelled = event.overrideStatus === 'cancelled'
+  const isForcedActive = event.overrideStatus === 'active'
+  const hasClass = isForcedActive || (!isCancelled && !!event.Refreshments)
+
+  if (hasClass) {
     return (
       <Row align="left" width={'49%'} className="deviceWidth">
         <Column style={columnAlignTop}>
@@ -154,6 +160,12 @@ export const SundaySchoolProgram = ({ event }: EventProps) => {
             Start time: 9:30 am
             <br />
             Refreshments: {event.Refreshments}
+            {event.overrideNote ? (
+              <>
+                <br />
+                {event.overrideNote}
+              </>
+            ) : null}
             {event['Holidays and Special Events'] && (
               <>
                 <br />
@@ -171,7 +183,13 @@ export const SundaySchoolProgram = ({ event }: EventProps) => {
           <Text style={defaultText}>
             <strong>{event.Date.toString()}</strong>
             <br />
-            {event['Holidays and Special Events']}
+            {event.overrideMessage || event['Holidays and Special Events']}
+            {event.overrideNote ? (
+              <>
+                <br />
+                {event.overrideNote}
+              </>
+            ) : null}
           </Text>
         </Column>
       </Row>

--- a/apps/next/app/admin/(admin-plus)/schedule-overrides/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/schedule-overrides/page.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useAdminAccess } from '@/hooks/use-admin-access'
+import { YStack, Text, Spinner, Heading } from '@my/ui'
+import { useHydrated } from '@my/app/hooks/use-hydrated'
+import { ScheduleOverridesManager } from '@my/app/features/schedule-overrides'
+
+export default function AdminScheduleOverridesPage() {
+  const isHydrated = useHydrated()
+  const { hasAccess, isLoading } = useAdminAccess()
+
+  if (!isHydrated || isLoading) {
+    return (
+      <YStack flex={1} justifyContent="center" alignItems="center" padding="$4">
+        <Spinner size="large" width={36} height={36} />
+      </YStack>
+    )
+  }
+
+  if (!hasAccess) {
+    return (
+      <YStack flex={1} padding="$4">
+        <Text>Access denied. Admin access required.</Text>
+      </YStack>
+    )
+  }
+
+  return (
+    <YStack flex={1} padding="$4" space="$4">
+      <YStack space="$2">
+        <Heading size="$8">Service Overrides</Heading>
+        <Text color="$colorSecondary">
+          Make a per-occurrence exception for a recurring service without editing the schedule
+          sheet — cancel it with a custom message, force it to show, or add an announcement note.
+          Overrides apply to both the web newsletter and the emailed newsletter.
+        </Text>
+      </YStack>
+
+      <ScheduleOverridesManager />
+    </YStack>
+  )
+}

--- a/apps/next/app/api/admin/schedule-overrides/route.ts
+++ b/apps/next/app/api/admin/schedule-overrides/route.ts
@@ -1,0 +1,189 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+import { ScheduleService } from '@my/app/provider/dynamodb/schedule-service'
+import { serviceOverrideRepository } from '@my/app/provider/dynamodb/repositories/service-override-repository'
+import type { ServiceOverrideType } from '@my/app/provider/dynamodb/service-override-types'
+import { normalizeToISODate } from '@my/app/utils/service-overrides/merge'
+import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
+import { invalidateScheduleCache } from '@/utils/cache'
+
+/**
+ * Per-occurrence Service Overrides admin API.
+ * Scoped to the home ecclesia; gated to ADMIN/OWNER. Overrides live in `tee-admin`
+ * and are merged onto the synced schedule at read time (web + email).
+ *
+ * TODO(multi-tenant, #110): everything here pins HOME_ECCLESIA and gates on the
+ * GLOBAL admin/owner role. When multi-tenant lands, resolve the ecclesia from the
+ * request host and authorize against the caller's managedRegions.
+ */
+
+const SERVICE_TYPES: ServiceOverrideType[] = ['memorial', 'bibleClass', 'sundaySchool', 'cyc']
+const OCCURRENCE_WINDOW_DAYS = 70
+
+const scheduleService = new ScheduleService()
+
+function isValidServiceType(v: any): v is ServiceOverrideType {
+  return v === 'memorial' || v === 'bibleClass' || v === 'sundaySchool' || v === 'cyc'
+}
+
+async function requireAdmin() {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const role = ((session.user as any).role as string) || ROLES.GUEST
+  if (role !== ROLES.ADMIN && role !== ROLES.OWNER) {
+    return { error: NextResponse.json({ error: 'Admin access required' }, { status: 403 }) }
+  }
+  return { email: session.user.email }
+}
+
+/** Short human summary of an occurrence, per service type. */
+function summarize(serviceType: ServiceOverrideType, data: Record<string, any>): string {
+  switch (serviceType) {
+    case 'memorial': {
+      const parts = [data.Exhort, data.Preside].filter(Boolean)
+      return parts.length ? `Exhort: ${data.Exhort || '—'} · Preside: ${data.Preside || '—'}` : 'No roster (would show "no service")'
+    }
+    case 'bibleClass':
+      return data.Speaker ? `${data.Speaker}${data.Topic ? ` · ${data.Topic}` : ''}` : 'No speaker (sparse)'
+    case 'sundaySchool':
+      return data.Refreshments ? `Refreshments: ${data.Refreshments}` : 'No refreshments (would show "no Sunday School")'
+    case 'cyc': {
+      if (data.event) return String(data.event)
+      const parts = [data.speaker, data.topic].filter(Boolean)
+      return parts.length ? parts.join(' · ') : 'No CYC details (sparse)'
+    }
+    default:
+      return ''
+  }
+}
+
+/**
+ * GET — returns upcoming occurrences (next 10 weeks across service types) plus the
+ * current overrides for the home ecclesia, so the admin UI can list and edit them.
+ */
+export async function GET() {
+  const gate = await requireAdmin()
+  if (gate.error) return gate.error
+
+  const ecclesia = HOME_ECCLESIA.canonicalName
+  const todayISO = normalizeToISODate(new Date())
+  const to = new Date()
+  to.setDate(to.getDate() + OCCURRENCE_WINDOW_DAYS)
+  const toISO = normalizeToISODate(to)
+
+  try {
+    const occurrences: Array<{
+      serviceType: ServiceOverrideType
+      date: string
+      formattedDate: string
+      summary: string
+    }> = []
+
+    for (const serviceType of SERVICE_TYPES) {
+      const schedule = await scheduleService.getScheduleData(serviceType)
+      if (!schedule?.content) continue
+      for (const data of schedule.content as Record<string, any>[]) {
+        const date = normalizeToISODate(data.Date || data.DateTime || data.date)
+        if (!date || date < todayISO || date > toISO) continue
+        const formattedDate = new Date(`${date}T00:00:00.000Z`).toLocaleDateString('en-US', {
+          weekday: 'long',
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+          timeZone: 'UTC',
+        })
+        occurrences.push({ serviceType, date, formattedDate, summary: summarize(serviceType, data) })
+      }
+    }
+
+    occurrences.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : a.serviceType.localeCompare(b.serviceType)))
+
+    const overrides = await serviceOverrideRepository.listByDateRange(ecclesia, todayISO, toISO)
+
+    return NextResponse.json(
+      { ecclesia, occurrences, overrides },
+      { headers: { 'Cache-Control': 'no-store, max-age=0, must-revalidate' } }
+    )
+  } catch (error) {
+    console.error('Error loading schedule overrides:', error)
+    return NextResponse.json({ error: 'Failed to load schedule overrides' }, { status: 500 })
+  }
+}
+
+/** PUT/POST — upsert an override for (serviceType, date). */
+async function upsert(request: NextRequest) {
+  const gate = await requireAdmin()
+  if (gate.error) return gate.error
+
+  try {
+    const body = await request.json()
+    const { serviceType, date, status, message, note, attendOptions } = body
+
+    if (!isValidServiceType(serviceType)) {
+      return NextResponse.json({ error: 'Invalid serviceType' }, { status: 400 })
+    }
+    const normalizedDate = normalizeToISODate(date)
+    if (!normalizedDate) {
+      return NextResponse.json({ error: 'Invalid or missing date' }, { status: 400 })
+    }
+    if (status !== undefined && status !== 'cancelled' && status !== 'active') {
+      return NextResponse.json({ error: 'Invalid status' }, { status: 400 })
+    }
+
+    const record = await serviceOverrideRepository.upsert({
+      ecclesia: HOME_ECCLESIA.canonicalName,
+      serviceType,
+      date: normalizedDate,
+      status,
+      message,
+      note,
+      attendOptions,
+      createdBy: gate.email!,
+    })
+
+    await invalidateScheduleCache(serviceType)
+
+    return NextResponse.json(record)
+  } catch (error) {
+    console.error('Error saving schedule override:', error)
+    return NextResponse.json({ error: 'Failed to save schedule override' }, { status: 500 })
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  return upsert(request)
+}
+
+export async function POST(request: NextRequest) {
+  return upsert(request)
+}
+
+/** DELETE — remove an override by ?serviceType=&date=. */
+export async function DELETE(request: NextRequest) {
+  const gate = await requireAdmin()
+  if (gate.error) return gate.error
+
+  try {
+    const { searchParams } = new URL(request.url)
+    const serviceType = searchParams.get('serviceType')
+    const date = normalizeToISODate(searchParams.get('date') || '')
+
+    if (!isValidServiceType(serviceType)) {
+      return NextResponse.json({ error: 'Invalid serviceType' }, { status: 400 })
+    }
+    if (!date) {
+      return NextResponse.json({ error: 'Invalid or missing date' }, { status: 400 })
+    }
+
+    await serviceOverrideRepository.deleteOne(HOME_ECCLESIA.canonicalName, serviceType, date)
+    await invalidateScheduleCache(serviceType)
+
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error('Error deleting schedule override:', error)
+    return NextResponse.json({ error: 'Failed to delete schedule override' }, { status: 500 })
+  }
+}

--- a/apps/next/app/api/upcoming-program/route.ts
+++ b/apps/next/app/api/upcoming-program/route.ts
@@ -7,6 +7,14 @@ import { getEcclesiaByName } from '../../../utils/dynamodb/locations'
 import { redactScheduleData } from '@my/app/utils/redact-schedule'
 import { resolveViewer } from '../../../utils/resolve-viewer'
 import { piiAwareCacheControl } from '../../../utils/pii-response'
+import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
+import {
+  fetchServiceOverrides,
+  applyOverrideToProgramItem,
+  normalizeToISODate,
+  overrideKey,
+} from '@my/app/utils/service-overrides/merge'
+import type { ServiceOverrideType } from '@my/app/provider/dynamodb/service-override-types'
 
 // Cache for 15 minutes in production (shorter for faster updates when debugging)
 const CACHE_DURATION = process.env.NODE_ENV === 'production' ? 900 : 0
@@ -57,6 +65,21 @@ export async function GET(request: NextRequest) {
     
     console.log(`✅ Served upcoming program from DynamoDB cache (${upcomingEvents.length} events)`)
 
+    // Per-occurrence overrides (cancel / custom message / note / attend-options).
+    // Fetched OUTSIDE getCachedUpcomingProgram so admin edits show promptly rather
+    // than being trapped behind the 15-minute schedule cache.
+    // TODO(multi-tenant, #110): pinned to HOME_ECCLESIA — resolve the tenant from
+    // the request host and gate on managedRegions once multi-tenant lands.
+    const occurrenceDates = upcomingEvents.map(e => normalizeToISODate(e.date)).filter(Boolean)
+    const sortedDates = [...occurrenceDates].sort()
+    const serviceTypes = Array.from(new Set(upcomingEvents.map(e => e.type))) as ServiceOverrideType[]
+    const overrides = await fetchServiceOverrides(
+      HOME_ECCLESIA.canonicalName,
+      serviceTypes,
+      sortedDates[0] ?? '',
+      sortedDates[sortedDates.length - 1] ?? ''
+    )
+
     // Transform to match the original Google Sheets format that newsletter expects
     const responseData = upcomingEvents.map(event => {
       // The newsletter expects human-readable formatted date strings like "Sunday, August 31, 2025"
@@ -81,7 +104,12 @@ export async function GET(request: NextRequest) {
         Key: event.type, // Override with the correct Key field
         Date: formattedDate, // Set the Date field with human-readable format
       }
-      
+
+      // Merge any per-occurrence override (matched on the UTC date key).
+      const occurrenceDate = normalizeToISODate(event.date)
+      result.occurrenceDate = occurrenceDate
+      applyOverrideToProgramItem(result, overrides.get(overrideKey(event.type, occurrenceDate)))
+
       return result
     })
 

--- a/apps/next/tests/service-override-merge.test.ts
+++ b/apps/next/tests/service-override-merge.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeToISODate,
+  overrideKey,
+  applyOverrideToProgramItem,
+} from '@my/app/utils/service-overrides/merge'
+import type { ServiceOccurrenceOverrideRecord } from '@my/app/provider/dynamodb/service-override-types'
+
+/**
+ * The UTC date key is the fragile part of the overlay: the admin listing, the web
+ * transform (/api/upcoming-program) and the email transform (get_upcoming_program)
+ * must all derive the SAME `serviceType#YYYY-MM-DD` key from different date
+ * representations, or an override silently fails to match its occurrence.
+ */
+describe('normalizeToISODate (UTC date key)', () => {
+  it('derives the date from UTC components of a Date object', () => {
+    // 2025-08-03T23:30:00Z is still Aug 3 in UTC regardless of the host timezone.
+    expect(normalizeToISODate(new Date('2025-08-03T23:30:00.000Z'))).toBe('2025-08-03')
+    expect(normalizeToISODate(new Date('2025-08-03T00:00:00.000Z'))).toBe('2025-08-03')
+  })
+
+  it('takes the date part of an ISO datetime string as-is (no re-parse drift)', () => {
+    expect(normalizeToISODate('2025-08-03T15:00:00.000Z')).toBe('2025-08-03')
+    expect(normalizeToISODate('2025-12-25T04:59:59.000Z')).toBe('2025-12-25')
+  })
+
+  it('passes a plain YYYY-MM-DD through unchanged', () => {
+    expect(normalizeToISODate('2025-08-03')).toBe('2025-08-03')
+  })
+
+  it('returns empty string for unparseable / missing input', () => {
+    expect(normalizeToISODate('')).toBe('')
+    expect(normalizeToISODate(null)).toBe('')
+    expect(normalizeToISODate(undefined)).toBe('')
+    expect(normalizeToISODate('not a date')).toBe('')
+    expect(normalizeToISODate(new Date('invalid'))).toBe('')
+  })
+
+  it('agrees across the representations of the same occurrence (cross-path match)', () => {
+    // Admin listing keys off the ISO date string; the transform keys off a Date /
+    // ISO DateTime. All three must collapse to one key so the override matches.
+    const fromIsoDate = normalizeToISODate('2025-08-03')
+    const fromDateTime = normalizeToISODate('2025-08-03T18:00:00.000Z')
+    const fromDateObj = normalizeToISODate(new Date('2025-08-03T18:00:00.000Z'))
+    expect(fromIsoDate).toBe(fromDateTime)
+    expect(fromDateTime).toBe(fromDateObj)
+    expect(overrideKey('memorial', fromIsoDate)).toBe('memorial#2025-08-03')
+  })
+})
+
+describe('applyOverrideToProgramItem', () => {
+  const override: ServiceOccurrenceOverrideRecord = {
+    ecclesia: 'Toronto East',
+    serviceType: 'memorial',
+    date: '2025-08-03',
+    status: 'cancelled',
+    message: 'No service at our hall',
+    note: 'Joint meeting at Toronto West',
+    attendOptions: [{ id: 'o1', mode: 'stream', label: 'West Stream' }],
+  } as ServiceOccurrenceOverrideRecord
+
+  it('merges override fields onto the item without dropping synced roster fields', () => {
+    const item: Record<string, any> = { Key: 'memorial', Exhort: 'Bro A', Preside: 'Bro B' }
+    const result = applyOverrideToProgramItem(item, override)
+    expect(result.Exhort).toBe('Bro A') // synced field preserved
+    expect(result.overrideStatus).toBe('cancelled')
+    expect(result.overrideMessage).toBe('No service at our hall')
+    expect(result.overrideNote).toBe('Joint meeting at Toronto West')
+    expect(result.attendOptions).toHaveLength(1)
+  })
+
+  it('is a no-op when there is no matching override', () => {
+    const item: Record<string, any> = { Key: 'memorial', Exhort: 'Bro A' }
+    const result = applyOverrideToProgramItem(item, undefined)
+    expect(result.overrideStatus).toBeUndefined()
+    expect(result).toEqual({ Key: 'memorial', Exhort: 'Bro A' })
+  })
+})

--- a/packages/app/features/newsletter/attend-options.tsx
+++ b/packages/app/features/newsletter/attend-options.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { Anchor, ExtLink, Paragraph, Text, YStack, XStack } from '@my/ui'
+import { MapPin, Video, Radio } from '@tamagui/lucide-icons'
+import type { AttendOption } from '@my/app/types'
+
+/**
+ * "Ways to attend" list for a single service occurrence.
+ *
+ * Phase 2 of per-occurrence overrides: an occurrence can offer several
+ * simultaneous access methods (e.g. a Toronto West live stream AND a Toronto
+ * East Zoom). When present, this supersedes the hardcoded single-Zoom block.
+ */
+type AttendOptionsProps = {
+  options?: AttendOption[]
+}
+
+export const AttendOptions: React.FC<AttendOptionsProps> = ({ options }) => {
+  if (!options || options.length === 0) return null
+
+  return (
+    <YStack gap="$2" marginTop="$2">
+      <Paragraph fontWeight={700}>Ways to attend:</Paragraph>
+      {options.map((opt) => (
+        <YStack
+          key={opt.id}
+          gap="$1"
+          padding="$3"
+          backgroundColor="$backgroundHover"
+          borderRadius="$3"
+          borderLeftWidth={4}
+          borderLeftColor="$blue9"
+        >
+          <XStack gap="$2" alignItems="center">
+            {opt.mode === 'in_person' ? <MapPin size={16} /> : null}
+            {opt.mode === 'stream' ? <Radio size={16} /> : null}
+            {opt.mode === 'online' ? <Video size={16} /> : null}
+            <Paragraph fontWeight={700}>
+              {opt.label}
+              {opt.hostEcclesia ? ` — ${opt.hostEcclesia}` : ''}
+            </Paragraph>
+          </XStack>
+
+          {opt.mode === 'in_person' ? (
+            <YStack paddingLeft="$5" gap="$1">
+              {opt.address ? <Paragraph>{opt.address}</Paragraph> : null}
+              {opt.mapsUrl ? (
+                <Anchor href={opt.mapsUrl} target="_blank">
+                  <Text color="$blue10" fontWeight={600}>View on Google Maps</Text>
+                </Anchor>
+              ) : null}
+            </YStack>
+          ) : (
+            <YStack paddingLeft="$5" gap="$1">
+              {opt.url ? (
+                <ExtLink href={opt.url}>
+                  <Text color="$blue10" fontWeight={600}>
+                    {opt.mode === 'stream' ? 'Watch the stream' : 'Join online'}
+                  </Text>
+                </ExtLink>
+              ) : null}
+              {opt.meetingId ? <Paragraph>Meeting ID: {opt.meetingId}</Paragraph> : null}
+              {opt.password ? <Paragraph>Passcode: {opt.password}</Paragraph> : null}
+              {opt.dialInNumber ? <Paragraph>Dial-in: {opt.dialInNumber}</Paragraph> : null}
+            </YStack>
+          )}
+        </YStack>
+      ))}
+    </YStack>
+  )
+}

--- a/packages/app/features/newsletter/bible-class.tsx
+++ b/packages/app/features/newsletter/bible-class.tsx
@@ -5,6 +5,7 @@ import { brandColors, type ColorMode } from '@my/ui/src/branding/brand-colors'
 
 import { BibleClassType } from '@my/app/types'
 import { Section } from '@my/app/features/newsletter/Section'
+import { AttendOptions } from '@my/app/features/newsletter/attend-options'
 
 type NextBibleClassProps = {
   event: BibleClassType
@@ -17,14 +18,24 @@ export const NextBibleClass: React.FC<NextBibleClassProps> = ({ event }) => {
   const isJoint = !!event.Host
   const hasInPerson = !!event.InPerson
   const hasCustomZoom = !!(event.ZoomURL || event.MeetingID)
+  // When per-occurrence attend-options are set, they supersede the hardcoded
+  // in-person card + Zoom accordion (admin has listed the ways to attend).
+  const hasAttendOptions = !!event.attendOptions && event.attendOptions.length > 0
 
-  if (!event.Speaker) {
+  // Override precedence: 'cancelled' forces the no-class branch (with optional
+  // message); 'active' forces the class to show; otherwise infer from Speaker.
+  const isCancelled = event.overrideStatus === 'cancelled'
+  const isForcedActive = event.overrideStatus === 'active'
+  const noClass = isCancelled || (!isForcedActive && !event.Speaker)
+
+  if (noClass) {
     return (
       <Section>
         <Paragraph size={'$5'} fontWeight={600}>
           {event.Date.toString()}
         </Paragraph>
-        <Paragraph>{event.Topic}</Paragraph>
+        <Paragraph>{event.overrideMessage || event.Topic}</Paragraph>
+        {event.overrideNote ? <Paragraph>{event.overrideNote}</Paragraph> : null}
       </Section>
     )
   }
@@ -69,9 +80,15 @@ export const NextBibleClass: React.FC<NextBibleClassProps> = ({ event }) => {
         <Text fontWeight={600}>Leader:</Text> {event.Speaker}
       </Paragraph>
       {event.Topic ? <Paragraph fontWeight={600}>{event.Topic}</Paragraph> : null}
+      {event.overrideNote ? (
+        <Paragraph fontWeight={600} color="$blue11">{event.overrideNote}</Paragraph>
+      ) : null}
+
+      {/* Per-occurrence "ways to attend" — supersedes the hardcoded blocks below */}
+      {hasAttendOptions ? <AttendOptions options={event.attendOptions} /> : null}
 
       {/* In-person location card for joint classes */}
-      {isJoint && hasInPerson ? (
+      {!hasAttendOptions && isJoint && hasInPerson ? (
         <YStack
           backgroundColor="$green3"
           padding="$3"
@@ -102,6 +119,7 @@ export const NextBibleClass: React.FC<NextBibleClassProps> = ({ event }) => {
       ) : null}
 
       {/* Zoom details accordion */}
+      {!hasAttendOptions ? (
       <Accordion overflow="hidden" type="multiple">
         <Accordion.Item value="a1">
           <Accordion.Trigger flexDirection="row" justifyContent="space-between">
@@ -166,6 +184,7 @@ export const NextBibleClass: React.FC<NextBibleClassProps> = ({ event }) => {
           </Accordion.Content>
         </Accordion.Item>
       </Accordion>
+      ) : null}
     </Section>
   )
 }

--- a/packages/app/features/newsletter/memorial.tsx
+++ b/packages/app/features/newsletter/memorial.tsx
@@ -5,6 +5,7 @@ import { Accordion, Anchor, ExtLink, Paragraph, Separator, Square, Text, YStack 
 import { XStack } from 'tamagui'
 import { ChevronDown, MapPin } from '@tamagui/lucide-icons'
 import { Section } from '@my/app/features/newsletter/Section'
+import { AttendOptions } from '@my/app/features/newsletter/attend-options'
 
 /** Find an event by title (case-insensitive substring match) */
 function findReplacementEvent(
@@ -23,8 +24,13 @@ type NextMemorialProps = {
   upcomingEvents?: Event[]
 }
 export const NextMemorial: React.FC<NextMemorialProps> = ({ event, isSameDay, upcomingEvents }) => {
-  // No service at hall: Both Exhort AND Preside are blank
-  const noServiceAtHall = !event.Exhort && !event.Preside
+  // Per-occurrence override precedence:
+  // - 'cancelled' forces the no-service branch (with optional custom message)
+  // - 'active' forces the normal service render even if the roster is blank
+  // - otherwise fall back to the synced heuristic (both Exhort AND Preside blank)
+  const isCancelled = event.overrideStatus === 'cancelled'
+  const isForcedActive = event.overrideStatus === 'active'
+  const noServiceAtHall = isCancelled || (!isForcedActive && !event.Exhort && !event.Preside)
 
   if (noServiceAtHall) {
     // The Lunch field contains the event title to match (same convention as email template)
@@ -40,7 +46,10 @@ export const NextMemorial: React.FC<NextMemorialProps> = ({ event, isSameDay, up
         <Paragraph size={'$5'} fontWeight={600}>
           {event.Date.toString()}
         </Paragraph>
-        <Paragraph fontWeight={600}>There will be no service at our hall.</Paragraph>
+        <Paragraph fontWeight={600}>
+          {event.overrideMessage || 'There will be no service at our hall.'}
+        </Paragraph>
+        {event.overrideNote ? <Paragraph>{event.overrideNote}</Paragraph> : null}
         {explanation ? <Paragraph>{explanation}</Paragraph> : null}
 
         {/* Replacement event details */}
@@ -111,6 +120,8 @@ export const NextMemorial: React.FC<NextMemorialProps> = ({ event, isSameDay, up
 
   // If Exhort is blank but Preside has a value, exhorter is TBD (show "--")
   const exhorterDisplay = event.Exhort || '--'
+  // Per-occurrence attend-options supersede the hardcoded Zoom accordion.
+  const hasAttendOptions = !!event.attendOptions && event.attendOptions.length > 0
 
   return (
     <Section>
@@ -122,6 +133,9 @@ export const NextMemorial: React.FC<NextMemorialProps> = ({ event, isSameDay, up
       <Paragraph size={'$5'} fontWeight={600}>
         Memorial Service at 11:00am
       </Paragraph>
+      {event.overrideNote ? (
+        <Paragraph fontWeight={600} color="$blue11">{event.overrideNote}</Paragraph>
+      ) : null}
       <XStack $xs={{ flexDirection: 'column' }}>
         <YStack flexGrow={1}>
           <Paragraph>
@@ -158,8 +172,10 @@ export const NextMemorial: React.FC<NextMemorialProps> = ({ event, isSameDay, up
       {event.Collection ? <Paragraph>Second Collection is for {event.Collection}</Paragraph> : null}
       {event.Lunch ? <Paragraph fontWeight={600}>{event.Lunch}</Paragraph> : null}
       {event.Activities ? <Paragraph>{event.Activities}</Paragraph> : null}
+      {hasAttendOptions ? <AttendOptions options={event.attendOptions} /> : null}
       <Separator alignSelf="stretch" borderColor={'$light4grey'} />
       <Accordion overflow="hidden" type="multiple">
+        {!hasAttendOptions ? (
         <Accordion.Item value="a1">
           <Accordion.Trigger flexDirection="row" justifyContent="space-between">
             {({ open }: { open: boolean }) => (
@@ -201,6 +217,7 @@ export const NextMemorial: React.FC<NextMemorialProps> = ({ event, isSameDay, up
             </Paragraph>
           </Accordion.Content>
         </Accordion.Item>
+        ) : null}
 
         <Accordion.Item value="a2">
           <Accordion.Trigger flexDirection="row" justifyContent="space-between">

--- a/packages/app/features/newsletter/sunday-school.tsx
+++ b/packages/app/features/newsletter/sunday-school.tsx
@@ -7,13 +7,20 @@ export type NextSundaySchoolProps = {
   event: SundaySchoolType
 }
 export const NextSundaySchool: React.FC<NextSundaySchoolProps> = ({ event }) => {
-  if (!event.Refreshments) {
+  // Override precedence: 'cancelled' forces no-class (with optional message);
+  // 'active' forces the class to show; otherwise infer from Refreshments.
+  const isCancelled = event.overrideStatus === 'cancelled'
+  const isForcedActive = event.overrideStatus === 'active'
+  const noClass = isCancelled || (!isForcedActive && !event.Refreshments)
+
+  if (noClass) {
     return (
       <YStack borderTopColor="$gray1Dark" borderWidth={1} borderTopWidth={2} padding="$size.1">
         <Paragraph size={'$5'} fontWeight={600}>
           {event.Date.toString()}
         </Paragraph>
-        <Paragraph>No Sunday School this week</Paragraph>
+        <Paragraph>{event.overrideMessage || 'No Sunday School this week'}</Paragraph>
+        {event.overrideNote ? <Paragraph>{event.overrideNote}</Paragraph> : null}
       </YStack>
     )
   }
@@ -25,6 +32,9 @@ export const NextSundaySchool: React.FC<NextSundaySchoolProps> = ({ event }) => 
       <Paragraph size={'$5'} fontWeight={600}>
         Sunday School at 9:30am
       </Paragraph>
+      {event.overrideNote ? (
+        <Paragraph fontWeight={600} color="$blue11">{event.overrideNote}</Paragraph>
+      ) : null}
       <Paragraph>Refreshments provided by: {event.Refreshments}</Paragraph>
     </Section>
   )

--- a/packages/app/features/schedule-overrides/index.ts
+++ b/packages/app/features/schedule-overrides/index.ts
@@ -1,0 +1,1 @@
+export { ScheduleOverridesManager } from './schedule-overrides-manager'

--- a/packages/app/features/schedule-overrides/schedule-overrides-manager.tsx
+++ b/packages/app/features/schedule-overrides/schedule-overrides-manager.tsx
@@ -1,0 +1,388 @@
+'use client'
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { YStack, XStack, Text, Heading, Card, Button, Separator, Spinner, Input } from '@my/ui'
+import type { AttendOption, AttendMode } from '@my/app/types'
+
+type ServiceType = 'memorial' | 'bibleClass' | 'sundaySchool' | 'cyc'
+
+const newOptionId = (): string => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
+  return `opt-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+}
+
+const MODE_LABELS: Record<AttendMode, string> = {
+  in_person: 'In person',
+  stream: 'Live stream',
+  online: 'Online',
+}
+
+const SERVICE_LABELS: Record<string, string> = {
+  memorial: 'Memorial',
+  bibleClass: 'Bible Class',
+  sundaySchool: 'Sunday School',
+  cyc: 'CYC',
+}
+
+type Occurrence = {
+  serviceType: ServiceType
+  date: string // YYYY-MM-DD
+  formattedDate: string
+  summary: string
+}
+
+type OverrideRecord = {
+  serviceType: ServiceType
+  date: string
+  status?: 'cancelled' | 'active'
+  message?: string
+  note?: string
+  attendOptions?: AttendOption[]
+}
+
+type ApiResponse = {
+  ecclesia: string
+  occurrences: Occurrence[]
+  overrides: OverrideRecord[]
+}
+
+type DraftStatus = 'default' | 'cancelled' | 'active'
+
+type Draft = {
+  status: DraftStatus
+  message: string
+  note: string
+  attendOptions: AttendOption[]
+}
+
+const keyOf = (serviceType: string, date: string) => `${serviceType}#${date}`
+
+const draftFromOverride = (o?: OverrideRecord): Draft => ({
+  status: o?.status ?? 'default',
+  message: o?.message ?? '',
+  note: o?.note ?? '',
+  attendOptions: o?.attendOptions ?? [],
+})
+
+export const ScheduleOverridesManager: React.FC = () => {
+  const [data, setData] = useState<ApiResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [savingKey, setSavingKey] = useState<string | null>(null)
+  const [drafts, setDrafts] = useState<Record<string, Draft>>({})
+  const [status, setStatus] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setStatus(null)
+    try {
+      const res = await fetch('/api/admin/schedule-overrides', { cache: 'no-store' })
+      if (!res.ok) throw new Error('Failed to load')
+      const json: ApiResponse = await res.json()
+      setData(json)
+      // Seed drafts from existing overrides
+      const seeded: Record<string, Draft> = {}
+      for (const o of json.overrides) {
+        seeded[keyOf(o.serviceType, o.date)] = draftFromOverride(o)
+      }
+      setDrafts(seeded)
+    } catch (err) {
+      setStatus({ type: 'error', text: 'Failed to load upcoming services.' })
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const overridesByKey = useMemo(() => {
+    const map: Record<string, OverrideRecord> = {}
+    for (const o of data?.overrides ?? []) map[keyOf(o.serviceType, o.date)] = o
+    return map
+  }, [data])
+
+  const getDraft = (k: string): Draft =>
+    drafts[k] ?? { status: 'default', message: '', note: '', attendOptions: [] }
+
+  const setDraft = (k: string, patch: Partial<Draft>) => {
+    setDrafts((prev) => ({ ...prev, [k]: { ...getDraft(k), ...patch } }))
+  }
+
+  const addOption = (k: string) => {
+    const d = getDraft(k)
+    setDraft(k, {
+      attendOptions: [...d.attendOptions, { id: newOptionId(), label: '', mode: 'online' }],
+    })
+  }
+
+  const updateOption = (k: string, idx: number, patch: Partial<AttendOption>) => {
+    const d = getDraft(k)
+    setDraft(k, {
+      attendOptions: d.attendOptions.map((o, i) => (i === idx ? { ...o, ...patch } : o)),
+    })
+  }
+
+  const removeOption = (k: string, idx: number) => {
+    const d = getDraft(k)
+    setDraft(k, { attendOptions: d.attendOptions.filter((_, i) => i !== idx) })
+  }
+
+  const save = async (occ: Occurrence) => {
+    const k = keyOf(occ.serviceType, occ.date)
+    const draft = getDraft(k)
+    setSavingKey(k)
+    setStatus(null)
+    try {
+      const res = await fetch('/api/admin/schedule-overrides', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          serviceType: occ.serviceType,
+          date: occ.date,
+          status: draft.status === 'default' ? undefined : draft.status,
+          message: draft.message || undefined,
+          note: draft.note || undefined,
+          attendOptions: draft.attendOptions.length
+            ? draft.attendOptions.filter((o) => o.label.trim())
+            : undefined,
+        }),
+      })
+      if (!res.ok) throw new Error('save failed')
+      setStatus({ type: 'success', text: `Saved override for ${SERVICE_LABELS[occ.serviceType]} on ${occ.formattedDate}.` })
+      await load()
+    } catch (err) {
+      setStatus({ type: 'error', text: 'Failed to save override.' })
+    } finally {
+      setSavingKey(null)
+    }
+  }
+
+  const clear = async (occ: Occurrence) => {
+    const k = keyOf(occ.serviceType, occ.date)
+    setSavingKey(k)
+    setStatus(null)
+    try {
+      const res = await fetch(
+        `/api/admin/schedule-overrides?serviceType=${encodeURIComponent(occ.serviceType)}&date=${encodeURIComponent(occ.date)}`,
+        { method: 'DELETE' }
+      )
+      if (!res.ok) throw new Error('delete failed')
+      setDrafts((prev) => {
+        const next = { ...prev }
+        delete next[k]
+        return next
+      })
+      setStatus({ type: 'success', text: `Cleared override for ${SERVICE_LABELS[occ.serviceType]} on ${occ.formattedDate}.` })
+      await load()
+    } catch (err) {
+      setStatus({ type: 'error', text: 'Failed to clear override.' })
+    } finally {
+      setSavingKey(null)
+    }
+  }
+
+  if (loading) {
+    return (
+      <YStack justifyContent="center" alignItems="center" padding="$6">
+        <Spinner size="large" width={36} height={36} />
+        <Text marginTop="$3">Loading upcoming services...</Text>
+      </YStack>
+    )
+  }
+
+  const occurrences = data?.occurrences ?? []
+
+  return (
+    <YStack space="$4">
+      {status ? (
+        <Card
+          padding="$3"
+          backgroundColor={status.type === 'success' ? '$green2' : '$red2'}
+          borderWidth={1}
+          borderColor={status.type === 'success' ? '$green6' : '$red6'}
+        >
+          <Text color={status.type === 'success' ? '$green11' : '$red11'}>{status.text}</Text>
+        </Card>
+      ) : null}
+
+      <XStack>
+        <Button size="$3" variant="outlined" onPress={load}>
+          Refresh
+        </Button>
+      </XStack>
+
+      {occurrences.length === 0 ? (
+        <Card padding="$4" borderWidth={1} borderColor="$borderColor">
+          <Text color="$colorSecondary">No upcoming services found in the next 10 weeks.</Text>
+        </Card>
+      ) : (
+        <YStack space="$3">
+          {occurrences.map((occ) => {
+            const k = keyOf(occ.serviceType, occ.date)
+            const draft = getDraft(k)
+            const hasOverride = !!overridesByKey[k]
+            const isSaving = savingKey === k
+
+            return (
+              <Card key={k} padding="$4" borderWidth={1} borderColor={hasOverride ? '$blue6' : '$borderColor'}>
+                <YStack space="$3">
+                  <XStack justifyContent="space-between" alignItems="flex-start" flexWrap="wrap" gap="$2">
+                    <YStack flex={1} minWidth={220} space="$1">
+                      <Text fontSize="$5" fontWeight="600">
+                        {SERVICE_LABELS[occ.serviceType]} — {occ.formattedDate}
+                      </Text>
+                      <Text fontSize="$2" color="$colorSecondary">
+                        {occ.summary}
+                      </Text>
+                    </YStack>
+                    {hasOverride ? (
+                      <Text fontSize="$2" color="$blue11" fontWeight="600">
+                        Override active
+                      </Text>
+                    ) : null}
+                  </XStack>
+
+                  <Separator />
+
+                  <YStack space="$2">
+                    <Text fontSize="$2" fontWeight="600" color="$colorSecondary">
+                      Status
+                    </Text>
+                    <XStack space="$2" flexWrap="wrap">
+                      {(['default', 'cancelled', 'active'] as DraftStatus[]).map((s) => (
+                        <Button
+                          key={s}
+                          size="$2"
+                          theme={draft.status === s ? 'blue' : undefined}
+                          variant={draft.status === s ? undefined : 'outlined'}
+                          onPress={() => setDraft(k, { status: s })}
+                        >
+                          {s === 'default' ? 'Use schedule default' : s === 'cancelled' ? 'Cancel service' : 'Force show'}
+                        </Button>
+                      ))}
+                    </XStack>
+                  </YStack>
+
+                  <YStack space="$2">
+                    <Text fontSize="$2" fontWeight="600" color="$colorSecondary">
+                      Custom message {draft.status === 'cancelled' ? '(replaces the "no service" text)' : '(shown when cancelled)'}
+                    </Text>
+                    <Input
+                      value={draft.message}
+                      onChangeText={(t) => setDraft(k, { message: t })}
+                      placeholder='e.g. "No service at Toronto East — joint meeting at Toronto West"'
+                    />
+                  </YStack>
+
+                  <YStack space="$2">
+                    <Text fontSize="$2" fontWeight="600" color="$colorSecondary">
+                      Note (announcement shown with the service)
+                    </Text>
+                    <Input
+                      value={draft.note}
+                      onChangeText={(t) => setDraft(k, { note: t })}
+                      placeholder='e.g. "Carpool leaves the hall at 10am"'
+                    />
+                  </YStack>
+
+                  <YStack space="$2">
+                    <XStack justifyContent="space-between" alignItems="center">
+                      <Text fontSize="$2" fontWeight="600" color="$colorSecondary">
+                        Ways to attend (overrides the default Zoom block)
+                      </Text>
+                      <Button size="$2" variant="outlined" onPress={() => addOption(k)}>
+                        + Add
+                      </Button>
+                    </XStack>
+
+                    {draft.attendOptions.map((opt, idx) => (
+                      <YStack key={opt.id} space="$2" padding="$3" borderWidth={1} borderColor="$borderColor" borderRadius="$3">
+                        <XStack space="$2" flexWrap="wrap">
+                          {(['in_person', 'stream', 'online'] as AttendMode[]).map((m) => (
+                            <Button
+                              key={m}
+                              size="$2"
+                              theme={opt.mode === m ? 'blue' : undefined}
+                              variant={opt.mode === m ? undefined : 'outlined'}
+                              onPress={() => updateOption(k, idx, { mode: m })}
+                            >
+                              {MODE_LABELS[m]}
+                            </Button>
+                          ))}
+                        </XStack>
+                        <Input
+                          value={opt.label}
+                          onChangeText={(t) => updateOption(k, idx, { label: t })}
+                          placeholder='Label, e.g. "Toronto West Stream" or "Toronto East Zoom"'
+                        />
+                        {opt.mode === 'in_person' ? (
+                          <>
+                            <Input
+                              value={opt.address ?? ''}
+                              onChangeText={(t) => updateOption(k, idx, { address: t })}
+                              placeholder="Address"
+                            />
+                            <Input
+                              value={opt.mapsUrl ?? ''}
+                              onChangeText={(t) => updateOption(k, idx, { mapsUrl: t })}
+                              placeholder="Google Maps URL (optional)"
+                            />
+                          </>
+                        ) : (
+                          <>
+                            <Input
+                              value={opt.url ?? ''}
+                              onChangeText={(t) => updateOption(k, idx, { url: t })}
+                              placeholder={opt.mode === 'stream' ? 'Stream URL' : 'Join URL'}
+                            />
+                            {opt.mode === 'online' ? (
+                              <>
+                                <Input
+                                  value={opt.meetingId ?? ''}
+                                  onChangeText={(t) => updateOption(k, idx, { meetingId: t })}
+                                  placeholder="Meeting ID (optional)"
+                                />
+                                <Input
+                                  value={opt.password ?? ''}
+                                  onChangeText={(t) => updateOption(k, idx, { password: t })}
+                                  placeholder="Passcode (optional)"
+                                />
+                              </>
+                            ) : null}
+                          </>
+                        )}
+                        <XStack>
+                          <Button size="$2" variant="outlined" theme="red" onPress={() => removeOption(k, idx)}>
+                            Remove
+                          </Button>
+                        </XStack>
+                      </YStack>
+                    ))}
+                  </YStack>
+
+                  <XStack space="$2" flexWrap="wrap">
+                    <Button
+                      size="$3"
+                      theme="blue"
+                      onPress={() => save(occ)}
+                      disabled={isSaving}
+                      icon={isSaving ? <Spinner size="small" width={16} height={16} /> : undefined}
+                    >
+                      {isSaving ? 'Saving...' : 'Save override'}
+                    </Button>
+                    {hasOverride ? (
+                      <Button size="$3" variant="outlined" onPress={() => clear(occ)} disabled={isSaving}>
+                        Clear override
+                      </Button>
+                    ) : null}
+                  </XStack>
+                </YStack>
+              </Card>
+            )
+          })}
+        </YStack>
+      )}
+    </YStack>
+  )
+}

--- a/packages/app/features/with-navigation.tsx
+++ b/packages/app/features/with-navigation.tsx
@@ -184,6 +184,12 @@ const AdminOwnerMenu: React.FC<SubMenuType> = ({ linkTo, path }) => {
         text="Meeting Manager"
         active={path === '/admin/meetings'}
       />
+      <NavigationButtonItem
+        key="scheduleOverrides"
+        linkTo={linkTo('/admin/schedule-overrides')}
+        text="Service Overrides"
+        active={path === '/admin/schedule-overrides'}
+      />
 
       {/* Admin Tools Sub-menu */}
       <NavHeading>

--- a/packages/app/types.ts
+++ b/packages/app/types.ts
@@ -166,6 +166,27 @@ export type SimplifiedContacts = {
   subscribed: { [key: email]: ContactPreferences }
 }
 
+// Re-export per-occurrence override types so consumers can import from @my/app/types.
+export type {
+  AttendOption,
+  AttendMode,
+  OverrideStatus,
+  ServiceOverrideType,
+} from '@my/app/provider/dynamodb/service-override-types'
+
+/**
+ * Per-occurrence override fields merged onto a synced service at read time.
+ * Source of truth: packages/app/provider/dynamodb/service-override-types.ts.
+ * `occurrenceDate` is the stable UTC YYYY-MM-DD key set by the transform paths.
+ */
+export type ServiceOverrideCarryFields = {
+  overrideStatus?: import('@my/app/provider/dynamodb/service-override-types').OverrideStatus
+  overrideMessage?: string
+  overrideNote?: string
+  attendOptions?: import('@my/app/provider/dynamodb/service-override-types').AttendOption[]
+  occurrenceDate?: string
+}
+
 export type MemorialServiceType = {
   Date: string | Date
   Key: ProgramsTypes.memorial
@@ -187,7 +208,7 @@ export type MemorialServiceType = {
   // Timezone-aware datetime fields
   DateTime?: string        // Full ISO datetime in UTC: "2026-02-01T16:00:00.000Z"
   ServiceTimezone?: string // IANA timezone: "America/Toronto"
-}
+} & ServiceOverrideCarryFields
 
 export type SundaySchoolType = {
   Date: string | Date
@@ -197,7 +218,7 @@ export type SundaySchoolType = {
   // Timezone-aware datetime fields
   DateTime?: string        // Full ISO datetime in UTC: "2026-02-01T14:30:00.000Z"
   ServiceTimezone?: string // IANA timezone: "America/Toronto"
-}
+} & ServiceOverrideCarryFields
 
 export type SundayEvents = MemorialServiceType &
   Pick<SundaySchoolType, 'Refreshments' | 'Holidays and Special Events'>
@@ -232,7 +253,7 @@ export type BibleClassType = {
   resolvedAddress?: string     // Full address from ecclesia lookup
   resolvedVenue?: string       // Venue name from ecclesia lookup
   resolvedMapUrl?: string      // Google Maps link for the host ecclesia
-}
+} & ServiceOverrideCarryFields
 
 export type NextBibleClassProps = {
   events: BibleClassType[]
@@ -261,7 +282,7 @@ export type CycType = {
   // Timezone-aware datetime fields
   DateTime?: string        // Full ISO datetime in UTC
   ServiceTimezone?: string // IANA timezone: "America/Toronto"
-} & (CycRegular | CycSpecial)
+} & (CycRegular | CycSpecial) & ServiceOverrideCarryFields
 
 export type ProgramTypes = MemorialServiceType | SundaySchoolType | BibleClassType | CycType
 


### PR DESCRIPTION
Closes #111.

## What
Overlay individual schedule occurrences on top of the recurring/Sheets base **without editing the sheet**. An admin can, per occurrence:
- **Cancel** a service (with an editable "no service" message),
- **Force show** it even when the synced roster is blank,
- add an **announcement note** shown with the service, and
- list per-occurrence **"ways to attend"** (in-person / stream / online) that supersede the hardcoded single-Zoom block.

Overrides live in `tee-admin` (`SERVICE_OVERRIDE#{ecclesia}`) and are merged onto the synced schedule **at read time**, so both the web newsletter and the emailed newsletter agree.

This is a clean, overrides-only PR reconstructed from the WIP `feat/schedule-occurrence-overrides` "crash-recovery" commit (which had swept in unrelated docs/CLAUDE.md/SVG/events changes — those are excluded).

## Why
Prototypes the overlay pattern the roster-CRUD epic will build on, and covers the immediate need (cancel/adjust a single week — e.g. a joint meeting elsewhere) without touching the Google Sheet.

## How it's built
- **Admin API** `apps/next/app/api/admin/schedule-overrides/route.ts` — GET upcoming occurrences (10-week window) + current overrides; PUT/POST upsert; DELETE clear. Gated to ADMIN/OWNER; invalidates the schedule cache on write.
- **Manager UI** `/admin/schedule-overrides` (`packages/app/features/schedule-overrides/*`) + nav link ("Service Overrides").
- **Web transform** `/api/upcoming-program` applies overrides **outside** the 15-min schedule cache so edits show promptly — **reconciled with main's viewer-aware PII redaction (both kept)**.
- **Render consumption**: web newsletter (memorial / bible-class / sunday-school) and the react-email templates (Newsletter / Memorial / BibleClass / SundaySchool) + shared `AttendOptions` (a react-email-safe copy for email, a Tamagui copy for web).
- **Types**: `ServiceOverrideCarryFields` mixed into the service types.
- Added `cyc` to the admin route's occurrence list (type/validator/render already supported it).

> The merge / repository / types / `home-ecclesia` infra already landed on `main`; `get_upcoming_program` (the email data path) already applies overrides. This PR wires the UI, API, and render layers on top.

## How verified
- `yarn workspace next-app typecheck` — clean.
- ESLint on all changed shared components — clean (no `jsx-no-leaked-render`).
- **Unit test** `apps/next/tests/service-override-merge.test.ts` (7 cases) covering the fragile **UTC date-key** matching in `service-overrides/merge.ts` (Date object, ISO datetime, plain `YYYY-MM-DD`, unparseable input, and cross-path agreement) plus non-destructive field merge. Passing.
- **Email-render safety (the #1 risk)** — VERIFIED. The scheduled send path renders `email-builder/emails/*` via `@react-email/render` and does **not** import the Tamagui `'use client'` `AttendOptions`. I rendered the actual cron `Newsletter` component **server-side** with an override present (cancelled memorial + note, and an active bible class with `attendOptions` + note): render did **not** throw and the output contained every override string. This also surfaced a gap — the emailed Newsletter wasn't rendering the bible-class override note in the *active* branch (only the no-class branch) — now fixed for parity with memorial/sunday-school and the web view.

## What was NOT verified
- No browser/E2E of `/admin/schedule-overrides` (Playwright smoke was a nice-to-have; the UI was type/lint-checked but not driven end-to-end). The save/clear/list round-trip against live DynamoDB has not been exercised.
- The standalone bible-class / recap / sunday-school **cron emails** were patched with the same override pattern but only the `newsletter` template was server-rendered in the verification harness.
- No visual review of the rendered override HTML/layout.

## Multi-tenant note
Everything pins `HOME_ECCLESIA` and gates on the **global** admin/owner role — `managedRegions` is not consulted. Flagged with `// TODO(multi-tenant, #110)` at the hardcoded ecclesia points; **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)