### PR TITLE
fix(gitignore): ignore .env.local at any depth (secrets footgun)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,9 @@ yarn-error.log*
 # local env files
 **/.env
 .env
-.env.development.local
-.env.test.local
-.env.production.local
+# All local env override files, at any depth (covers .env.local, which was
+# previously untracked-but-not-ignored — a footgun for committing secrets).
+**/.env*.local
 
 # vercel
 .vercel


### PR DESCRIPTION
## Problem
`.gitignore`'s env section listed `.env.development.local`, `.env.test.local`, `.env.production.local` but **omitted `.env.local`** — and those entries were root-relative (no `**/`), so a nested **`apps/next/.env.local` was untracked-but-not-ignored.** That's a real footgun: local dev secrets there could be `git add`ed and committed. (Hit this while pulling prod creds locally to run the visiting-speaker ingest.)

## Fix
Replace the three specific `.env.*.local` lines with one comprehensive **`**/.env*.local`** — covers `.env.local` and every env-override variant at any depth.

## Verified (`git check-ignore`)
- Now ignored: `.env.local`, `apps/next/.env.local`, `apps/expo/.env.local`, `packages/app/.env.local`, `.env.production.local`.
- Still tracked (unaffected): `apps/next/.env.example`, `.env.example`, `.env.dynamodb.example`. `**/.env` (already present) still covers `.env`.

Docs-only / config-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)