### PR TITLE
feat(schedule): roster field-overlay substrate (#110 Slice A)

### DIFF
--- a/apps/next/app/api/admin/schedule-overrides/route.ts
+++ b/apps/next/app/api/admin/schedule-overrides/route.ts
@@ -6,6 +6,7 @@ import { serviceOverrideRepository } from '@my/app/provider/dynamodb/repositorie
 import type { ServiceOverrideType } from '@my/app/provider/dynamodb/service-override-types'
 import { normalizeToISODate } from '@my/app/utils/service-overrides/merge'
 import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
+import { SCHEDULE_TYPE_CATALOGUE } from '@my/app/config/schedule-fields'
 import { invalidateScheduleCache } from '@/utils/cache'
 
 /**
@@ -37,6 +38,40 @@ async function requireAdmin() {
     return { error: NextResponse.json({ error: 'Admin access required' }, { status: 403 }) }
   }
   return { email: session.user.email }
+}
+
+/**
+ * Current synced (Google-Sheets) value for every catalogue field of a service type,
+ * so the admin UI can pre-fill the per-role inputs with what's live today. Values are
+ * coerced to strings; missing columns become ''.
+ */
+function syncedFieldsFor(serviceType: ServiceOverrideType, data: Record<string, any>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const field of SCHEDULE_TYPE_CATALOGUE[serviceType].fields) {
+    const raw = data[field.key]
+    out[field.key] = raw === undefined || raw === null ? '' : String(raw)
+  }
+  return out
+}
+
+/**
+ * Validate an incoming `roleFields` payload: a flat map of catalogue fieldKey → string.
+ * Unknown keys (not in the type's catalogue) are dropped rather than rejected, so a
+ * stale client can't inject arbitrary columns. Returns undefined when nothing valid.
+ */
+function sanitizeRoleFields(
+  serviceType: ServiceOverrideType,
+  raw: any
+): Record<string, string> | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const allowed = new Set(SCHEDULE_TYPE_CATALOGUE[serviceType].fields.map((f) => f.key))
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(raw)) {
+    if (!allowed.has(key)) continue
+    if (typeof value !== 'string') continue
+    out[key] = value
+  }
+  return Object.keys(out).length > 0 ? out : undefined
 }
 
 /** Short human summary of an occurrence, per service type. */
@@ -80,6 +115,7 @@ export async function GET() {
       date: string
       formattedDate: string
       summary: string
+      syncedFields: Record<string, string>
     }> = []
 
     for (const serviceType of SERVICE_TYPES) {
@@ -95,7 +131,13 @@ export async function GET() {
           day: 'numeric',
           timeZone: 'UTC',
         })
-        occurrences.push({ serviceType, date, formattedDate, summary: summarize(serviceType, data) })
+        occurrences.push({
+          serviceType,
+          date,
+          formattedDate,
+          summary: summarize(serviceType, data),
+          syncedFields: syncedFieldsFor(serviceType, data),
+        })
       }
     }
 
@@ -120,7 +162,7 @@ async function upsert(request: NextRequest) {
 
   try {
     const body = await request.json()
-    const { serviceType, date, status, message, note, attendOptions } = body
+    const { serviceType, date, status, message, note, attendOptions, roleFields } = body
 
     if (!isValidServiceType(serviceType)) {
       return NextResponse.json({ error: 'Invalid serviceType' }, { status: 400 })
@@ -141,6 +183,7 @@ async function upsert(request: NextRequest) {
       message,
       note,
       attendOptions,
+      roleFields: sanitizeRoleFields(serviceType, roleFields),
       createdBy: gate.email!,
     })
 

--- a/apps/next/tests/service-override-merge.test.ts
+++ b/apps/next/tests/service-override-merge.test.ts
@@ -5,6 +5,8 @@ import {
   applyOverrideToProgramItem,
 } from '@my/app/utils/service-overrides/merge'
 import type { ServiceOccurrenceOverrideRecord } from '@my/app/provider/dynamodb/service-override-types'
+import { redactScheduleData } from '@my/app/utils/redact-schedule'
+import { ANONYMOUS_VIEWER } from '@my/app/utils/viewer-pii'
 
 /**
  * The UTC date key is the fragile part of the overlay: the admin listing, the web
@@ -74,5 +76,65 @@ describe('applyOverrideToProgramItem', () => {
     const result = applyOverrideToProgramItem(item, undefined)
     expect(result.overrideStatus).toBeUndefined()
     expect(result).toEqual({ Key: 'memorial', Exhort: 'Bro A' })
+  })
+})
+
+/**
+ * Slice A (#110): per-ROLE field overlay. The override's `roleFields` map writes
+ * onto the program item's matching role columns at read time; roster columns NOT in
+ * the map keep their synced Sheets value. `tee-schedules` is never touched.
+ */
+describe('applyOverrideToProgramItem — roleFields (roster overlay)', () => {
+  const makeOverride = (roleFields: Record<string, string>): ServiceOccurrenceOverrideRecord =>
+    ({
+      ecclesia: 'Toronto East',
+      serviceType: 'memorial',
+      date: '2025-08-03',
+      roleFields,
+    }) as ServiceOccurrenceOverrideRecord
+
+  it('applies each roleFields entry onto the matching role column', () => {
+    const item: Record<string, any> = {
+      Key: 'memorial',
+      Exhort: 'Bro Synced',
+      Preside: 'Bro Preside',
+      Organist: 'Sis Organist',
+    }
+    const result = applyOverrideToProgramItem(item, makeOverride({ Exhort: 'Bro Override' }))
+    expect(result.Exhort).toBe('Bro Override') // overridden
+    expect(result.Preside).toBe('Bro Preside') // untouched (absent key)
+    expect(result.Organist).toBe('Sis Organist') // untouched (absent key)
+  })
+
+  it('leaves columns absent from roleFields untouched, and overrides multiple keys', () => {
+    const item: Record<string, any> = {
+      Key: 'memorial',
+      Exhort: 'Bro A',
+      Preside: 'Bro B',
+      Steward: 'Bro C',
+    }
+    const result = applyOverrideToProgramItem(
+      item,
+      makeOverride({ Exhort: 'Bro X', Steward: 'Bro Z' })
+    )
+    expect(result.Exhort).toBe('Bro X')
+    expect(result.Steward).toBe('Bro Z')
+    expect(result.Preside).toBe('Bro B') // untouched
+  })
+
+  it('an overridden role value is still first-name-only redacted for an anon viewer', () => {
+    const item: Record<string, any> = { Key: 'memorial', Exhort: 'Bro Synced' }
+    applyOverrideToProgramItem(item, makeOverride({ Exhort: 'Jonathan Bowen' }))
+    // Merge runs BEFORE redaction on the anon read path, so the overridden full name
+    // must collapse to the first name just like a synced value would.
+    const [safe] = redactScheduleData([item], ANONYMOUS_VIEWER, 'public-web')
+    expect(safe.Exhort).toBe('Jonathan')
+  })
+
+  it('reveals the overridden full name on the member/newsletter channel', () => {
+    const item: Record<string, any> = { Key: 'memorial', Exhort: 'Bro Synced' }
+    applyOverrideToProgramItem(item, makeOverride({ Exhort: 'Jonathan Bowen' }))
+    const [full] = redactScheduleData([item], ANONYMOUS_VIEWER, 'newsletter-email')
+    expect(full.Exhort).toBe('Jonathan Bowen')
   })
 })

--- a/packages/app/features/schedule-overrides/schedule-overrides-manager.tsx
+++ b/packages/app/features/schedule-overrides/schedule-overrides-manager.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { YStack, XStack, Text, Heading, Card, Button, Separator, Spinner, Input } from '@my/ui'
 import type { AttendOption, AttendMode } from '@my/app/types'
+import { SCHEDULE_TYPE_CATALOGUE } from '@my/app/config/schedule-fields'
 
 type ServiceType = 'memorial' | 'bibleClass' | 'sundaySchool' | 'cyc'
 
@@ -29,6 +30,9 @@ type Occurrence = {
   date: string // YYYY-MM-DD
   formattedDate: string
   summary: string
+  // Current synced (Google-Sheets) value per catalogue field key — used to pre-fill
+  // the per-role inputs so the admin edits from what's live rather than a blank slate.
+  syncedFields: Record<string, string>
 }
 
 type OverrideRecord = {
@@ -38,6 +42,7 @@ type OverrideRecord = {
   message?: string
   note?: string
   attendOptions?: AttendOption[]
+  roleFields?: Record<string, string>
 }
 
 type ApiResponse = {
@@ -53,15 +58,28 @@ type Draft = {
   message: string
   note: string
   attendOptions: AttendOption[]
+  // Sparse: holds ONLY role fields the admin has edited this session (seeded from an
+  // existing override's roleFields). A field absent here falls back to the synced
+  // value at render time. On save we persist only fields that differ from synced.
+  roleFields: Record<string, string>
 }
 
 const keyOf = (serviceType: string, date: string) => `${serviceType}#${date}`
+
+const emptyDraft = (): Draft => ({
+  status: 'default',
+  message: '',
+  note: '',
+  attendOptions: [],
+  roleFields: {},
+})
 
 const draftFromOverride = (o?: OverrideRecord): Draft => ({
   status: o?.status ?? 'default',
   message: o?.message ?? '',
   note: o?.note ?? '',
   attendOptions: o?.attendOptions ?? [],
+  roleFields: { ...(o?.roleFields ?? {}) },
 })
 
 export const ScheduleOverridesManager: React.FC = () => {
@@ -102,11 +120,15 @@ export const ScheduleOverridesManager: React.FC = () => {
     return map
   }, [data])
 
-  const getDraft = (k: string): Draft =>
-    drafts[k] ?? { status: 'default', message: '', note: '', attendOptions: [] }
+  const getDraft = (k: string): Draft => drafts[k] ?? emptyDraft()
 
   const setDraft = (k: string, patch: Partial<Draft>) => {
     setDrafts((prev) => ({ ...prev, [k]: { ...getDraft(k), ...patch } }))
+  }
+
+  const setRoleField = (k: string, fieldKey: string, value: string) => {
+    const d = getDraft(k)
+    setDraft(k, { roleFields: { ...d.roleFields, [fieldKey]: value } })
   }
 
   const addOption = (k: string) => {
@@ -134,6 +156,12 @@ export const ScheduleOverridesManager: React.FC = () => {
     setSavingKey(k)
     setStatus(null)
     try {
+      // Persist ONLY role fields the admin changed away from the synced value, so the
+      // override stays a sparse overlay (untouched roles keep tracking the Sheet).
+      const roleFieldsDiff: Record<string, string> = {}
+      for (const [fieldKey, value] of Object.entries(draft.roleFields)) {
+        if (value !== (occ.syncedFields[fieldKey] ?? '')) roleFieldsDiff[fieldKey] = value
+      }
       const res = await fetch('/api/admin/schedule-overrides', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -146,6 +174,7 @@ export const ScheduleOverridesManager: React.FC = () => {
           attendOptions: draft.attendOptions.length
             ? draft.attendOptions.filter((o) => o.label.trim())
             : undefined,
+          roleFields: Object.keys(roleFieldsDiff).length ? roleFieldsDiff : undefined,
         }),
       })
       if (!res.ok) throw new Error('save failed')
@@ -284,6 +313,37 @@ export const ScheduleOverridesManager: React.FC = () => {
                       onChangeText={(t) => setDraft(k, { note: t })}
                       placeholder='e.g. "Carpool leaves the hall at 10am"'
                     />
+                  </YStack>
+
+                  <YStack space="$2">
+                    <Text fontSize="$2" fontWeight="600" color="$colorSecondary">
+                      Roster (overrides the synced schedule value for this occurrence)
+                    </Text>
+                    {SCHEDULE_TYPE_CATALOGUE[occ.serviceType].fields.map((field) => {
+                      const synced = occ.syncedFields[field.key] ?? ''
+                      const current =
+                        field.key in draft.roleFields ? draft.roleFields[field.key] : synced
+                      const changed = current !== synced
+                      return (
+                        <YStack key={field.key} space="$1">
+                          <XStack justifyContent="space-between" alignItems="center">
+                            <Text fontSize="$2" color="$colorSecondary">
+                              {field.defaultLabel}
+                            </Text>
+                            {changed ? (
+                              <Text fontSize="$1" color="$blue11" fontWeight="600">
+                                edited
+                              </Text>
+                            ) : null}
+                          </XStack>
+                          <Input
+                            value={current}
+                            onChangeText={(t) => setRoleField(k, field.key, t)}
+                            placeholder={synced || field.defaultLabel}
+                          />
+                        </YStack>
+                      )
+                    })}
                   </YStack>
 
                   <YStack space="$2">

--- a/packages/app/provider/dynamodb/repositories/service-override-repository.ts
+++ b/packages/app/provider/dynamodb/repositories/service-override-repository.ts
@@ -14,6 +14,7 @@ export interface UpsertOverrideInput {
   message?: string
   note?: string
   attendOptions?: AttendOption[]
+  roleFields?: Record<string, string>
   createdBy: string
 }
 
@@ -60,6 +61,7 @@ export class ServiceOverrideRepository extends BaseRepository<ServiceOccurrenceO
       ...(input.message !== undefined ? { message: input.message } : {}),
       ...(input.note !== undefined ? { note: input.note } : {}),
       ...(input.attendOptions !== undefined ? { attendOptions: input.attendOptions } : {}),
+      ...(input.roleFields !== undefined ? { roleFields: input.roleFields } : {}),
       createdBy: existing?.createdBy ?? input.createdBy,
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,

--- a/packages/app/provider/dynamodb/service-override-types.ts
+++ b/packages/app/provider/dynamodb/service-override-types.ts
@@ -60,6 +60,13 @@ export interface ServiceOccurrenceOverrideRecord extends BaseRecord {
   note?: string // free-form announcement (shown regardless of status)
   attendOptions?: AttendOption[] // Phase 2
 
+  // Slice A (#110): per-ROLE field values, natively edited as an overlay on the
+  // synced Google-Sheets base. Map of catalogue fieldKey (Exhort/Preside/Speaker/…
+  // — see SCHEDULE_TYPE_CATALOGUE) → free-text value. Only keys the admin actually
+  // changed are stored; absent keys keep the synced value at read time. The app
+  // NEVER writes these back to Sheets (`tee-schedules` stays a one-way input).
+  roleFields?: Record<string, string>
+
   createdBy: string
   createdAt: string
   updatedAt: string

--- a/packages/app/utils/service-overrides/merge.ts
+++ b/packages/app/utils/service-overrides/merge.ts
@@ -91,5 +91,18 @@ export function applyOverrideToProgramItem<T extends Record<string, any>>(
   if (override.note !== undefined) target.overrideNote = override.note
   if (override.attendOptions !== undefined) target.attendOptions = override.attendOptions
 
+  // Slice A (#110): per-ROLE field overlay. Each key is a catalogue field
+  // (Exhort/Preside/Speaker/… — see SCHEDULE_TYPE_CATALOGUE) that maps directly to
+  // the program item's role column, so we write the overridden value straight onto
+  // the matching column. Only keys PRESENT in the override are touched — absent
+  // roster fields keep their synced Sheets value. Values stay first-name redacted
+  // downstream because the role column names live in redact-schedule's PERSON_KEYS
+  // and redaction runs AFTER this merge on the anon read path.
+  if (override.roleFields) {
+    for (const [key, value] of Object.entries(override.roleFields)) {
+      target[key] = value
+    }
+  }
+
   return item
 }


### PR DESCRIPTION
## What
Slice A of #110 (Native Roster CRUD) — the **roster field-overlay substrate**. Admins can now natively edit per-**role** field values (Exhort / Preside / Organist / Speaker / …) for a single occurrence, as an **overlay** on the synced Google-Sheets base. Free-text values in this slice (the resolver-backed member-picker is Slice B).

Builds directly on #111's per-occurrence override overlay — reuses the same `service-override` record, repository, `merge.ts`, and read wiring rather than reinventing them.

## Why
Per #110's confirmed decisions: Google Sheets stays a **one-way input** (members who don't sign in keep updating it); the app **never writes back** to `tee-schedules` (collision risk). In-app edits are an overlay merged at read time — the proven #111 pattern.

## How
- **Type** (`service-override-types.ts`): add `roleFields?: Record<string, string>` (catalogue fieldKey → value) to `ServiceOccurrenceOverrideRecord`. One override record per occurrence now carries status/message/note/attendOptions (#111) **and** roleFields — extended rather than a new `ROSTER_OVERRIDE#` record, to reuse the merged repo/merge/read-wiring.
- **Repository** (`service-override-repository.ts`): `UpsertOverrideInput.roleFields` + conditional spread (omitted when absent so DynamoDB stores nothing empty).
- **Merge** (`merge.ts`): `applyOverrideToProgramItem` writes each `roleFields` entry onto the item's matching role column. **Only keys present in the override are touched**; absent roster fields keep their synced value. Merge runs **before** redaction on the anon read path, and role column names are in `redact-schedule`'s `PERSON_KEYS`, so overridden name values still collapse to first-name for anon.
- **Admin API** (`/api/admin/schedule-overrides`): GET returns each occurrence's current **synced field values** (to pre-fill inputs); upsert accepts + **sanitizes** `roleFields` against the type's catalogue (unknown / non-string keys dropped). Same authz.
- **Admin UI** (`ScheduleOverridesManager`): per-role free-text input derived from `SCHEDULE_TYPE_CATALOGUE[serviceType].fields`, pre-filled from the synced value, with an "edited" marker. On save persists **only** fields changed away from synced (sparse overlay).
- **Tests** (`service-override-merge.test.ts`): +4 roleFields cases — applies onto matching column; absent keys untouched (multi-key); anon first-name-only redaction on an overridden value; member/newsletter channel reveals the full overridden name.

Read wiring already flows through `applyOverrideToProgramItem`, so **both** the web (`/api/upcoming-program`) and email (`get_upcoming_program`) paths pick up roleFields with no further change.

`// TODO(multi-tenant, #110)` markers for the hardcoded `HOME_ECCLESIA` are already present on the API route (from #111); multi-tenancy is intentionally **not** addressed here.

## Verified
- `yarn vitest run apps/next/tests/service-override-merge.test.ts` → **11/11 pass** (7 existing + 4 new).
- `yarn workspace next-app typecheck` → **clean** (exit 0, no errors introduced).
- Logic guarantees: with **no** roleFields override, `applyOverrideToProgramItem` is a no-op (test) so `/schedule` + newsletter render identically to before. All writes target `tee-admin` (`serviceOverrideRepository` uses the `admin` table) — `tee-schedules` is never written (grep-confirmed).

## NOT verified
- Did **not** run the live app (`/schedule`, `/admin/schedule-overrides`, newsletter render) end-to-end — this environment has no AWS/Google credentials or running server. Verification is via unit tests + static analysis of the read paths.
- Pre-existing `yarn workspace next-app lint` is broken in this env (ESLint 9 vs config expecting 8.x) — unrelated to this change; JSX follows the ternary+null rule manually.

Refs #110 (Slice A).