### PR TITLE
feat(resolver): capture visiting-speaker email/phone, backfill records, scope privacy (#109)

### DIFF
--- a/apps/next/tests/sync/visiting-speakers-ingest.test.ts
+++ b/apps/next/tests/sync/visiting-speakers-ingest.test.ts
@@ -4,18 +4,20 @@ import {
   syncVisitingSpeakers,
   splitSpeakerName,
   type PersonRepositoryLike,
+  type PrivacyRepositoryLike,
 } from '@my/app/provider/sync/visiting-speakers-ingest'
 import type { PersonRecord } from '@my/app/provider/dynamodb/types'
 
 // ---- Fixtures ---------------------------------------------------------------
 
 /** Minimal PersonRecord for the directory candidate list (only the fields the
- * resolver reads matter). */
+ * resolver + backfill guard read matter). */
 function personRecord(
   personId: string,
   firstName: string,
   lastName: string,
-  ecclesia: string
+  ecclesia: string,
+  overrides: Partial<PersonRecord> = {}
 ): PersonRecord {
   return {
     pkey: `PERSON#${personId}`,
@@ -33,7 +35,24 @@ function personRecord(
     displayName: `${firstName} ${lastName}`,
     ecclesia,
     memberStatus: 'member',
+    ...overrides,
   } as PersonRecord
+}
+
+/** A record shaped like one WE auto-created: emailless schedule-import visitor. */
+function scheduleImportVisitor(
+  personId: string,
+  firstName: string,
+  lastName: string,
+  ecclesia: string,
+  overrides: Partial<PersonRecord> = {}
+): PersonRecord {
+  return personRecord(personId, firstName, lastName, ecclesia, {
+    memberStatus: 'visitor',
+    source: 'schedule-import',
+    sourceRef: 'visiting-speakers:sheet-1',
+    ...overrides,
+  })
 }
 
 /** A GoogleSheetsService stub returning canned tab data. */
@@ -43,17 +62,50 @@ function fakeSheets(headers: string[], rows: any[][]) {
   } as any
 }
 
-/** A repository stub capturing create() inputs. */
-function fakeRepo(existing: PersonRecord[]) {
+/**
+ * A repository stub capturing every mutation. `phonesByPerson` seeds getPhones
+ * so the phone-idempotency guard can be exercised.
+ */
+function fakeRepo(
+  existing: PersonRecord[],
+  phonesByPerson: Record<string, any[]> = {}
+) {
   const createInputs: any[] = []
+  const addEmailCalls: any[] = []
+  const addPhoneCalls: any[] = []
+  const updatePersonCalls: any[] = []
   const repo: PersonRepositoryLike = {
     listAll: vi.fn(async () => ({ items: existing, lastEvaluatedKey: undefined })) as any,
     create: vi.fn(async (input: any) => {
       createInputs.push(input)
       return { ...input, personId: `new-${createInputs.length}` } as PersonRecord
     }) as any,
+    addEmail: vi.fn(async (personId: string, email: any) => {
+      addEmailCalls.push({ personId, ...email })
+      return { emailId: `email-${addEmailCalls.length}`, ...email } as any
+    }) as any,
+    addPhone: vi.fn(async (personId: string, phone: any) => {
+      addPhoneCalls.push({ personId, ...phone })
+      return { phoneId: `phone-${addPhoneCalls.length}`, ...phone } as any
+    }) as any,
+    getPhones: vi.fn(async (personId: string) => phonesByPerson[personId] ?? []) as any,
+    updatePerson: vi.fn(async (personId: string, updates: any) => {
+      updatePersonCalls.push({ personId, ...updates })
+      return { personId, ...updates } as any
+    }) as any,
   }
-  return { repo, createInputs }
+  return { repo, createInputs, addEmailCalls, addPhoneCalls, updatePersonCalls }
+}
+
+/** A privacy stub capturing createPrivacySettings calls. */
+function fakePrivacy() {
+  const privacyCalls: any[] = []
+  const privacy: PrivacyRepositoryLike = {
+    createPrivacySettings: vi.fn(async (email: string, settings: any) => {
+      privacyCalls.push({ email, settings })
+    }) as any,
+  }
+  return { privacy, privacyCalls }
 }
 
 // ---- splitSpeakerName -------------------------------------------------------
@@ -86,16 +138,32 @@ describe('readVisitingSpeakers', () => {
     )
     const out = await readVisitingSpeakers('sheet-1', sheets)
     expect(out).toEqual([
-      { name: 'Alan Markwith', ecclesia: 'Greenaway Hamilton' },
-      { name: 'Brad Stephens', ecclesia: 'Toronto East' },
+      { name: 'Alan Markwith', ecclesia: 'Greenaway Hamilton', email: undefined, phone: undefined },
+      { name: 'Brad Stephens', ecclesia: 'Toronto East', email: undefined, phone: undefined },
     ])
   })
 
-  it('falls back to the first column for the name when no header matches', async () => {
+  it('captures email + phone, lowercasing the email and trimming both', async () => {
     const sheets = fakeSheets(
-      ['Col A', 'Col B'],
-      [['Alan Markwith', 'note']]
+      ['Name', 'Ecclesia', 'E-mail', 'Mobile'],
+      [
+        ['Alan Markwith', 'Greenaway Hamilton', '  Alan.Markwith@Example.COM ', ' 416 555 1234 '],
+        ['Brad Stephens', 'Toronto East', '', ''], // blank contact cells → undefined
+      ]
     )
+    const out = await readVisitingSpeakers('sheet-1', sheets)
+    expect(out[0]).toEqual({
+      name: 'Alan Markwith',
+      ecclesia: 'Greenaway Hamilton',
+      email: 'alan.markwith@example.com',
+      phone: '416 555 1234',
+    })
+    expect(out[1].email).toBeUndefined()
+    expect(out[1].phone).toBeUndefined()
+  })
+
+  it('falls back to the first column for the name when no header matches', async () => {
+    const sheets = fakeSheets(['Col A', 'Col B'], [['Alan Markwith', 'note']])
     const out = await readVisitingSpeakers('sheet-1', sheets)
     expect(out[0].name).toBe('Alan Markwith')
     expect(out[0].ecclesia).toBeUndefined()
@@ -121,8 +189,9 @@ describe('syncVisitingSpeakers', () => {
   it('creates confident not-found visitors, skips the rest, and is idempotent', async () => {
     const sheets = fakeSheets(['Name', 'Ecclesia'], ROWS)
     const { repo, createInputs } = fakeRepo(existingDirectory())
+    const { privacy } = fakePrivacy()
 
-    const result = await syncVisitingSpeakers('sheet-1', { repository: repo, sheets })
+    const result = await syncVisitingSpeakers('sheet-1', { repository: repo, sheets, privacy })
 
     expect(result.dryRun).toBe(false)
     expect(result.totalRows).toBe(6)
@@ -146,6 +215,7 @@ describe('syncVisitingSpeakers', () => {
       sourceRef: 'visiting-speakers:sheet-1',
     })
     expect(createInputs[0].email).toBeUndefined()
+    expect(result.created[0].emailless).toBe(true)
 
     // Skips carry a reason.
     const skipReasons = Object.fromEntries(result.skipped.map((s) => [s.name, s.reason]))
@@ -161,10 +231,12 @@ describe('syncVisitingSpeakers', () => {
   it('dryRun reports what WOULD be created without calling create()', async () => {
     const sheets = fakeSheets(['Name', 'Ecclesia'], ROWS)
     const { repo, createInputs } = fakeRepo(existingDirectory())
+    const { privacy } = fakePrivacy()
 
     const result = await syncVisitingSpeakers('sheet-1', {
       repository: repo,
       sheets,
+      privacy,
       dryRun: true,
     })
 
@@ -176,5 +248,190 @@ describe('syncVisitingSpeakers', () => {
       'David Owens',
     ])
     expect(result.created.every((c) => c.personId === undefined)).toBe(true)
+  })
+
+  // ---- Change 2: create WITH contact info -----------------------------------
+
+  it('creates a not-found visitor WITH email (normal create path), phone, and privacy', async () => {
+    const sheets = fakeSheets(
+      ['Name', 'Ecclesia', 'Email', 'Phone'],
+      [['Bro. Alan Markwith', 'Greenaway Hamilton', 'alan@example.com', '4165551234']]
+    )
+    const { repo, createInputs, addPhoneCalls } = fakeRepo(existingDirectory())
+    const { privacy, privacyCalls } = fakePrivacy()
+
+    const result = await syncVisitingSpeakers('sheet-1', { repository: repo, sheets, privacy })
+
+    // create() called WITH the email → getByEmail can find them.
+    expect(createInputs).toHaveLength(1)
+    expect(createInputs[0].email).toBe('alan@example.com')
+    expect(result.created[0].emailless).toBe(false)
+    expect(result.created[0].email).toBe('alan@example.com')
+
+    // Phone stored.
+    expect(addPhoneCalls).toHaveLength(1)
+    expect(addPhoneCalls[0]).toMatchObject({ number: '4165551234', type: 'mobile', isPrimary: true })
+    expect(result.created[0].phone).toBe('4165551234')
+
+    // Privacy set to ecclesia_and_connections for every sensitive field.
+    expect(privacyCalls).toHaveLength(1)
+    expect(privacyCalls[0].email).toBe('alan@example.com')
+    expect(privacyCalls[0].settings).toEqual({
+      showName: 'ecclesia_and_connections',
+      showEmail: 'ecclesia_and_connections',
+      showPhone: 'ecclesia_and_connections',
+      showAddress: 'ecclesia_and_connections',
+      showFamily: 'ecclesia_and_connections',
+    })
+    expect(result.created[0].privacy).toBe('ecclesia_and_connections')
+  })
+
+  it('creates an EMAILLESS visitor when the sheet has no email (keeps NOEMAIL# path)', async () => {
+    const sheets = fakeSheets(
+      ['Name', 'Ecclesia', 'Email', 'Phone'],
+      [['Bro. Alan Markwith', 'Greenaway Hamilton', '', '']]
+    )
+    const { repo, createInputs, addPhoneCalls } = fakeRepo(existingDirectory())
+    const { privacy, privacyCalls } = fakePrivacy()
+
+    const result = await syncVisitingSpeakers('sheet-1', { repository: repo, sheets, privacy })
+
+    expect(createInputs).toHaveLength(1)
+    // No email key handed to create() → falls back to the emailless sentinel.
+    expect(createInputs[0].email).toBeUndefined()
+    expect(result.created[0].emailless).toBe(true)
+    expect(result.created[0].privacy).toBeUndefined()
+    // No phone, no privacy record for an emailless visitor.
+    expect(addPhoneCalls).toHaveLength(0)
+    expect(privacyCalls).toHaveLength(0)
+  })
+
+  // ---- Change 3: backfill onto an existing auto-created visitor -------------
+
+  it('backfills email + phone + privacy onto an existing schedule-import visitor', async () => {
+    const visitor = scheduleImportVisitor('v1', 'Alan', 'Markwith', 'Greenaway Hamilton')
+    const sheets = fakeSheets(
+      ['Name', 'Ecclesia', 'Email', 'Phone'],
+      [['Bro. Alan Markwith', 'Greenaway Hamilton', 'Alan@Example.com', '4165551234']]
+    )
+    const { repo, createInputs, addEmailCalls, addPhoneCalls, updatePersonCalls } = fakeRepo([visitor])
+    const { privacy, privacyCalls } = fakePrivacy()
+
+    const result = await syncVisitingSpeakers('sheet-1', { repository: repo, sheets, privacy })
+
+    // No new record created — the existing one is reconciled in place.
+    expect(createInputs).toHaveLength(0)
+    expect(result.created).toHaveLength(0)
+
+    // Email added as primary + PROFILE sentinel flipped so getByEmail works.
+    expect(addEmailCalls).toHaveLength(1)
+    expect(addEmailCalls[0]).toMatchObject({
+      personId: 'v1',
+      email: 'alan@example.com',
+      emailType: 'primary',
+    })
+    expect(updatePersonCalls).toHaveLength(1)
+    expect(updatePersonCalls[0]).toEqual({
+      personId: 'v1',
+      gsi1pk: 'EMAIL#alan@example.com',
+      primaryEmail: 'alan@example.com',
+    })
+
+    // Phone added.
+    expect(addPhoneCalls).toHaveLength(1)
+    expect(addPhoneCalls[0]).toMatchObject({ personId: 'v1', number: '4165551234' })
+
+    // Privacy set on the backfilled record.
+    expect(privacyCalls).toHaveLength(1)
+    expect(privacyCalls[0].email).toBe('alan@example.com')
+    expect(privacyCalls[0].settings.showEmail).toBe('ecclesia_and_connections')
+
+    // Report reflects the backfill.
+    expect(result.backfilled).toHaveLength(1)
+    expect(result.backfilled[0]).toEqual({
+      name: 'Bro. Alan Markwith',
+      ecclesia: 'Greenaway Hamilton',
+      personId: 'v1',
+      addedEmail: 'alan@example.com',
+      addedPhone: '4165551234',
+      privacy: 'ecclesia_and_connections',
+    })
+  })
+
+  it('dryRun reports a backfill WITHOUT writing', async () => {
+    const visitor = scheduleImportVisitor('v1', 'Alan', 'Markwith', 'Greenaway Hamilton')
+    const sheets = fakeSheets(
+      ['Name', 'Ecclesia', 'Email', 'Phone'],
+      [['Bro. Alan Markwith', 'Greenaway Hamilton', 'alan@example.com', '4165551234']]
+    )
+    const { repo, addEmailCalls, addPhoneCalls, updatePersonCalls } = fakeRepo([visitor])
+    const { privacy, privacyCalls } = fakePrivacy()
+
+    const result = await syncVisitingSpeakers('sheet-1', {
+      repository: repo,
+      sheets,
+      privacy,
+      dryRun: true,
+    })
+
+    // Nothing written.
+    expect(addEmailCalls).toHaveLength(0)
+    expect(addPhoneCalls).toHaveLength(0)
+    expect(updatePersonCalls).toHaveLength(0)
+    expect(privacyCalls).toHaveLength(0)
+
+    // But the intended backfill is reported.
+    expect(result.backfilled).toHaveLength(1)
+    expect(result.backfilled[0].addedEmail).toBe('alan@example.com')
+    expect(result.backfilled[0].addedPhone).toBe('4165551234')
+    expect(result.backfilled[0].privacy).toBe('ecclesia_and_connections')
+  })
+
+  it('does NOT add a phone when the visitor already has one (idempotent)', async () => {
+    const visitor = scheduleImportVisitor('v1', 'Alan', 'Markwith', 'Greenaway Hamilton', {
+      primaryEmail: 'alan@example.com', // already backfilled email
+    })
+    const sheets = fakeSheets(
+      ['Name', 'Ecclesia', 'Email', 'Phone'],
+      [['Bro. Alan Markwith', 'Greenaway Hamilton', 'alan@example.com', '4165551234']]
+    )
+    const { repo, addEmailCalls, addPhoneCalls } = fakeRepo([visitor], {
+      v1: [{ phoneId: 'existing', number: '4165551234' }],
+    })
+    const { privacy } = fakePrivacy()
+
+    const result = await syncVisitingSpeakers('sheet-1', { repository: repo, sheets, privacy })
+
+    // Email already present, phone already present → nothing to do.
+    expect(addEmailCalls).toHaveLength(0)
+    expect(addPhoneCalls).toHaveLength(0)
+    expect(result.backfilled).toHaveLength(0)
+    expect(result.skipped.some((s) => /up to date/.test(s.reason))).toBe(true)
+  })
+
+  // ---- Change 3 (CRITICAL SAFETY): never touch a real member ---------------
+
+  it('NEVER modifies a real member even when the sheet carries their email + phone', async () => {
+    // Brad is a genuine member (no source, memberStatus 'member').
+    const member = personRecord('p1', 'Brad', 'Stephens', 'Toronto East')
+    const sheets = fakeSheets(
+      ['Name', 'Ecclesia', 'Email', 'Phone'],
+      [['Brad Stephens', 'Toronto East', 'brad@personal.com', '9055559999']]
+    )
+    const { repo, createInputs, addEmailCalls, addPhoneCalls, updatePersonCalls } = fakeRepo([member])
+    const { privacy, privacyCalls } = fakePrivacy()
+
+    const result = await syncVisitingSpeakers('sheet-1', { repository: repo, sheets, privacy })
+
+    // Absolutely no writes of any kind against the real member.
+    expect(createInputs).toHaveLength(0)
+    expect(addEmailCalls).toHaveLength(0)
+    expect(addPhoneCalls).toHaveLength(0)
+    expect(updatePersonCalls).toHaveLength(0)
+    expect(privacyCalls).toHaveLength(0)
+    expect(result.backfilled).toHaveLength(0)
+
+    // Left untouched, reported as already present.
+    expect(result.skipped).toEqual([{ name: 'Brad Stephens', reason: 'already in directory' }])
   })
 })

--- a/packages/app/provider/sync/visiting-speakers-ingest.ts
+++ b/packages/app/provider/sync/visiting-speakers-ingest.ts
@@ -2,10 +2,30 @@
  * Visiting-speaker ingest (keystone — issue #109, WRITE increment).
  *
  * Reads the memorial "Visiting Speakers" tab and, for CONFIDENT not-found
- * names, creates an emailless `visitor` PersonRecord under the speaker's home
- * ecclesia so the schedule name resolver can match them next time. This is the
- * WRITE half of the resolver keystone: increment 2 shipped the read-only
- * diagnostic; this turns reviewed not-found names into real directory records.
+ * names, creates a `visitor` PersonRecord under the speaker's home ecclesia so
+ * the schedule name resolver can match them next time. This is the WRITE half
+ * of the resolver keystone: increment 2 shipped the read-only diagnostic; this
+ * turns reviewed not-found names into real directory records.
+ *
+ * CONTACT INFO + PRIVACY (issue #109 follow-up):
+ *   - The tab may now carry an email and/or phone. When an email is present the
+ *     record is created the NORMAL way (real EMAIL# item, gsi1 EMAIL# key) so
+ *     `getByEmail` finds them; with no email we keep the emailless NOEMAIL#
+ *     sentinel path. Phones are stored when present.
+ *   - Records we ALREADY auto-created (source:'schedule-import',
+ *     memberStatus:'visitor') that are missing an email/phone the sheet now
+ *     provides are BACKFILLED in place. 23 emailless records were created before
+ *     the sheet carried contact columns; this reconciles them.
+ *   - Privacy: on both create and backfill the sensitive fields are set to
+ *     `ecclesia_and_connections` so only the speaker's OWN ecclesia (plus the
+ *     owner / same-ecclesia admin-recorder-rep via the privacy resolver's role
+ *     overrides) can see their info — until the person changes it themselves.
+ *
+ * CRITICAL SAFETY
+ *   - We ONLY ever read/modify records that are BOTH source:'schedule-import'
+ *     AND memberStatus:'visitor' (records this ingest created). A name that
+ *     resolves to a real member is left completely untouched — never edited,
+ *     never given an email.
  *
  * DESIGN NOTES
  *   - ADMIN-TRIGGERED, not auto-firing. This module never runs itself — it is
@@ -17,13 +37,17 @@
  *   - Idempotent. Candidates are re-resolved before each create against a list
  *     that grows as records are made, so a name repeated within one batch (or
  *     on a second run) matches the record it just created — no duplicates.
+ *     Backfill is idempotent too: an email is only added when the record is
+ *     emailless, a phone only when no phone exists yet.
  *   - No emails / notifications. See the NEXT INCREMENT note below.
  *
- * I/O is injectable (sheets + repository) so this unit-tests with fixtures and
- * never touches live DynamoDB or Sheets in tests.
+ * I/O is injectable (sheets + repository + privacy) so this unit-tests with
+ * fixtures and never touches live DynamoDB or Sheets in tests.
  */
 import { GoogleSheetsService } from './google-sheets-service'
 import { personRepository } from '../dynamodb/repositories/person-repository'
+import { privacyRepository } from '../dynamodb/repositories/privacy-repository'
+import type { PersonRecord, VisibilityLevel } from '../dynamodb/types'
 import {
   resolveNames,
   toDirectoryPerson,
@@ -37,11 +61,41 @@ const HONORIFIC_RE = /^(bro\.?|brother|bre\.?|sis\.?|sister|mr\.?|mrs\.?|ms\.?|d
 const NAME_HEADER_RE = /(name|speaker|exhort|brother|visitor|preside)/i
 /** Header that holds the speaker's home ecclesia. */
 const ECCLESIA_HEADER_RE = /(ecclesia|assembly|congregation|meeting|home|from)/i
+/** Header that holds the speaker's email address. */
+const EMAIL_HEADER_RE = /e-?mail/i
+/** Header that holds the speaker's phone number. */
+const PHONE_HEADER_RE = /phone|mobile|cell|tel/i
+
+/**
+ * Field visibility applied to every record this ingest touches. Sensitive
+ * fields are `ecclesia_and_connections` — same-ecclesia members see them, and
+ * the owner / same-ecclesia admin-recorder-rep see them via the role overrides
+ * in `PrivacyRepository.canViewField`. Deliberately NOT the literal 'private'
+ * level, which would hide the speaker from their own ecclesia too.
+ */
+export const VISITING_SPEAKER_VISIBILITY: VisibilityLevel = 'ecclesia_and_connections'
+
+const VISITOR_PRIVACY_SETTINGS = {
+  showName: VISITING_SPEAKER_VISIBILITY,
+  showEmail: VISITING_SPEAKER_VISIBILITY,
+  showPhone: VISITING_SPEAKER_VISIBILITY,
+  showAddress: VISITING_SPEAKER_VISIBILITY,
+  showFamily: VISITING_SPEAKER_VISIBILITY,
+} as const
 
 /** The minimal repository surface this module needs — lets tests inject a fake. */
 export interface PersonRepositoryLike {
   listAll: (typeof personRepository)['listAll']
   create: (typeof personRepository)['create']
+  addEmail: (typeof personRepository)['addEmail']
+  addPhone: (typeof personRepository)['addPhone']
+  getPhones: (typeof personRepository)['getPhones']
+  updatePerson: (typeof personRepository)['updatePerson']
+}
+
+/** The minimal privacy surface this module needs — lets tests inject a fake. */
+export interface PrivacyRepositoryLike {
+  createPrivacySettings: (typeof privacyRepository)['createPrivacySettings']
 }
 
 /** One row of the "Visiting Speakers" tab we care about. */
@@ -50,13 +104,18 @@ export interface VisitingSpeaker {
   name: string
   /** Home ecclesia column value, if present. */
   ecclesia?: string
+  /** Email column value, lowercased + trimmed, if present. */
+  email?: string
+  /** Phone column value, trimmed, if present. */
+  phone?: string
 }
 
 export interface SyncOptions {
-  /** When true, resolve + report what WOULD be created without writing. */
+  /** When true, resolve + report what WOULD be created/backfilled without writing. */
   dryRun?: boolean
   sheets?: GoogleSheetsService
   repository?: PersonRepositoryLike
+  privacy?: PrivacyRepositoryLike
 }
 
 export interface SyncCreated {
@@ -64,8 +123,28 @@ export interface SyncCreated {
   ecclesia: string
   firstName: string
   lastName: string
+  /** Email the record was (or would be) created with. */
+  email?: string
+  /** Phone stored (or that would be stored) with the record. */
+  phone?: string
+  /** True when created via the emailless NOEMAIL# sentinel path. */
+  emailless: boolean
+  /** Visibility level applied to the sensitive fields (only when an email exists). */
+  privacy?: VisibilityLevel
   /** Set only on a real (non-dry-run) create. */
   personId?: string
+}
+
+export interface SyncBackfilled {
+  name: string
+  ecclesia: string
+  personId: string
+  /** Email added to a previously-emailless record (undefined if none added). */
+  addedEmail?: string
+  /** Phone added to the record (undefined if none added). */
+  addedPhone?: string
+  /** Visibility level applied when an email was added. */
+  privacy?: VisibilityLevel
 }
 
 export interface SyncSkipped {
@@ -78,6 +157,7 @@ export interface SyncResult {
   sheetId: string
   totalRows: number
   created: SyncCreated[]
+  backfilled: SyncBackfilled[]
   skipped: SyncSkipped[]
 }
 
@@ -88,6 +168,14 @@ function findColumn(headers: string[], re: RegExp): number | null {
     if (typeof h === 'string' && re.test(h)) return i
   }
   return null
+}
+
+/** Read a trimmed string cell, or undefined when blank/missing. */
+function cell(row: any[], col: number | null): string | undefined {
+  if (col == null) return undefined
+  const value = row[col]
+  const str = typeof value === 'string' ? value.trim() : ''
+  return str || undefined
 }
 
 /**
@@ -108,10 +196,11 @@ export function splitSpeakerName(raw: string): { firstName: string; lastName: st
 }
 
 /**
- * Read the memorial "Visiting Speakers" tab into `{ name, ecclesia? }` rows.
- * Falls back to the first column for the name when no header matches (the tab
- * layout is not something we control). Placeholder/blank names are kept here
- * and filtered downstream by the resolver.
+ * Read the memorial "Visiting Speakers" tab into
+ * `{ name, ecclesia?, email?, phone? }` rows. Falls back to the first column
+ * for the name when no header matches (the tab layout is not something we
+ * control). Placeholder/blank names are kept here and filtered downstream by
+ * the resolver.
  */
 export async function readVisitingSpeakers(
   sheetId: string,
@@ -124,25 +213,34 @@ export async function readVisitingSpeakers(
 
   const nameCol = findColumn(headers, NAME_HEADER_RE) ?? 0
   const ecclesiaCol = findColumn(headers, ECCLESIA_HEADER_RE)
+  const emailCol = findColumn(headers, EMAIL_HEADER_RE)
+  const phoneCol = findColumn(headers, PHONE_HEADER_RE)
 
   const out: VisitingSpeaker[] = []
   for (const row of rows) {
     const nameCell = row[nameCol]
     const name = typeof nameCell === 'string' ? nameCell.trim() : ''
     if (!name) continue
-    const ecclesiaCell = ecclesiaCol != null ? row[ecclesiaCol] : undefined
-    const ecclesia = typeof ecclesiaCell === 'string' ? ecclesiaCell.trim() : undefined
-    out.push({ name, ecclesia: ecclesia || undefined })
+    const email = cell(row, emailCol)?.toLowerCase()
+    out.push({
+      name,
+      ecclesia: cell(row, ecclesiaCol),
+      email,
+      phone: cell(row, phoneCol),
+    })
   }
   return out
 }
 
 /**
- * Ingest visiting speakers: create emailless `visitor` records for confident
- * not-found names under their home ecclesia. Idempotent and admin-triggered.
+ * Ingest visiting speakers: create `visitor` records for confident not-found
+ * names under their home ecclesia (with email/phone/privacy when the sheet
+ * provides them) and backfill contact info onto the emailless records we
+ * created before the sheet carried contact columns. Idempotent and
+ * admin-triggered.
  *
  * @param sheetId  the memorial spreadsheet id
- * @param options  dryRun + injectable sheets/repository for testing
+ * @param options  dryRun + injectable sheets/repository/privacy for testing
  */
 export async function syncVisitingSpeakers(
   sheetId: string,
@@ -151,17 +249,27 @@ export async function syncVisitingSpeakers(
   const dryRun = options.dryRun ?? false
   const sheets = options.sheets ?? new GoogleSheetsService()
   const repo: PersonRepositoryLike = options.repository ?? personRepository
+  const privacy: PrivacyRepositoryLike = options.privacy ?? privacyRepository
 
   const speakers = await readVisitingSpeakers(sheetId, sheets)
 
-  // Load the directory once. We mutate this in-memory list as records are
-  // created so idempotency holds WITHIN a run (a name repeated in the same
-  // batch resolves as matched after its first creation).
+  // Load the directory once. `candidates` is the resolver's view and grows as
+  // records are created so idempotency holds WITHIN a run. `recordsById` keeps
+  // the FULL PersonRecord for the PRE-EXISTING directory only — it is what we
+  // consult before any backfill so we can prove a match is one of our own
+  // schedule-import visitors (never a real member). Records created during this
+  // run are intentionally left OUT of recordsById: a repeated name in the same
+  // batch resolves to a candidate with no full record and is simply skipped as
+  // already-present, never re-created and never treated as a backfill target.
   const candidates: DirectoryPerson[] = []
+  const recordsById = new Map<string, PersonRecord>()
   let lastEvaluatedKey: Record<string, any> | undefined
   do {
     const page = await repo.listAll({ lastEvaluatedKey })
-    for (const record of page.items) candidates.push(toDirectoryPerson(record))
+    for (const record of page.items) {
+      candidates.push(toDirectoryPerson(record))
+      recordsById.set(record.personId, record)
+    }
     lastEvaluatedKey = page.lastEvaluatedKey
   } while (lastEvaluatedKey)
 
@@ -170,6 +278,7 @@ export async function syncVisitingSpeakers(
     sheetId,
     totalRows: speakers.length,
     created: [],
+    backfilled: [],
     skipped: [],
   }
 
@@ -178,18 +287,91 @@ export async function syncVisitingSpeakers(
     // earlier in this run) so a repeated name never creates a duplicate.
     const report = resolveNames([speaker.name], candidates)
 
+    // ---- MATCHED: possibly backfill one of OUR auto-created visitors --------
+    if (report.matched.length > 0) {
+      const matched = recordsById.get(report.matched[0].person.personId)
+
+      // Only touch records we created (schedule-import visitors). Anything else
+      // — a real member, or an in-batch record we just created — is left alone.
+      const isOurVisitor =
+        matched != null &&
+        matched.source === 'schedule-import' &&
+        matched.memberStatus === 'visitor'
+
+      if (!matched || !isOurVisitor) {
+        result.skipped.push({ name: speaker.name, reason: 'already in directory' })
+        continue
+      }
+
+      const personId = matched.personId
+      const email = speaker.email
+      const phone = speaker.phone
+
+      // Email only backfilled onto a still-emailless record.
+      const willAddEmail = !!email && !matched.primaryEmail
+      // Phone only added when the sheet has one and the record has none yet.
+      let willAddPhone = false
+      if (phone) {
+        const phones = await repo.getPhones(personId)
+        willAddPhone = phones.length === 0
+      }
+
+      if (!willAddEmail && !willAddPhone) {
+        result.skipped.push({
+          name: speaker.name,
+          reason: 'already in directory (contact info up to date)',
+        })
+        continue
+      }
+
+      if (!dryRun) {
+        if (willAddEmail && email) {
+          // Create the real primary EMAIL# item (mirrors create()'s primary
+          // email), then flip the PROFILE off its NOEMAIL# sentinel so
+          // getByEmail() surfaces the record. addEmail alone does NOT move the
+          // PROFILE's gsi1pk, so we update it here.
+          await repo.addEmail(personId, {
+            email,
+            emailType: 'primary',
+            order: 0,
+            verified: true,
+            sesSubscribed: false,
+            sesStatus: 'active',
+          })
+          await repo.updatePerson(personId, {
+            gsi1pk: `EMAIL#${email}`,
+            primaryEmail: email,
+          })
+          await privacy.createPrivacySettings(email, { ...VISITOR_PRIVACY_SETTINGS })
+        }
+        if (willAddPhone && phone) {
+          await repo.addPhone(personId, { type: 'mobile', number: phone, isPrimary: true })
+        }
+      }
+
+      result.backfilled.push({
+        name: speaker.name,
+        ecclesia: matched.ecclesia,
+        personId,
+        addedEmail: willAddEmail ? email : undefined,
+        addedPhone: willAddPhone ? phone : undefined,
+        privacy: willAddEmail ? VISITING_SPEAKER_VISIBILITY : undefined,
+      })
+      continue
+    }
+
+    // ---- NOT MATCHED, NOT not-found: leave typo/ambiguous/blank for a human --
     if (report.notFound.length === 0) {
-      const reason = report.matched.length
-        ? 'already in directory'
-        : report.typos.length
-          ? 'possible typo — left for human review'
-          : report.ambiguous.length
-            ? 'ambiguous — left for human review'
-            : 'placeholder/blank'
+      const reason = report.typos.length
+        ? 'possible typo — left for human review'
+        : report.ambiguous.length
+          ? 'ambiguous — left for human review'
+          : 'placeholder/blank'
       result.skipped.push({ name: speaker.name, reason })
       continue
     }
 
+    // ---- NOT-FOUND: create a new visitor record -----------------------------
     const ecclesia = speaker.ecclesia?.trim()
     if (!ecclesia) {
       result.skipped.push({ name: speaker.name, reason: 'no home ecclesia column value' })
@@ -197,6 +379,9 @@ export async function syncVisitingSpeakers(
     }
 
     const { firstName, lastName } = splitSpeakerName(speaker.name)
+    const email = speaker.email
+    const phone = speaker.phone
+    const emailless = !email
 
     let personId: string | undefined
     if (!dryRun) {
@@ -208,15 +393,36 @@ export async function syncVisitingSpeakers(
         role: 'guest',
         source: 'schedule-import',
         sourceRef: `visiting-speakers:${sheetId}`,
+        // With an email we take the normal create() path (real EMAIL# item +
+        // EMAIL# gsi1 key) so getByEmail finds them; without, create() falls
+        // back to the emailless NOEMAIL# sentinel.
+        ...(email ? { email } : {}),
       })
       personId = created.personId
+      if (phone) {
+        await repo.addPhone(personId, { type: 'mobile', number: phone, isPrimary: true })
+      }
+      if (email) {
+        await privacy.createPrivacySettings(email, { ...VISITOR_PRIVACY_SETTINGS })
+      }
     }
 
-    result.created.push({ name: speaker.name, ecclesia, firstName, lastName, personId })
+    result.created.push({
+      name: speaker.name,
+      ecclesia,
+      firstName,
+      lastName,
+      email,
+      phone,
+      emailless,
+      privacy: email ? VISITING_SPEAKER_VISIBILITY : undefined,
+      personId,
+    })
 
     // Add to the in-memory candidate list (dry-run too) so a second occurrence
     // of this name in the same batch resolves as matched — dryRun reports
-    // exactly what a real run would create, no phantom duplicates.
+    // exactly what a real run would create, no phantom duplicates. Left OUT of
+    // recordsById on purpose (see the load comment above).
     candidates.push({
       personId: personId ?? `dry-${result.created.length}`,
       firstName,


### PR DESCRIPTION
Extends the visiting-speakers ingest (part of #109) so contact info on the memorial **Visiting Speakers** tab flows into the directory, and restricts who can see the auto-created records.

## What
1. **Capture email + phone.** `readVisitingSpeakers` now parses an optional `email` (trimmed + lowercased) and `phone` (trimmed) via `EMAIL_HEADER_RE = /e-?mail/i` and `PHONE_HEADER_RE = /phone|mobile|cell|tel/i`, alongside name/ecclesia.
2. **Create with contact info.** A confident not-found visitor is created via the normal `create()` path **with** the email when present (so `getByEmail` finds them); with no email it keeps the emailless `NOEMAIL#` sentinel path. Phone stored via `addPhone` when present.
3. **Backfill existing auto-created records.** A name resolving to one of **our** records (`source:'schedule-import'` **AND** `memberStatus:'visitor'`) that is missing an email/phone the sheet now provides is reconciled in place: `addEmail` (primary) **plus** an explicit `updatePerson` flip of the PROFILE `gsi1pk` → `EMAIL#{email}` and `primaryEmail` (off the `NOEMAIL#` sentinel, so `getByEmail` works), and `addPhone`. This reconciles the 23 emailless records created before the sheet carried contact columns.
4. **Privacy.** On both create and backfill the sensitive fields (`showName`, `showEmail`, `showPhone`, `showAddress`, `showFamily`) are set to **`ecclesia_and_connections`** via `privacyRepository.createPrivacySettings`, so only the speaker's own ecclesia sees their info — plus owner / same-ecclesia admin-recorder-rep through the existing role overrides in `PrivacyRepository.canViewField`. Not the literal `'private'` (that would hide them from their own ecclesia too).

## Why
The ingest previously created emailless `visitor` records from name+ecclesia only. The tab now carries email/phone; capturing it makes the records usable (email lookup, contact) while keeping visiting speakers' PII scoped to their own ecclesia until they change it themselves.

## Critical safety
The backfill guard reads/writes **only** records that are both `source:'schedule-import'` and `memberStatus:'visitor'`. A name matching a real member is skipped untouched — never edited, never given an email. Records created earlier in the same run are deliberately kept out of the backfill map so a repeated name is skipped, not re-created or mutated. All idempotent: email only added when emailless, phone only when none exists.

## How verified
- `yarn vitest run tests/sync/visiting-speakers-ingest.test.ts` → **12/12 pass**. Covers: create-with-email (normal path), create-emailless-when-no-email, phone captured, privacy = `ecclesia_and_connections` (create + backfill), backfill email+phone+privacy + gsi1pk flip onto a schedule-import visitor, phone idempotency, dry-run for both create and backfill (asserts no writes), and **NEVER touch a real member** (asserts zero create/addEmail/addPhone/updatePerson/privacy calls).
- `yarn workspace next-app typecheck` → clean (exit 0).
- Shared-package rule respected: no `next-auth` / `next/navigation` imports.

## What was NOT done
- No live data touched — unit tests with fixtures/mocks only; the ingest is still admin-triggered, not wired to any cron/sync.
- No route/UI wiring changes; the injectable `privacy` + expanded `PersonRepositoryLike` default to the real singletons in production.
- Emailless visitors get no privacy record (privacy is email-keyed; they expose only a name). No notification/email side effects (deferred, per project rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)