### PR TITLE
feat(resolver): auto-create visiting speakers — write increment (#109)

### DIFF
--- a/apps/next/app/api/admin/name-resolution/route.ts
+++ b/apps/next/app/api/admin/name-resolution/route.ts
@@ -7,25 +7,28 @@ import {
   toDirectoryPerson,
   type DirectoryPerson,
 } from '@my/app/utils/name-resolver-directory'
+import { syncVisitingSpeakers } from '@my/app/provider/sync/visiting-speakers-ingest'
 import { getTeeServicesConfig } from '../../../../utils/tee-services-config'
 
 /**
- * READ-ONLY admin diagnostic for the schedule name↔member resolver
- * (keystone — issue #109, increment 2).
+ * Admin diagnostic + write path for the schedule name↔member resolver
+ * (keystone — issue #109).
  *
- * Loads the directory as candidates, harvests the free-text names from the
- * memorial schedule (inline role columns + the "Visiting Speakers" tab), runs
- * the pure resolver, and returns a grouped match report so a human can eyeball
- * match quality and tune the typo threshold BEFORE any write path is built.
+ * GET  — READ-ONLY diagnostic (increment 2). Loads the directory as candidates,
+ *        harvests the free-text names from the memorial schedule (inline role
+ *        columns + the "Visiting Speakers" tab), runs the pure resolver, and
+ *        returns a grouped match report so a human can eyeball match quality
+ *        BEFORE triggering any write. ZERO mutations.
  *
- * ZERO mutations: no PersonRecord writes, no SES, no notifications.
+ * POST — WRITE increment. AFTER reviewing the GET diagnostic, an owner/admin
+ *        triggers ingest of confident not-found visiting speakers into emailless
+ *        `visitor` PersonRecords (see visiting-speakers-ingest). Defaults to
+ *        dryRun; the caller must pass { dryRun: false } to actually write.
+ *        This is NEVER auto-fired on sheet sync.
  *
- * // NEXT INCREMENT: the auto-create-visiting-speaker + RB/Rep notification
- * // paths are deliberately NOT here. They are gated on a schema decision:
- * // personRepository.create() currently REQUIRES an email, but visiting
- * // speakers harvested from the sheet have none. That must be resolved
- * // (nullable email / synthetic placeholder / separate record kind) before
- * // the not-found group can be turned into created records or notifications.
+ * // NEXT INCREMENT: the RB/Rep discrepancy notification + exhorter heads-up
+ * // email are deliberately NOT here — per project rules this increment has no
+ * // notification/email side effects. See visiting-speakers-ingest.ts.
  */
 
 // Memorial schedule columns whose cells hold a person's name (case-insensitive
@@ -175,6 +178,71 @@ export async function GET(_request: NextRequest) {
       {
         success: false,
         error: 'Failed to run name-resolution diagnostic',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * POST — trigger the visiting-speaker ingest (WRITE increment, issue #109).
+ *
+ * Owner/admin only. A human runs this AFTER reviewing the GET diagnostic.
+ * Defaults to a dry run; pass { "dryRun": false } to actually create records.
+ * Creates emailless `visitor` PersonRecords for confident not-found speakers
+ * under their home ecclesia. Idempotent. No emails/notifications are sent.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // --- Auth gate: owner/admin only (matches GET) ---
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+    }
+    const userRole = (session.user as any).role || 'guest'
+    if (!['admin', 'owner'].includes(userRole)) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+    }
+
+    // Default to dryRun for safety — a real write requires explicit dryRun:false.
+    let dryRun = true
+    try {
+      const body = await request.json()
+      if (body && typeof body.dryRun === 'boolean') dryRun = body.dryRun
+    } catch {
+      // No/invalid JSON body → keep the safe default (dry run).
+    }
+
+    // --- Resolve the memorial sheet id from the Google config ---
+    const config = getTeeServicesConfig()
+    const memorial = config.sheet_ids?.['memorial']
+    if (!memorial?.key) {
+      return NextResponse.json(
+        { error: 'Memorial sheet is not configured (sheet_ids.memorial missing)' },
+        { status: 500 }
+      )
+    }
+
+    const result = await syncVisitingSpeakers(memorial.key, { dryRun })
+
+    return NextResponse.json({
+      success: true,
+      timestamp: new Date().toISOString(),
+      requestedBy: session.user.email,
+      ...result,
+      counts: {
+        totalRows: result.totalRows,
+        created: result.created.length,
+        skipped: result.skipped.length,
+      },
+    })
+  } catch (error) {
+    console.error('❌ Visiting-speaker ingest failed:', error)
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to run visiting-speaker ingest',
         message: error instanceof Error ? error.message : 'Unknown error',
       },
       { status: 500 }

--- a/apps/next/tests/db/person-repository-emailless.test.ts
+++ b/apps/next/tests/db/person-repository-emailless.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock DynamoDB — use vi.hoisted so mockSend exists when vi.mock runs.
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }))
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mockSend })),
+  },
+  QueryCommand: vi.fn().mockImplementation((params) => ({ type: 'QueryCommand', params })),
+  PutCommand: vi.fn().mockImplementation((params) => ({ type: 'PutCommand', params })),
+  GetCommand: vi.fn().mockImplementation((params) => ({ type: 'GetCommand', params })),
+  UpdateCommand: vi.fn().mockImplementation((params) => ({ type: 'UpdateCommand', params })),
+  DeleteCommand: vi.fn().mockImplementation((params) => ({ type: 'DeleteCommand', params })),
+  ScanCommand: vi.fn().mockImplementation((params) => ({ type: 'ScanCommand', params })),
+}))
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}))
+
+// Import after mocking.
+import { PersonRepository } from '@my/app/provider/dynamodb/repositories/person-repository'
+
+/** Collect the item from every PutCommand the repo issued. */
+function putItems(): any[] {
+  return mockSend.mock.calls
+    .map((call) => call[0])
+    .filter((cmd) => cmd?.type === 'PutCommand')
+    .map((cmd) => cmd.params.Item)
+}
+
+describe('PersonRepository.create — emailless visitor path (issue #109)', () => {
+  let repository: PersonRepository
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSend.mockResolvedValue({})
+    repository = new PersonRepository()
+  })
+
+  it('creates a visitor with NO email: no EMAIL# item, NOEMAIL# GSI1 sentinel', async () => {
+    const record = await repository.create({
+      firstName: 'Alan',
+      lastName: 'Markwith',
+      ecclesia: 'Greenaway Hamilton',
+      memberStatus: 'visitor',
+      role: 'guest',
+      source: 'schedule-import',
+      sourceRef: 'visiting-speakers:sheet-123',
+    })
+
+    const items = putItems()
+    // Exactly ONE put — the PROFILE. No secondary EMAIL# item.
+    expect(items).toHaveLength(1)
+    const profile = items[0]
+
+    expect(profile.skey).toBe('PROFILE')
+    // GSI1 uses a NOEMAIL# sentinel keyed by personId — never EMAIL#.
+    expect(profile.gsi1pk).toBe(`NOEMAIL#${record.personId}`)
+    expect(profile.gsi1pk.startsWith('EMAIL#')).toBe(false)
+    expect(profile.gsi1sk).toBe('PERSON')
+    // No fake email pollutes the record / SES.
+    expect(profile.primaryEmail).toBe('')
+    expect(profile.memberStatus).toBe('visitor')
+    expect(profile.role).toBe('guest')
+    // Provenance is persisted.
+    expect(profile.source).toBe('schedule-import')
+    expect(profile.sourceRef).toBe('visiting-speakers:sheet-123')
+
+    // No EMAIL# item was ever written.
+    expect(items.some((i) => typeof i.skey === 'string' && i.skey.startsWith('EMAIL#'))).toBe(false)
+
+    // Returned record matches what was persisted.
+    expect(record.gsi1pk).toBe(`NOEMAIL#${record.personId}`)
+    expect(record.primaryEmail).toBe('')
+  })
+
+  it('rejects an emailless create when memberStatus is not "visitor"', async () => {
+    await expect(
+      repository.create({
+        firstName: 'Alan',
+        lastName: 'Markwith',
+        ecclesia: 'Greenaway Hamilton',
+        memberStatus: 'member',
+      })
+    ).rejects.toThrow(/requires an email unless memberStatus is "visitor"/)
+
+    // Defaulting memberStatus (→ 'member') must also reject.
+    await expect(
+      repository.create({
+        firstName: 'No',
+        lastName: 'Email',
+        ecclesia: 'Toronto East',
+      })
+    ).rejects.toThrow(/requires an email/)
+
+    expect(putItems()).toHaveLength(0)
+  })
+
+  it('keeps the existing email path unchanged: writes PROFILE + EMAIL# with EMAIL# GSI1', async () => {
+    const record = await repository.create({
+      email: 'Test.Person@Example.com',
+      firstName: 'Test',
+      lastName: 'Person',
+      ecclesia: 'Toronto East',
+    })
+
+    const items = putItems()
+    // PROFILE + primary EMAIL# item.
+    expect(items).toHaveLength(2)
+
+    const profile = items.find((i) => i.skey === 'PROFILE')
+    expect(profile.gsi1pk).toBe('EMAIL#test.person@example.com')
+    expect(profile.primaryEmail).toBe('test.person@example.com')
+    expect(profile.memberStatus).toBe('member')
+
+    const emailItem = items.find((i) => typeof i.skey === 'string' && i.skey.startsWith('EMAIL#'))
+    expect(emailItem).toBeTruthy()
+    expect(emailItem.email).toBe('test.person@example.com')
+    expect(emailItem.emailType).toBe('primary')
+
+    expect(record.primaryEmail).toBe('test.person@example.com')
+  })
+})

--- a/apps/next/tests/sync/visiting-speakers-ingest.test.ts
+++ b/apps/next/tests/sync/visiting-speakers-ingest.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  readVisitingSpeakers,
+  syncVisitingSpeakers,
+  splitSpeakerName,
+  type PersonRepositoryLike,
+} from '@my/app/provider/sync/visiting-speakers-ingest'
+import type { PersonRecord } from '@my/app/provider/dynamodb/types'
+
+// ---- Fixtures ---------------------------------------------------------------
+
+/** Minimal PersonRecord for the directory candidate list (only the fields the
+ * resolver reads matter). */
+function personRecord(
+  personId: string,
+  firstName: string,
+  lastName: string,
+  ecclesia: string
+): PersonRecord {
+  return {
+    pkey: `PERSON#${personId}`,
+    skey: 'PROFILE',
+    gsi1pk: `NOEMAIL#${personId}`,
+    gsi1sk: 'PERSON',
+    gsi2pk: `ECCLESIA#${ecclesia}`,
+    gsi2sk: `${lastName}#${firstName}#${personId}`.toLowerCase(),
+    gsi3pk: `NAME#${lastName}`.toLowerCase(),
+    gsi3sk: `${firstName}#${personId}`.toLowerCase(),
+    personId,
+    primaryEmail: '',
+    firstName,
+    lastName,
+    displayName: `${firstName} ${lastName}`,
+    ecclesia,
+    memberStatus: 'member',
+  } as PersonRecord
+}
+
+/** A GoogleSheetsService stub returning canned tab data. */
+function fakeSheets(headers: string[], rows: any[][]) {
+  return {
+    getSheetDataWithHeaders: vi.fn(async () => ({ headers, rows })),
+  } as any
+}
+
+/** A repository stub capturing create() inputs. */
+function fakeRepo(existing: PersonRecord[]) {
+  const createInputs: any[] = []
+  const repo: PersonRepositoryLike = {
+    listAll: vi.fn(async () => ({ items: existing, lastEvaluatedKey: undefined })) as any,
+    create: vi.fn(async (input: any) => {
+      createInputs.push(input)
+      return { ...input, personId: `new-${createInputs.length}` } as PersonRecord
+    }) as any,
+  }
+  return { repo, createInputs }
+}
+
+// ---- splitSpeakerName -------------------------------------------------------
+
+describe('splitSpeakerName', () => {
+  it('strips honorifics, preserves casing, keeps last token as surname', () => {
+    expect(splitSpeakerName('Bro. Alan Markwith')).toEqual({
+      firstName: 'Alan',
+      lastName: 'Markwith',
+    })
+    expect(splitSpeakerName('John Michael Smith')).toEqual({
+      firstName: 'John',
+      lastName: 'Smith',
+    })
+    expect(splitSpeakerName('Madonna')).toEqual({ firstName: 'Madonna', lastName: '' })
+  })
+})
+
+// ---- readVisitingSpeakers ---------------------------------------------------
+
+describe('readVisitingSpeakers', () => {
+  it('reads name + ecclesia columns by header', async () => {
+    const sheets = fakeSheets(
+      ['Speaker', 'Home Ecclesia'],
+      [
+        ['Alan Markwith', 'Greenaway Hamilton'],
+        ['  ', 'Ignored'], // blank name → dropped
+        ['Brad Stephens', 'Toronto East'],
+      ]
+    )
+    const out = await readVisitingSpeakers('sheet-1', sheets)
+    expect(out).toEqual([
+      { name: 'Alan Markwith', ecclesia: 'Greenaway Hamilton' },
+      { name: 'Brad Stephens', ecclesia: 'Toronto East' },
+    ])
+  })
+
+  it('falls back to the first column for the name when no header matches', async () => {
+    const sheets = fakeSheets(
+      ['Col A', 'Col B'],
+      [['Alan Markwith', 'note']]
+    )
+    const out = await readVisitingSpeakers('sheet-1', sheets)
+    expect(out[0].name).toBe('Alan Markwith')
+    expect(out[0].ecclesia).toBeUndefined()
+  })
+})
+
+// ---- syncVisitingSpeakers ---------------------------------------------------
+
+const ROWS = [
+  ['Brad Stephens', 'Toronto East'], // already in directory → skipped
+  ['Bro. Alan Markwith', 'Greenaway Hamilton'], // not-found → created
+  ['TBD', 'Somewhere'], // placeholder → skipped
+  ['Charlie Newman', ''], // not-found but no ecclesia → skipped
+  ['David Owens', 'Book Road'], // not-found → created
+  ['David Owens', 'Book Road'], // duplicate in same batch → skipped (idempotent)
+]
+
+function existingDirectory() {
+  return [personRecord('p1', 'Brad', 'Stephens', 'Toronto East')]
+}
+
+describe('syncVisitingSpeakers', () => {
+  it('creates confident not-found visitors, skips the rest, and is idempotent', async () => {
+    const sheets = fakeSheets(['Name', 'Ecclesia'], ROWS)
+    const { repo, createInputs } = fakeRepo(existingDirectory())
+
+    const result = await syncVisitingSpeakers('sheet-1', { repository: repo, sheets })
+
+    expect(result.dryRun).toBe(false)
+    expect(result.totalRows).toBe(6)
+
+    // Only Alan + David created (David's duplicate resolves to the just-created
+    // record and is skipped — no duplicate).
+    expect(result.created.map((c) => c.name)).toEqual([
+      'Bro. Alan Markwith',
+      'David Owens',
+    ])
+    expect(createInputs).toHaveLength(2)
+
+    // Real writes: emailless visitor / guest with provenance, correct ecclesia.
+    expect(createInputs[0]).toMatchObject({
+      firstName: 'Alan',
+      lastName: 'Markwith',
+      ecclesia: 'Greenaway Hamilton',
+      memberStatus: 'visitor',
+      role: 'guest',
+      source: 'schedule-import',
+      sourceRef: 'visiting-speakers:sheet-1',
+    })
+    expect(createInputs[0].email).toBeUndefined()
+
+    // Skips carry a reason.
+    const skipReasons = Object.fromEntries(result.skipped.map((s) => [s.name, s.reason]))
+    expect(skipReasons['Brad Stephens']).toMatch(/already in directory/)
+    expect(skipReasons['TBD']).toMatch(/placeholder/)
+    expect(skipReasons['Charlie Newman']).toMatch(/no home ecclesia/)
+    expect(skipReasons['David Owens']).toMatch(/already in directory/)
+
+    // Created records carry a real personId.
+    expect(result.created[0].personId).toBeTruthy()
+  })
+
+  it('dryRun reports what WOULD be created without calling create()', async () => {
+    const sheets = fakeSheets(['Name', 'Ecclesia'], ROWS)
+    const { repo, createInputs } = fakeRepo(existingDirectory())
+
+    const result = await syncVisitingSpeakers('sheet-1', {
+      repository: repo,
+      sheets,
+      dryRun: true,
+    })
+
+    expect(result.dryRun).toBe(true)
+    expect(createInputs).toHaveLength(0)
+    // Same set as a real run, but no personId (nothing written).
+    expect(result.created.map((c) => c.name)).toEqual([
+      'Bro. Alan Markwith',
+      'David Owens',
+    ])
+    expect(result.created.every((c) => c.personId === undefined)).toBe(true)
+  })
+})

--- a/packages/app/provider/dynamodb/repositories/person-repository.ts
+++ b/packages/app/provider/dynamodb/repositories/person-repository.ts
@@ -16,7 +16,10 @@ import type {
 
 // Input types for creating/updating persons
 export interface CreatePersonInput {
-  email: string
+  // Optional: a record may be created with NO email (visiting speakers
+  // harvested from the schedule have none). Emailless creation is only allowed
+  // when memberStatus is 'visitor' — see create().
+  email?: string
   firstName: string
   lastName: string
   ecclesia: string
@@ -25,6 +28,9 @@ export interface CreatePersonInput {
   role?: 'owner' | 'admin' | 'recorder' | 'rep' | 'member' | 'guest' | 'deceased'
   provider?: 'google' | 'credentials'
   userId?: string
+  // Provenance for machine-created records (e.g. schedule ingest).
+  source?: 'schedule-import'
+  sourceRef?: string
 }
 
 // OAuth profile from Google
@@ -218,27 +224,41 @@ export class PersonRepository extends BaseRepository<PersonRecord> {
     const personId = uuidv4()
     const displayName = `${input.firstName} ${input.lastName}`.trim()
     const now = new Date().toISOString()
+    const email = input.email?.trim().toLowerCase() || undefined
+    const memberStatus = input.memberStatus || 'member'
+
+    // Emailless records are only allowed for visitors (e.g. visiting speakers
+    // harvested from the schedule). This keeps anything fake OUT of the EMAIL#
+    // GSI space and SES — the record gets a NOEMAIL#{personId} GSI1 sentinel
+    // and NO EMAIL# item, so getByEmail() can never surface it.
+    if (!email && memberStatus !== 'visitor') {
+      throw new Error(
+        'PersonRepository.create requires an email unless memberStatus is "visitor"'
+      )
+    }
 
     const record: PersonRecord = {
       pkey: `PERSON#${personId}`,
       skey: 'PROFILE',
-      gsi1pk: `EMAIL#${input.email.toLowerCase()}`,
+      gsi1pk: email ? `EMAIL#${email}` : `NOEMAIL#${personId}`,
       gsi1sk: 'PERSON',
       gsi2pk: `ECCLESIA#${input.ecclesia}`,
       gsi2sk: `${input.lastName.toLowerCase()}#${input.firstName.toLowerCase()}#${personId}`,
       gsi3pk: `NAME#${input.lastName.toLowerCase()}`,
       gsi3sk: `${input.firstName.toLowerCase()}#${personId}`,
       personId,
-      primaryEmail: input.email.toLowerCase(),
+      primaryEmail: email ?? '',
       firstName: input.firstName,
       lastName: input.lastName,
       displayName,
       ecclesia: input.ecclesia,
-      memberStatus: input.memberStatus || 'member',
+      memberStatus,
       isInterEcclesiaRep: input.isInterEcclesiaRep,
       role: input.role,
       provider: input.provider,
       userId: input.userId,
+      source: input.source,
+      sourceRef: input.sourceRef,
       createdAt: now,
       lastUpdated: now,
       version: 0,
@@ -246,15 +266,18 @@ export class PersonRepository extends BaseRepository<PersonRecord> {
 
     await this.put(record)
 
-    // Also create the primary email record
-    await this.addEmail(personId, {
-      email: input.email.toLowerCase(),
-      emailType: 'primary',
-      order: 0,
-      verified: true,
-      sesSubscribed: false,
-      sesStatus: 'active',
-    })
+    // Only create a primary EMAIL# item when there is a real email. Emailless
+    // visitor records intentionally have none (keeps SES / the email GSI clean).
+    if (email) {
+      await this.addEmail(personId, {
+        email,
+        emailType: 'primary',
+        order: 0,
+        verified: true,
+        sesSubscribed: false,
+        sesStatus: 'active',
+      })
+    }
 
     return record
   }

--- a/packages/app/provider/dynamodb/types.ts
+++ b/packages/app/provider/dynamodb/types.ts
@@ -506,6 +506,12 @@ export interface PersonRecord extends BaseRecord {
   adminRegion?: string              // @deprecated — use managedRegions instead
   managedRegions?: string[]         // Regions this admin oversees (e.g., ['canada_east', 'caribbean'])
 
+  // Provenance — set when a record is auto-created from an external source
+  // rather than by a person (e.g. a visiting speaker harvested from the
+  // memorial schedule). Lets an admin trace/undo machine-created records.
+  source?: 'schedule-import'
+  sourceRef?: string                // Free-form ref to the origin, e.g. "visiting-speakers:{sheetId}"
+
   createdAt: string
 }
 

--- a/packages/app/provider/sync/visiting-speakers-ingest.ts
+++ b/packages/app/provider/sync/visiting-speakers-ingest.ts
@@ -1,0 +1,236 @@
+/**
+ * Visiting-speaker ingest (keystone — issue #109, WRITE increment).
+ *
+ * Reads the memorial "Visiting Speakers" tab and, for CONFIDENT not-found
+ * names, creates an emailless `visitor` PersonRecord under the speaker's home
+ * ecclesia so the schedule name resolver can match them next time. This is the
+ * WRITE half of the resolver keystone: increment 2 shipped the read-only
+ * diagnostic; this turns reviewed not-found names into real directory records.
+ *
+ * DESIGN NOTES
+ *   - ADMIN-TRIGGERED, not auto-firing. This module never runs itself — it is
+ *     invoked from an owner/admin-gated POST route after a human has reviewed
+ *     the diagnostic. It is NOT wired into any Google Sheet sync/cron.
+ *   - Only CONFIDENT not-found names are created. matched / typo / ambiguous
+ *     names are left for a human — a typo or ambiguous name is very likely an
+ *     EXISTING member and auto-creating would duplicate them.
+ *   - Idempotent. Candidates are re-resolved before each create against a list
+ *     that grows as records are made, so a name repeated within one batch (or
+ *     on a second run) matches the record it just created — no duplicates.
+ *   - No emails / notifications. See the NEXT INCREMENT note below.
+ *
+ * I/O is injectable (sheets + repository) so this unit-tests with fixtures and
+ * never touches live DynamoDB or Sheets in tests.
+ */
+import { GoogleSheetsService } from './google-sheets-service'
+import { personRepository } from '../dynamodb/repositories/person-repository'
+import {
+  resolveNames,
+  toDirectoryPerson,
+  type DirectoryPerson,
+} from '../../utils/name-resolver-directory'
+
+/** Honorifics stripped before splitting a name (mirrors the resolver). */
+const HONORIFIC_RE = /^(bro\.?|brother|bre\.?|sis\.?|sister|mr\.?|mrs\.?|ms\.?|dr\.?)$/i
+
+/** Header that holds the speaker's name on the "Visiting Speakers" tab. */
+const NAME_HEADER_RE = /(name|speaker|exhort|brother|visitor|preside)/i
+/** Header that holds the speaker's home ecclesia. */
+const ECCLESIA_HEADER_RE = /(ecclesia|assembly|congregation|meeting|home|from)/i
+
+/** The minimal repository surface this module needs — lets tests inject a fake. */
+export interface PersonRepositoryLike {
+  listAll: (typeof personRepository)['listAll']
+  create: (typeof personRepository)['create']
+}
+
+/** One row of the "Visiting Speakers" tab we care about. */
+export interface VisitingSpeaker {
+  /** Free-text speaker name as written in the sheet (may carry honorifics). */
+  name: string
+  /** Home ecclesia column value, if present. */
+  ecclesia?: string
+}
+
+export interface SyncOptions {
+  /** When true, resolve + report what WOULD be created without writing. */
+  dryRun?: boolean
+  sheets?: GoogleSheetsService
+  repository?: PersonRepositoryLike
+}
+
+export interface SyncCreated {
+  name: string
+  ecclesia: string
+  firstName: string
+  lastName: string
+  /** Set only on a real (non-dry-run) create. */
+  personId?: string
+}
+
+export interface SyncSkipped {
+  name: string
+  reason: string
+}
+
+export interface SyncResult {
+  dryRun: boolean
+  sheetId: string
+  totalRows: number
+  created: SyncCreated[]
+  skipped: SyncSkipped[]
+}
+
+/** Find the first column index whose header matches, or null if none. */
+function findColumn(headers: string[], re: RegExp): number | null {
+  for (let i = 0; i < headers.length; i++) {
+    const h = headers[i]
+    if (typeof h === 'string' && re.test(h)) return i
+  }
+  return null
+}
+
+/**
+ * Split a free-text name into first/last, stripping honorifics and preserving
+ * original casing. Mirrors the resolver's tokenization (last token → last name,
+ * middles dropped) so a created record resolves back to the same input.
+ */
+export function splitSpeakerName(raw: string): { firstName: string; lastName: string } {
+  const tokens = (raw ?? '')
+    .replace(/[.,]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .filter((t) => t && !HONORIFIC_RE.test(t))
+  const firstName = tokens[0] ?? raw.trim()
+  const lastName = tokens.length > 1 ? tokens[tokens.length - 1] : ''
+  return { firstName, lastName }
+}
+
+/**
+ * Read the memorial "Visiting Speakers" tab into `{ name, ecclesia? }` rows.
+ * Falls back to the first column for the name when no header matches (the tab
+ * layout is not something we control). Placeholder/blank names are kept here
+ * and filtered downstream by the resolver.
+ */
+export async function readVisitingSpeakers(
+  sheetId: string,
+  sheets: GoogleSheetsService = new GoogleSheetsService()
+): Promise<VisitingSpeaker[]> {
+  const { headers, rows } = await sheets.getSheetDataWithHeaders(
+    sheetId,
+    "'Visiting Speakers'!A:Z"
+  )
+
+  const nameCol = findColumn(headers, NAME_HEADER_RE) ?? 0
+  const ecclesiaCol = findColumn(headers, ECCLESIA_HEADER_RE)
+
+  const out: VisitingSpeaker[] = []
+  for (const row of rows) {
+    const nameCell = row[nameCol]
+    const name = typeof nameCell === 'string' ? nameCell.trim() : ''
+    if (!name) continue
+    const ecclesiaCell = ecclesiaCol != null ? row[ecclesiaCol] : undefined
+    const ecclesia = typeof ecclesiaCell === 'string' ? ecclesiaCell.trim() : undefined
+    out.push({ name, ecclesia: ecclesia || undefined })
+  }
+  return out
+}
+
+/**
+ * Ingest visiting speakers: create emailless `visitor` records for confident
+ * not-found names under their home ecclesia. Idempotent and admin-triggered.
+ *
+ * @param sheetId  the memorial spreadsheet id
+ * @param options  dryRun + injectable sheets/repository for testing
+ */
+export async function syncVisitingSpeakers(
+  sheetId: string,
+  options: SyncOptions = {}
+): Promise<SyncResult> {
+  const dryRun = options.dryRun ?? false
+  const sheets = options.sheets ?? new GoogleSheetsService()
+  const repo: PersonRepositoryLike = options.repository ?? personRepository
+
+  const speakers = await readVisitingSpeakers(sheetId, sheets)
+
+  // Load the directory once. We mutate this in-memory list as records are
+  // created so idempotency holds WITHIN a run (a name repeated in the same
+  // batch resolves as matched after its first creation).
+  const candidates: DirectoryPerson[] = []
+  let lastEvaluatedKey: Record<string, any> | undefined
+  do {
+    const page = await repo.listAll({ lastEvaluatedKey })
+    for (const record of page.items) candidates.push(toDirectoryPerson(record))
+    lastEvaluatedKey = page.lastEvaluatedKey
+  } while (lastEvaluatedKey)
+
+  const result: SyncResult = {
+    dryRun,
+    sheetId,
+    totalRows: speakers.length,
+    created: [],
+    skipped: [],
+  }
+
+  for (const speaker of speakers) {
+    // Re-resolve against the CURRENT candidate list (includes anything created
+    // earlier in this run) so a repeated name never creates a duplicate.
+    const report = resolveNames([speaker.name], candidates)
+
+    if (report.notFound.length === 0) {
+      const reason = report.matched.length
+        ? 'already in directory'
+        : report.typos.length
+          ? 'possible typo — left for human review'
+          : report.ambiguous.length
+            ? 'ambiguous — left for human review'
+            : 'placeholder/blank'
+      result.skipped.push({ name: speaker.name, reason })
+      continue
+    }
+
+    const ecclesia = speaker.ecclesia?.trim()
+    if (!ecclesia) {
+      result.skipped.push({ name: speaker.name, reason: 'no home ecclesia column value' })
+      continue
+    }
+
+    const { firstName, lastName } = splitSpeakerName(speaker.name)
+
+    let personId: string | undefined
+    if (!dryRun) {
+      const created = await repo.create({
+        firstName,
+        lastName,
+        ecclesia,
+        memberStatus: 'visitor',
+        role: 'guest',
+        source: 'schedule-import',
+        sourceRef: `visiting-speakers:${sheetId}`,
+      })
+      personId = created.personId
+    }
+
+    result.created.push({ name: speaker.name, ecclesia, firstName, lastName, personId })
+
+    // Add to the in-memory candidate list (dry-run too) so a second occurrence
+    // of this name in the same batch resolves as matched — dryRun reports
+    // exactly what a real run would create, no phantom duplicates.
+    candidates.push({
+      personId: personId ?? `dry-${result.created.length}`,
+      firstName,
+      lastName,
+      ecclesia,
+      displayName: `${firstName} ${lastName}`.trim(),
+    })
+  }
+
+  return result
+
+  // NEXT INCREMENT (deliberately NOT in this write increment — per project
+  // rules, no notification/email side effects here):
+  //   - RB/Rep discrepancy notification for typo/ambiguous names (link to fix).
+  //   - Exhorter heads-up email (2 Saturdays before, visitor→lunch, +Zoom).
+  // Both are follow-ups a human opts into; neither fires from this ingest.
+}


### PR DESCRIPTION
Refs #109 (name↔member resolver keystone). This is the **WRITE (data) increment** that sits on top of the merged read-only resolver + diagnostic (PR #117). Owner chose option **(a): allow emailless `visitor` PersonRecords**.

## What
- **Emailless visitor create (schema).** `PersonRepository.create()` now allows creating a record with **no email** when `memberStatus: 'visitor'`. Such records get a `NOEMAIL#{personId}` GSI1 sentinel and **no `EMAIL#` item**, so nothing fake lands in the email GSI or SES. `getByEmail()` can never surface them. Non-visitor emailless creates throw. The existing email path is unchanged. Added `source?: 'schedule-import'` / `sourceRef?` provenance to `PersonRecord`.
- **Admin-triggered visiting-speaker ingest.** New `packages/app/provider/sync/visiting-speakers-ingest.ts`:
  - `readVisitingSpeakers(sheetId)` reads the memorial `'Visiting Speakers'!A:Z` tab → `{ name, ecclesia? }[]` (header-matched name/ecclesia columns, first-column fallback).
  - `syncVisitingSpeakers(sheetId, { dryRun })` loads directory candidates, resolves via `resolveNames`, and for **confident `not-found`** names creates `visitor`/`guest`/`schedule-import` records under the speaker's home ecclesia. **Idempotent** — re-resolves against a growing in-memory candidate list before each create, so a repeat name (same batch or a second run) matches instead of duplicating. `dryRun` reports what would be created without writing. matched/typo/ambiguous names are left for a human.
- **POST `/api/admin/name-resolution`** — owner/admin-gated trigger, **defaults to `dryRun`** (must pass `{ "dryRun": false }` to write). A human runs it after reviewing the GET diagnostic. **Never auto-fires** on sheet sync.

## Why
The resolver needs visiting exhorters to exist in the directory to match schedule names. Visiting speakers harvested from the sheet have no email, which previously blocked record creation (documented as the schema decision in PR #117). Option (a) unblocks it without polluting SES.

## How verified
- `yarn vitest run` — new tests green: emailless create path (3: NOEMAIL# sentinel + no EMAIL# item + provenance; non-visitor rejects; email path unchanged writes PROFILE+EMAIL#) and ingest (5: name split, tab read + fallback, confident-create/skip, in-batch idempotency, dryRun-no-write). Existing resolver tests (17) still pass.
- `yarn workspace next-app typecheck` — clean (exit 0).
- **NOT** executed against live data (would create real records) — fixtures/mocks only, per instructions.

## What is NOT done (deferred)
- **No emails / notifications** this increment (per project no-side-effects rule). The RB/Rep discrepancy notification + exhorter heads-up email are a later increment — left as `// NEXT INCREMENT` notes in `visiting-speakers-ingest.ts` and the route.
- Admin UI to review + click-to-ingest (POST is API-only for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)