### PR TITLE
feat(schedule): resolver-backed roster member-pickers (#110 Slice B)

### DIFF
--- a/apps/next/app/api/admin/schedule-overrides/route.ts
+++ b/apps/next/app/api/admin/schedule-overrides/route.ts
@@ -74,6 +74,28 @@ function sanitizeRoleFields(
   return Object.keys(out).length > 0 ? out : undefined
 }
 
+/**
+ * Validate an incoming `roleFieldRefs` payload: catalogue fieldKey → PersonRecord
+ * personId. Slice B (#110) metadata recording WHICH directory member was picked for
+ * a role. Same allow-list discipline as roleFields — unknown/blank keys are dropped.
+ * This is metadata only; it is NEVER applied to the program item, so it can't leak to
+ * the anon read path. Returns undefined when nothing valid.
+ */
+function sanitizeRoleFieldRefs(
+  serviceType: ServiceOverrideType,
+  raw: any
+): Record<string, string> | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const allowed = new Set(SCHEDULE_TYPE_CATALOGUE[serviceType].fields.map((f) => f.key))
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(raw)) {
+    if (!allowed.has(key)) continue
+    if (typeof value !== 'string' || value.trim().length === 0) continue
+    out[key] = value
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
 /** Short human summary of an occurrence, per service type. */
 function summarize(serviceType: ServiceOverrideType, data: Record<string, any>): string {
   switch (serviceType) {
@@ -162,7 +184,8 @@ async function upsert(request: NextRequest) {
 
   try {
     const body = await request.json()
-    const { serviceType, date, status, message, note, attendOptions, roleFields } = body
+    const { serviceType, date, status, message, note, attendOptions, roleFields, roleFieldRefs } =
+      body
 
     if (!isValidServiceType(serviceType)) {
       return NextResponse.json({ error: 'Invalid serviceType' }, { status: 400 })
@@ -184,6 +207,7 @@ async function upsert(request: NextRequest) {
       note,
       attendOptions,
       roleFields: sanitizeRoleFields(serviceType, roleFields),
+      roleFieldRefs: sanitizeRoleFieldRefs(serviceType, roleFieldRefs),
       createdBy: gate.email!,
     })
 

--- a/apps/next/app/api/roster/resolve-candidates/route.ts
+++ b/apps/next/app/api/roster/resolve-candidates/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+import { personRepository } from '@my/app/provider/dynamodb/repositories/person-repository'
+import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
+
+/**
+ * READ-ONLY roster member-picker candidate endpoint (#110, Slice B).
+ *
+ * GET /api/roster/resolve-candidates?q=<typeahead>&ecclesia=<name>
+ *
+ * Backs the `RoleMemberPicker` typeahead: given a partial name, returns directory
+ * members (PersonRecords) whose name matches, so an admin can pick a real member
+ * for a roster role instead of free-typing. ZERO mutations — no writes anywhere.
+ *
+ * Matching strategy: substring filter over `listByEcclesia`. `searchByName` (GSI3)
+ * is an EXACT last-name lookup (`NAME#{lastname}` partition, first-name prefix on
+ * the sort key), which can't answer the partial/any-token queries a typeahead
+ * emits, so a directory-scoped substring scan is the correct primary path here.
+ * The ecclesia set is small (a few hundred people), so this is a single cheap GSI2
+ * partition read.
+ *
+ * TODO(multi-tenant, #110): the ecclesia is currently clamped to HOME_ECCLESIA and
+ * gated on the GLOBAL admin/owner role. When multi-tenant lands, authorize the
+ * requested `ecclesia` against the caller's managedRegions before returning members
+ * from a foreign ecclesia (cross-ecclesia visiting speakers get their own create
+ * path in Slice C).
+ */
+
+const MAX_RESULTS = 15
+
+export interface RosterCandidate {
+  personId: string
+  displayName: string
+  ecclesia?: string
+}
+
+export async function GET(request: NextRequest) {
+  // --- Auth gate: owner/admin only (matches sibling admin routes) ---
+  const session = await auth()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const role = ((session.user as any).role as string) || ROLES.GUEST
+  if (role !== ROLES.ADMIN && role !== ROLES.OWNER) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const q = (searchParams.get('q') || '').trim().toLowerCase()
+  // Multi-tenant guard: only the home ecclesia is addressable today. Ignore any
+  // other requested ecclesia rather than leak a foreign directory.
+  const ecclesia = HOME_ECCLESIA.canonicalName
+
+  // Empty query returns no candidates (the picker only searches once the admin types).
+  if (q.length < 1) {
+    return NextResponse.json(
+      { candidates: [] as RosterCandidate[] },
+      { headers: { 'Cache-Control': 'no-store, max-age=0, must-revalidate' } }
+    )
+  }
+
+  try {
+    const candidates: RosterCandidate[] = []
+    let lastEvaluatedKey: Record<string, any> | undefined
+    do {
+      const page = await personRepository.listByEcclesia(ecclesia, { lastEvaluatedKey })
+      for (const p of page.items) {
+        const displayName = (p.displayName || `${p.firstName ?? ''} ${p.lastName ?? ''}`).trim()
+        const haystack = `${displayName} ${p.firstName ?? ''} ${p.lastName ?? ''}`.toLowerCase()
+        if (haystack.includes(q)) {
+          candidates.push({ personId: p.personId, displayName, ecclesia: p.ecclesia })
+        }
+      }
+      lastEvaluatedKey = page.lastEvaluatedKey
+    } while (lastEvaluatedKey && candidates.length < MAX_RESULTS)
+
+    // Prefer names that START with the query (more relevant), then alphabetical.
+    candidates.sort((a, b) => {
+      const aStarts = a.displayName.toLowerCase().startsWith(q) ? 0 : 1
+      const bStarts = b.displayName.toLowerCase().startsWith(q) ? 0 : 1
+      if (aStarts !== bStarts) return aStarts - bStarts
+      return a.displayName.localeCompare(b.displayName)
+    })
+
+    return NextResponse.json(
+      { candidates: candidates.slice(0, MAX_RESULTS) },
+      { headers: { 'Cache-Control': 'no-store, max-age=0, must-revalidate' } }
+    )
+  } catch (error) {
+    console.error('Error resolving roster candidates:', error)
+    return NextResponse.json({ error: 'Failed to resolve candidates' }, { status: 500 })
+  }
+}

--- a/apps/next/tests/service-override-merge.test.ts
+++ b/apps/next/tests/service-override-merge.test.ts
@@ -138,3 +138,42 @@ describe('applyOverrideToProgramItem — roleFields (roster overlay)', () => {
     expect(full.Exhort).toBe('Jonathan Bowen')
   })
 })
+
+/**
+ * Slice B (#110): `roleFieldRefs` (fieldKey → picked personId) is metadata for
+ * future linking ONLY. It must NEVER be applied to the program item — the display
+ * value in `roleFields` remains the single thing that renders and gets redacted, so
+ * a personId can't leak to any read path (member or anon).
+ */
+describe('applyOverrideToProgramItem — roleFieldRefs (metadata isolation, Slice B)', () => {
+  const makeOverride = (
+    roleFields: Record<string, string>,
+    roleFieldRefs: Record<string, string>
+  ): ServiceOccurrenceOverrideRecord =>
+    ({
+      ecclesia: 'Toronto East',
+      serviceType: 'memorial',
+      date: '2025-08-03',
+      roleFields,
+      roleFieldRefs,
+    }) as ServiceOccurrenceOverrideRecord
+
+  it('applies the display value but never writes the personId onto the item', () => {
+    const item: Record<string, any> = { Key: 'memorial', Exhort: 'Bro Synced' }
+    const result = applyOverrideToProgramItem(
+      item,
+      makeOverride({ Exhort: 'Jonathan Bowen' }, { Exhort: 'person-123' })
+    )
+    expect(result.Exhort).toBe('Jonathan Bowen') // display value drives render
+    expect(result.roleFieldRefs).toBeUndefined() // metadata never merged in
+    expect(JSON.stringify(result)).not.toContain('person-123') // personId absent everywhere
+  })
+
+  it('anon redaction is unchanged when a member is linked (still first-name-only)', () => {
+    const item: Record<string, any> = { Key: 'memorial', Exhort: 'Bro Synced' }
+    applyOverrideToProgramItem(item, makeOverride({ Exhort: 'Jonathan Bowen' }, { Exhort: 'person-123' }))
+    const [safe] = redactScheduleData([item], ANONYMOUS_VIEWER, 'public-web')
+    expect(safe.Exhort).toBe('Jonathan')
+    expect(JSON.stringify(safe)).not.toContain('person-123')
+  })
+})

--- a/packages/app/features/schedule-overrides/schedule-overrides-manager.tsx
+++ b/packages/app/features/schedule-overrides/schedule-overrides-manager.tsx
@@ -1,7 +1,19 @@
 'use client'
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { YStack, XStack, Text, Heading, Card, Button, Separator, Spinner, Input } from '@my/ui'
+import {
+  YStack,
+  XStack,
+  Text,
+  Heading,
+  Card,
+  Button,
+  Separator,
+  Spinner,
+  Input,
+  RoleMemberPicker,
+} from '@my/ui'
+import type { RosterCandidate } from '@my/ui'
 import type { AttendOption, AttendMode } from '@my/app/types'
 import { SCHEDULE_TYPE_CATALOGUE } from '@my/app/config/schedule-fields'
 
@@ -43,6 +55,9 @@ type OverrideRecord = {
   note?: string
   attendOptions?: AttendOption[]
   roleFields?: Record<string, string>
+  // Slice B (#110): fieldKey → picked PersonRecord personId (parallel metadata to
+  // roleFields; drives no rendering/redaction — see service-override-types.ts).
+  roleFieldRefs?: Record<string, string>
 }
 
 type ApiResponse = {
@@ -62,6 +77,9 @@ type Draft = {
   // existing override's roleFields). A field absent here falls back to the synced
   // value at render time. On save we persist only fields that differ from synced.
   roleFields: Record<string, string>
+  // Sparse: fieldKey → picked directory personId. Set when the admin picks a member
+  // from the typeahead; cleared when they free-type or unlink. Metadata only.
+  roleFieldRefs: Record<string, string>
 }
 
 const keyOf = (serviceType: string, date: string) => `${serviceType}#${date}`
@@ -72,6 +90,7 @@ const emptyDraft = (): Draft => ({
   note: '',
   attendOptions: [],
   roleFields: {},
+  roleFieldRefs: {},
 })
 
 const draftFromOverride = (o?: OverrideRecord): Draft => ({
@@ -80,6 +99,7 @@ const draftFromOverride = (o?: OverrideRecord): Draft => ({
   note: o?.note ?? '',
   attendOptions: o?.attendOptions ?? [],
   roleFields: { ...(o?.roleFields ?? {}) },
+  roleFieldRefs: { ...(o?.roleFieldRefs ?? {}) },
 })
 
 export const ScheduleOverridesManager: React.FC = () => {
@@ -126,9 +146,34 @@ export const ScheduleOverridesManager: React.FC = () => {
     setDrafts((prev) => ({ ...prev, [k]: { ...getDraft(k), ...patch } }))
   }
 
+  // Free-text edit of a role field: update the display value AND drop any member
+  // link for that field (the field no longer reflects the previously picked member).
   const setRoleField = (k: string, fieldKey: string, value: string) => {
     const d = getDraft(k)
-    setDraft(k, { roleFields: { ...d.roleFields, [fieldKey]: value } })
+    const nextRefs = { ...d.roleFieldRefs }
+    delete nextRefs[fieldKey]
+    setDraft(k, {
+      roleFields: { ...d.roleFields, [fieldKey]: value },
+      roleFieldRefs: nextRefs,
+    })
+  }
+
+  // A directory member was picked: store BOTH the display name (what renders/redacts)
+  // and the personId (Slice-B metadata) for the field.
+  const setRoleMember = (k: string, fieldKey: string, member: RosterCandidate) => {
+    const d = getDraft(k)
+    setDraft(k, {
+      roleFields: { ...d.roleFields, [fieldKey]: member.displayName },
+      roleFieldRefs: { ...d.roleFieldRefs, [fieldKey]: member.personId },
+    })
+  }
+
+  // Unlink the member but keep the typed display value.
+  const clearRoleMember = (k: string, fieldKey: string) => {
+    const d = getDraft(k)
+    const nextRefs = { ...d.roleFieldRefs }
+    delete nextRefs[fieldKey]
+    setDraft(k, { roleFieldRefs: nextRefs })
   }
 
   const addOption = (k: string) => {
@@ -162,6 +207,13 @@ export const ScheduleOverridesManager: React.FC = () => {
       for (const [fieldKey, value] of Object.entries(draft.roleFields)) {
         if (value !== (occ.syncedFields[fieldKey] ?? '')) roleFieldsDiff[fieldKey] = value
       }
+      // Persist member links (personIds) only for fields we're actually overriding —
+      // a ref without a stored display value would be orphaned metadata.
+      const roleFieldRefsDiff: Record<string, string> = {}
+      for (const fieldKey of Object.keys(roleFieldsDiff)) {
+        const personId = draft.roleFieldRefs[fieldKey]
+        if (personId) roleFieldRefsDiff[fieldKey] = personId
+      }
       const res = await fetch('/api/admin/schedule-overrides', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -175,6 +227,7 @@ export const ScheduleOverridesManager: React.FC = () => {
             ? draft.attendOptions.filter((o) => o.label.trim())
             : undefined,
           roleFields: Object.keys(roleFieldsDiff).length ? roleFieldsDiff : undefined,
+          roleFieldRefs: Object.keys(roleFieldRefsDiff).length ? roleFieldRefsDiff : undefined,
         }),
       })
       if (!res.ok) throw new Error('save failed')
@@ -336,10 +389,14 @@ export const ScheduleOverridesManager: React.FC = () => {
                               </Text>
                             ) : null}
                           </XStack>
-                          <Input
+                          <RoleMemberPicker
                             value={current}
-                            onChangeText={(t) => setRoleField(k, field.key, t)}
+                            ecclesia={data?.ecclesia ?? ''}
+                            selectedPersonId={draft.roleFieldRefs[field.key]}
                             placeholder={synced || field.defaultLabel}
+                            onChangeText={(t) => setRoleField(k, field.key, t)}
+                            onSelectMember={(m) => setRoleMember(k, field.key, m)}
+                            onClearMember={() => clearRoleMember(k, field.key)}
                           />
                         </YStack>
                       )

--- a/packages/app/provider/dynamodb/repositories/service-override-repository.ts
+++ b/packages/app/provider/dynamodb/repositories/service-override-repository.ts
@@ -15,6 +15,7 @@ export interface UpsertOverrideInput {
   note?: string
   attendOptions?: AttendOption[]
   roleFields?: Record<string, string>
+  roleFieldRefs?: Record<string, string>
   createdBy: string
 }
 
@@ -62,6 +63,7 @@ export class ServiceOverrideRepository extends BaseRepository<ServiceOccurrenceO
       ...(input.note !== undefined ? { note: input.note } : {}),
       ...(input.attendOptions !== undefined ? { attendOptions: input.attendOptions } : {}),
       ...(input.roleFields !== undefined ? { roleFields: input.roleFields } : {}),
+      ...(input.roleFieldRefs !== undefined ? { roleFieldRefs: input.roleFieldRefs } : {}),
       createdBy: existing?.createdBy ?? input.createdBy,
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,

--- a/packages/app/provider/dynamodb/service-override-types.ts
+++ b/packages/app/provider/dynamodb/service-override-types.ts
@@ -67,6 +67,14 @@ export interface ServiceOccurrenceOverrideRecord extends BaseRecord {
   // NEVER writes these back to Sheets (`tee-schedules` stays a one-way input).
   roleFields?: Record<string, string>
 
+  // Slice B (#110): parallel metadata map, catalogue fieldKey → PersonRecord
+  // personId, recording WHICH directory member an admin picked for a role via the
+  // member-picker. This is metadata for future linking ONLY — it is deliberately
+  // NOT applied to the program item at read time, so the display value in
+  // `roleFields` still solely drives what renders (and gets first-name redacted).
+  // `roleFieldRefs` must NEVER reach the anon/public read path.
+  roleFieldRefs?: Record<string, string>
+
   createdBy: string
   createdAt: string
   updatedAt: string

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -39,3 +39,6 @@ export * from './email/person-selector-dialog'
 
 // Directory System
 export * from './directory'
+
+// Roster member-pickers (#110, Slice B)
+export * from './roster'

--- a/packages/ui/src/roster/index.ts
+++ b/packages/ui/src/roster/index.ts
@@ -1,0 +1,1 @@
+export * from './role-member-picker'

--- a/packages/ui/src/roster/role-member-picker.tsx
+++ b/packages/ui/src/roster/role-member-picker.tsx
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { YStack, XStack, Text, Input, Spinner } from 'tamagui'
+import { Button } from '../Button'
+import { User, X } from '@tamagui/lucide-icons'
+
+/**
+ * RoleMemberPicker (#110, Slice B) — a typeahead over directory members for a
+ * single roster role (Preside/Exhort/Organist/…).
+ *
+ * SHARED UI: this lives in `packages/ui` and is used by both web and (eventually)
+ * native, so it MUST NOT import `next-auth` or `next/navigation`. It talks to the
+ * read-only candidate endpoint with a plain same-origin `fetch` (cookies ride
+ * along for the owner/admin gate); callers on other platforms can inject their own
+ * `fetchCandidates`.
+ *
+ * Selecting a member fills the display name AND surfaces the chosen `personId` to
+ * the parent (via `onSelectMember`) — but the DISPLAY VALUE is still what renders /
+ * gets redacted downstream. Free-typing a name that isn't in the directory stays
+ * fully supported (visiting speakers etc.); typing clears any prior member link.
+ */
+
+export interface RosterCandidate {
+  personId: string
+  displayName: string
+  ecclesia?: string
+}
+
+export interface RoleMemberPickerProps {
+  /** Current display value (the free-text/synced name shown in the field). */
+  value: string
+  /** Ecclesia to scope the directory search to. */
+  ecclesia: string
+  /** personId of a currently-linked member, if the value came from a pick. */
+  selectedPersonId?: string
+  placeholder?: string
+  disabled?: boolean
+  /** Free-text edit — clears any member link in the parent. */
+  onChangeText: (text: string) => void
+  /** A directory member was picked from the typeahead. */
+  onSelectMember: (member: RosterCandidate) => void
+  /** Unlink the member but keep the typed display value. */
+  onClearMember?: () => void
+  /**
+   * Optional injected fetcher (native/testing). Defaults to a same-origin GET
+   * against `/api/roster/resolve-candidates`.
+   */
+  fetchCandidates?: (q: string, ecclesia: string) => Promise<RosterCandidate[]>
+}
+
+const DEBOUNCE_MS = 250
+
+async function defaultFetchCandidates(q: string, ecclesia: string): Promise<RosterCandidate[]> {
+  const params = new URLSearchParams({ q, ecclesia })
+  const res = await fetch(`/api/roster/resolve-candidates?${params.toString()}`, {
+    cache: 'no-store',
+  })
+  if (!res.ok) return []
+  const json = await res.json()
+  return Array.isArray(json?.candidates) ? (json.candidates as RosterCandidate[]) : []
+}
+
+export function RoleMemberPicker({
+  value,
+  ecclesia,
+  selectedPersonId,
+  placeholder,
+  disabled,
+  onChangeText,
+  onSelectMember,
+  onClearMember,
+  fetchCandidates = defaultFetchCandidates,
+}: RoleMemberPickerProps) {
+  const [query, setQuery] = useState('')
+  const [candidates, setCandidates] = useState<RosterCandidate[]>([])
+  const [loading, setLoading] = useState(false)
+  const [open, setOpen] = useState(false)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const blurRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Guards against a stale in-flight request overwriting fresher results.
+  const requestSeq = useRef(0)
+
+  const runSearch = useCallback(
+    (q: string) => {
+      const trimmed = q.trim()
+      if (trimmed.length < 1) {
+        setCandidates([])
+        setLoading(false)
+        return
+      }
+      const seq = ++requestSeq.current
+      setLoading(true)
+      fetchCandidates(trimmed, ecclesia)
+        .then((results) => {
+          if (seq !== requestSeq.current) return
+          setCandidates(results)
+        })
+        .catch(() => {
+          if (seq !== requestSeq.current) return
+          setCandidates([])
+        })
+        .finally(() => {
+          if (seq !== requestSeq.current) return
+          setLoading(false)
+        })
+    },
+    [ecclesia, fetchCandidates]
+  )
+
+  // Debounced search as the query changes.
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (!open) return
+    debounceRef.current = setTimeout(() => runSearch(query), DEBOUNCE_MS)
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [query, open, runSearch])
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      if (blurRef.current) clearTimeout(blurRef.current)
+    }
+  }, [])
+
+  const handleChangeText = (text: string) => {
+    setQuery(text)
+    setOpen(true)
+    // Any manual edit means the field no longer reflects the previously picked
+    // member — the parent drops the ref link.
+    onChangeText(text)
+  }
+
+  const handleSelect = (candidate: RosterCandidate) => {
+    onSelectMember(candidate)
+    setOpen(false)
+    setCandidates([])
+    setQuery('')
+  }
+
+  const handleFocus = () => {
+    if (blurRef.current) clearTimeout(blurRef.current)
+    setOpen(true)
+    // Seed the dropdown from the current display value so a click-in searches.
+    if (value.trim().length > 0 && candidates.length === 0) {
+      setQuery(value)
+    }
+  }
+
+  const handleBlur = () => {
+    // Delay so an item press registers before the list unmounts.
+    blurRef.current = setTimeout(() => setOpen(false), 150)
+  }
+
+  const showDropdown = open && !disabled && (loading || candidates.length > 0)
+
+  return (
+    <YStack position="relative" space="$1">
+      <Input
+        value={value}
+        onChangeText={handleChangeText}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        placeholder={placeholder}
+        disabled={disabled}
+      />
+
+      {selectedPersonId ? (
+        <XStack alignItems="center" gap="$2" paddingHorizontal="$1">
+          <User size={12} color="$blue10" />
+          <Text fontSize="$1" color="$blue11">
+            Linked to directory member
+          </Text>
+          {onClearMember ? (
+            <Button
+              size="$1"
+              chromeless
+              icon={X}
+              onPress={onClearMember}
+              accessibilityLabel="Unlink directory member"
+            >
+              Unlink
+            </Button>
+          ) : null}
+        </XStack>
+      ) : null}
+
+      {showDropdown ? (
+        <YStack
+          position="absolute"
+          top="100%"
+          left={0}
+          right={0}
+          zIndex={1000}
+          marginTop="$1"
+          backgroundColor="$background"
+          borderWidth={1}
+          borderColor="$borderColor"
+          borderRadius="$3"
+          elevation="$2"
+          overflow="hidden"
+          maxHeight={240}
+        >
+          {loading ? (
+            <XStack padding="$3" alignItems="center" gap="$2">
+              <Spinner size="small" width={14} height={14} />
+              <Text fontSize="$2" color="$colorSecondary">
+                Searching directory…
+              </Text>
+            </XStack>
+          ) : candidates.length === 0 ? (
+            <XStack padding="$3">
+              <Text fontSize="$2" color="$colorSecondary">
+                No directory match — the typed name is kept as-is.
+              </Text>
+            </XStack>
+          ) : (
+            <YStack>
+              {candidates.map((c) => (
+                <XStack
+                  key={c.personId}
+                  padding="$3"
+                  gap="$2"
+                  alignItems="center"
+                  cursor="pointer"
+                  backgroundColor="$background"
+                  hoverStyle={{ backgroundColor: '$blue3' }}
+                  pressStyle={{ backgroundColor: '$blue4' }}
+                  // onPress fires before the input's blur timeout closes the list.
+                  onPress={() => handleSelect(c)}
+                >
+                  <User size={14} color="$colorSecondary" />
+                  <Text fontSize="$3" flex={1}>
+                    {c.displayName}
+                  </Text>
+                  {c.ecclesia ? (
+                    <Text fontSize="$1" color="$colorSecondary">
+                      {c.ecclesia}
+                    </Text>
+                  ) : null}
+                </XStack>
+              ))}
+            </YStack>
+          )}
+        </YStack>
+      ) : null}
+    </YStack>
+  )
+}


### PR DESCRIPTION
## Slice B of #110 (Native Roster CRUD) — resolver-backed member-pickers

Stacks on Slice A (#119). Replaces the free-text roster role inputs in the schedule-overrides admin with a **typeahead over directory members**, keeping free-text as a fallback for names not in the directory. Cross-ecclesia visiting-speaker **create** path is deliberately NOT built here (deferred to Slice C).

### What
1. **Read-only candidate endpoint** — `GET /api/roster/resolve-candidates?q=&ecclesia=` (owner/admin gated). Returns `{ personId, displayName, ecclesia }[]`. No mutations.
2. **`RoleMemberPicker`** (`packages/ui/src/roster/`) — shared typeahead component. No `next-auth`/`next/navigation` imports; talks to the endpoint with a plain same-origin `fetch` (injectable `fetchCandidates` for other platforms). Selecting a member fills the display name; free-typing still works and clears any prior link.
3. **Wired into `ScheduleOverridesManager`** — each role field uses `RoleMemberPicker`, pre-filled from the synced/override value. On pick, stores **BOTH** the display value in `roleFields[fieldKey]` (unchanged Slice-A behavior — this renders + redacts) **AND** the chosen `personId` in a NEW parallel `roleFieldRefs?: Record<string,string>` map on the override record + repository `upsert` + admin API (`sanitizeRoleFieldRefs`, allow-listed to catalogue keys).

### Why
Toward the in-app editable roster (issue #110 slicing plan): admins pick a real directory member instead of typing a name, laying the `personId` linkage for later slices — without changing what the newsletter shows.

### How the display/redaction contract is preserved
`roleFieldRefs` is **metadata only**. `merge.ts` is untouched: it still applies only `roleFields` onto the program item, so the display value remains the single thing that renders and gets first-name-only redacted for anon viewers. The `personId` is never written to the program item, so it cannot leak to the anon/public path.

### How verified
- `yarn workspace next-app typecheck` — clean (0 errors).
- `vitest`: `service-override-merge` (13, incl. 2 new Slice-B isolation tests proving `roleFieldRefs` never reaches the item and anon redaction stays first-name-only), `redact-schedule` (8), `name-resolver-directory` (4) — all pass.
- Manually verified no `&&`-in-JSX (ternary+null throughout); interactive picker rows carry `hoverStyle`.

### What is NOT verified
- **No live/browser run** of the picker (endpoint auth cookies, dropdown UX, focus/blur timing) — worktree lacks a dev server session; typecheck+unit tests only.
- `yarn lint` could not run: the repo's ESLint patch script rejects ESLint 9.21.0 (pre-existing tooling issue, errors before linting any file). Verified the JSX rule manually instead.
- GSI3 `searchByName` is intentionally **not** used (exact-lastname only, unsuited to partial typeahead); the substring scan over `listByEcclesia` is the primary path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)