### PR TITLE
feat(email): exhorter heads-up email + manual test-mode trigger (#124 slice A)

### DIFF
--- a/apps/email-builder/emails/ExhorterHeadsUp.tsx
+++ b/apps/email-builder/emails/ExhorterHeadsUp.tsx
@@ -208,7 +208,7 @@ const ExhorterHeadsUp: React.FC<ExhorterHeadsUpProps> = ({
           <Text style={{ ...defaultText, margin: '0' }}>
             {signatoryName?.trim() ? (
               <>
-                <strong>{`Brother ${signatoryName.trim()}`}</strong>
+                {`Brother ${signatoryName.trim()}`}
                 <br />
                 Ecclesial Recorder
               </>

--- a/apps/email-builder/emails/ExhorterHeadsUp.tsx
+++ b/apps/email-builder/emails/ExhorterHeadsUp.tsx
@@ -37,6 +37,11 @@ import { EmailBrandLinkContent } from '../components/EmailBrandLinkContent'
  * shared `FooterContent`'s `{{emailPreferencesUrl}}` token (which would ship as
  * a literal placeholder here). The shared FooterContent is intentionally left
  * untouched.
+ *
+ * Content values (short ecclesia name, hall address, Recording Brother
+ * signature, lunch style, ways-to-attend) are resolved SERVER-SIDE from the
+ * ecclesia directory + the memorial row and passed as plain props — this
+ * template renders them, it does not derive them.
  */
 
 /** One "way to attend" the memorial (Zoom / stream / in-person online meeting). */
@@ -49,19 +54,30 @@ export interface ExhorterHeadsUpAttendOption {
   dialInNumber?: string
 }
 
+/** How the fellowship lunch (if any) is provided — drives the invite wording. */
+export type ExhorterHeadsUpLunch = 'potluck' | 'provided' | 'generic'
+
 export interface ExhorterHeadsUpProps {
-  /** Exhorter's first name for the greeting. */
-  firstName: string
-  /** Host ecclesia public name, e.g. "Toronto East Christadelphians". */
+  /** Exhorter's full name for the formal "Dear Brother {name}" greeting. */
+  exhorterName: string
+  /** Host ecclesia SHORT name, e.g. "Toronto East" (Christadelphians trimmed). */
   hostEcclesiaName: string
+  /** Full street address of the meeting hall, e.g. "975 Cosburn Ave., …". */
+  address?: string
   /** Pre-formatted date, e.g. "Sunday, February 1, 2026". */
   dateDisplay: string
   /** Pre-formatted time, e.g. "11:00am". */
   timeDisplay: string
-  /** True when the speaker is visiting (non-member / different ecclesia). */
-  visiting: boolean
-  /** Ways to attend — from the per-occurrence override, else the default Zoom. */
+  /**
+   * Ways to attend online — from the per-occurrence override, else the host's
+   * default meeting. Shown "just in case" the exhorter can't attend in person;
+   * omitted entirely when empty (no digital option for this meeting).
+   */
   attendOptions: ExhorterHeadsUpAttendOption[]
+  /** Fellowship lunch style for this occasion, or undefined for no lunch line. */
+  lunchType?: ExhorterHeadsUpLunch
+  /** Recording Brother's full name for the signature (host ecclesia). */
+  signatoryName?: string
   /** Real (resolved) Email Preferences URL for this recipient. */
   emailPreferencesUrl: string
   /** Echad Hub URL for the footer "powered by" line. */
@@ -71,6 +87,19 @@ export interface ExhorterHeadsUpProps {
 }
 
 const ECHAD_HUB_URL = 'https://echadhub.org'
+
+function lunchSentence(lunchType?: ExhorterHeadsUpLunch): string | null {
+  switch (lunchType) {
+    case 'potluck':
+      return "You're warmly invited to stay for a potluck fellowship lunch at the hall following the Memorial Service."
+    case 'provided':
+      return "You're warmly invited to stay for lunch and fellowship following the Memorial Service — lunch will be provided."
+    case 'generic':
+      return "You're warmly invited to stay for lunch and fellowship following the Memorial Service."
+    default:
+      return null
+  }
+}
 
 const AttendOptionBlock = ({ option }: { option: ExhorterHeadsUpAttendOption }) => {
   return (
@@ -97,24 +126,29 @@ const AttendOptionBlock = ({ option }: { option: ExhorterHeadsUpAttendOption }) 
 }
 
 const ExhorterHeadsUp: React.FC<ExhorterHeadsUpProps> = ({
-  firstName,
+  exhorterName,
   hostEcclesiaName,
+  address,
   dateDisplay,
   timeDisplay,
-  visiting,
   attendOptions,
+  lunchType,
+  signatoryName,
   emailPreferencesUrl,
   echadHubUrl = ECHAD_HUB_URL,
   identity,
 }) => {
-  const greetingName = firstName?.trim() ? firstName.trim() : 'Brother'
+  const trimmedName = exhorterName?.trim() ?? ''
+  const greeting = trimmedName ? `Dear Brother ${trimmedName},` : 'Dear Brother,'
+  const lunchLine = lunchSentence(lunchType)
+  const hasDigital = attendOptions.length > 0
 
   return (
     <Html lang="en">
       <Head>
         <style>{globalCss}</style>
       </Head>
-      <Preview>{`You're scheduled to exhort at ${hostEcclesiaName} on ${dateDisplay}.`}</Preview>
+      <Preview>{`We're looking forward to your exhortation at ${hostEcclesiaName} on ${dateDisplay}.`}</Preview>
       <Body style={main}>
         <Section style={header}>
           <Heading>{hostEcclesiaName}</Heading>
@@ -123,39 +157,64 @@ const ExhorterHeadsUp: React.FC<ExhorterHeadsUpProps> = ({
         </Section>
 
         <Container style={{ ...container, marginTop: '24px' }} className="container">
-          <Text style={defaultText}>{`Dear ${greetingName},`}</Text>
+          <Text style={defaultText}>{greeting}</Text>
           <Text style={defaultText}>
-            {`You're scheduled to give the exhortation at ${hostEcclesiaName} on `}
+            {`We're looking forward to your exhortation at ${hostEcclesiaName} on `}
             <strong>{dateDisplay}</strong>
             {' at '}
             <strong>{timeDisplay}</strong>
-            {'. Thank you for serving — we look forward to hearing from you.'}
+            {'.'}
           </Text>
-
-          {visiting ? (
-            <Text style={defaultText}>
-              <strong>Lunch is provided — please plan to stay and share it with us.</strong>
-            </Text>
-          ) : null}
         </Container>
 
         <Container style={container} className="container">
           <Heading style={defaultText}>Ways to attend</Heading>
-          <Text style={defaultText}>
-            For any who cannot be with us in person, here are the ways to join:
+          <Text style={{ ...defaultText, margin: '0 0 4px 0' }}>
+            <strong>In person:</strong>
           </Text>
-          {attendOptions.length > 0 ? (
-            attendOptions.map((option, i) => <AttendOptionBlock key={i} option={option} />)
-          ) : (
-            <Text style={defaultText}>Attendance details will follow.</Text>
-          )}
+          {address ? (
+            <Text style={{ ...defaultText, margin: '0 0 12px 0' }}>{`We're located at: ${address}`}</Text>
+          ) : null}
+          {hasDigital ? (
+            <>
+              <Text style={defaultText}>If you can&apos;t be with us in person, please join:</Text>
+              {attendOptions.map((option, i) => (
+                <AttendOptionBlock key={i} option={option} />
+              ))}
+            </>
+          ) : null}
         </Container>
 
         <Container style={container} className="container">
-          <Heading style={defaultText}>What to expect</Heading>
+          <Heading style={defaultText}>What&apos;s next</Heading>
           <Text style={defaultText}>
             The week of your exhortation, we&apos;ll send a follow-up email to request your theme,
             readings, and hymn preferences so we can prepare the service with you.
+          </Text>
+        </Container>
+
+        {lunchLine ? (
+          <Container style={container} className="container">
+            <Text style={defaultText}>{lunchLine}</Text>
+          </Container>
+        ) : null}
+
+        <Container style={container} className="container">
+          <Text style={defaultText}>
+            In the event you&apos;re unable to join us, please reply to this email and let us know at
+            your earliest convenience.
+          </Text>
+          <Text style={{ ...defaultText, margin: '16px 0 0 0' }}>With love in the LORD,</Text>
+          <Text style={{ ...defaultText, margin: '0' }}>
+            {signatoryName?.trim() ? (
+              <>
+                <strong>{`Brother ${signatoryName.trim()}`}</strong>
+                <br />
+                Ecclesial Recorder
+              </>
+            ) : (
+              'The Ecclesial Recorder'
+            )}
           </Text>
         </Container>
 

--- a/apps/email-builder/emails/ExhorterHeadsUp.tsx
+++ b/apps/email-builder/emails/ExhorterHeadsUp.tsx
@@ -201,8 +201,8 @@ const ExhorterHeadsUp: React.FC<ExhorterHeadsUpProps> = ({
 
         <Container style={container} className="container">
           <Text style={defaultText}>
-            In the event you&apos;re unable to join us, please reply to this email and let us know at
-            your earliest convenience.
+            If for any reason you&apos;re unable to be with us, please reply to this email to let us
+            know as soon as you can.
           </Text>
           <Text style={{ ...defaultText, margin: '16px 0 0 0' }}>With love in the LORD,</Text>
           <Text style={{ ...defaultText, margin: '0' }}>

--- a/apps/email-builder/emails/ExhorterHeadsUp.tsx
+++ b/apps/email-builder/emails/ExhorterHeadsUp.tsx
@@ -1,0 +1,197 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components'
+import React from 'react'
+import {
+  container,
+  defaultText,
+  footer,
+  footerLink,
+  footerText,
+  globalCss,
+  header,
+  link,
+  main,
+} from '../styles'
+import type { EmailIdentity } from '@my/app/types/brand-profile'
+import { EmailBrandLinkContent } from '../components/EmailBrandLinkContent'
+
+/**
+ * Exhorter heads-up email (#124, slice A). A warm 1:1 reminder to whoever is
+ * scheduled to give the exhortation at an upcoming memorial — reaching visiting
+ * speakers across ecclesias via their resolved directory email.
+ *
+ * SERVER-SAFE: identity is a plain PROP (no EmailIdentityProvider context /
+ * `'use client'` import), so this renders from an App Router server route. This
+ * email is sent 1:1 via `sendEmail()` which does NOT do per-recipient token
+ * substitution (that lives in the bulk `emailSend` path) — so the footer here
+ * builds a REAL Email Preferences URL passed in as a prop, and does NOT use the
+ * shared `FooterContent`'s `{{emailPreferencesUrl}}` token (which would ship as
+ * a literal placeholder here). The shared FooterContent is intentionally left
+ * untouched.
+ */
+
+/** One "way to attend" the memorial (Zoom / stream / in-person online meeting). */
+export interface ExhorterHeadsUpAttendOption {
+  label: string
+  url?: string
+  meetingId?: string
+  password?: string
+  platform?: string
+  dialInNumber?: string
+}
+
+export interface ExhorterHeadsUpProps {
+  /** Exhorter's first name for the greeting. */
+  firstName: string
+  /** Host ecclesia public name, e.g. "Toronto East Christadelphians". */
+  hostEcclesiaName: string
+  /** Pre-formatted date, e.g. "Sunday, February 1, 2026". */
+  dateDisplay: string
+  /** Pre-formatted time, e.g. "11:00am". */
+  timeDisplay: string
+  /** True when the speaker is visiting (non-member / different ecclesia). */
+  visiting: boolean
+  /** Ways to attend — from the per-occurrence override, else the default Zoom. */
+  attendOptions: ExhorterHeadsUpAttendOption[]
+  /** Real (resolved) Email Preferences URL for this recipient. */
+  emailPreferencesUrl: string
+  /** Echad Hub URL for the footer "powered by" line. */
+  echadHubUrl?: string
+  /** Brand identity for the header/footer address — passed as a prop. */
+  identity?: EmailIdentity
+}
+
+const ECHAD_HUB_URL = 'https://echadhub.org'
+
+const AttendOptionBlock = ({ option }: { option: ExhorterHeadsUpAttendOption }) => {
+  return (
+    <Section style={{ marginBottom: '12px' }}>
+      <Text style={{ ...defaultText, fontWeight: 'bold', margin: '0 0 4px 0' }}>{option.label}</Text>
+      {option.url ? (
+        <Text style={{ ...defaultText, margin: '0 0 4px 0' }}>
+          <Link href={option.url} style={link}>
+            Click to join
+          </Link>
+        </Text>
+      ) : null}
+      {option.meetingId ? (
+        <Text style={{ ...defaultText, margin: '0' }}>{`Meeting ID: ${option.meetingId}`}</Text>
+      ) : null}
+      {option.password ? (
+        <Text style={{ ...defaultText, margin: '0' }}>{`Password: ${option.password}`}</Text>
+      ) : null}
+      {option.dialInNumber ? (
+        <Text style={{ ...defaultText, margin: '0' }}>{`Join by phone: ${option.dialInNumber}`}</Text>
+      ) : null}
+    </Section>
+  )
+}
+
+const ExhorterHeadsUp: React.FC<ExhorterHeadsUpProps> = ({
+  firstName,
+  hostEcclesiaName,
+  dateDisplay,
+  timeDisplay,
+  visiting,
+  attendOptions,
+  emailPreferencesUrl,
+  echadHubUrl = ECHAD_HUB_URL,
+  identity,
+}) => {
+  const greetingName = firstName?.trim() ? firstName.trim() : 'Brother'
+
+  return (
+    <Html lang="en">
+      <Head>
+        <style>{globalCss}</style>
+      </Head>
+      <Preview>{`You're scheduled to exhort at ${hostEcclesiaName} on ${dateDisplay}.`}</Preview>
+      <Body style={main}>
+        <Section style={header}>
+          <Heading>{hostEcclesiaName}</Heading>
+          <Text style={defaultText}>A note about your upcoming exhortation</Text>
+          <EmailBrandLinkContent identity={identity} />
+        </Section>
+
+        <Container style={{ ...container, marginTop: '24px' }} className="container">
+          <Text style={defaultText}>{`Dear ${greetingName},`}</Text>
+          <Text style={defaultText}>
+            {`You're scheduled to give the exhortation at ${hostEcclesiaName} on `}
+            <strong>{dateDisplay}</strong>
+            {' at '}
+            <strong>{timeDisplay}</strong>
+            {'. Thank you for serving — we look forward to hearing from you.'}
+          </Text>
+
+          {visiting ? (
+            <Text style={defaultText}>
+              <strong>Lunch is provided — please plan to stay and share it with us.</strong>
+            </Text>
+          ) : null}
+        </Container>
+
+        <Container style={container} className="container">
+          <Heading style={defaultText}>Ways to attend</Heading>
+          <Text style={defaultText}>
+            For any who cannot be with us in person, here are the ways to join:
+          </Text>
+          {attendOptions.length > 0 ? (
+            attendOptions.map((option, i) => <AttendOptionBlock key={i} option={option} />)
+          ) : (
+            <Text style={defaultText}>Attendance details will follow.</Text>
+          )}
+        </Container>
+
+        <Container style={container} className="container">
+          <Heading style={defaultText}>What to expect</Heading>
+          <Text style={defaultText}>
+            The week of your exhortation, we&apos;ll send a follow-up email to request your theme,
+            readings, and hymn preferences so we can prepare the service with you.
+          </Text>
+        </Container>
+
+        {/* Custom, email-scoped footer. Deliberately NOT the shared FooterContent:
+            this 1:1 send does no {{emailPreferencesUrl}} token substitution, so we
+            render a REAL preferences link here instead. */}
+        <Section style={footer}>
+          <Text style={footerText}>
+            {'TEE-Admin — powered by '}
+            <Link href={echadHubUrl} style={footerLink}>
+              Echad Hub
+            </Link>
+            {', and Christadelphian Initiative'}
+          </Text>
+          <Text style={footerText}>
+            <Link href={emailPreferencesUrl} style={footerLink}>
+              Email Preferences
+            </Link>
+          </Text>
+          {identity?.name ? (
+            <Text style={footerText}>
+              <strong>Our address is:</strong>
+              <br />
+              {identity.name}
+              {(identity.addressLines ?? []).map((lineText, i) => (
+                <React.Fragment key={i}>
+                  <br />
+                  {lineText}
+                </React.Fragment>
+              ))}
+            </Text>
+          ) : null}
+        </Section>
+      </Body>
+    </Html>
+  )
+}
+
+export default ExhorterHeadsUp

--- a/apps/next/app/api/admin/exhorter-heads-up/route.ts
+++ b/apps/next/app/api/admin/exhorter-heads-up/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+import {
+  resolveAndSendExhorterHeadsUp,
+  computeNextTargetSunday,
+} from '@/utils/email/exhorter-heads-up'
+
+/**
+ * Exhorter heads-up — manual admin trigger (#124, slice A).
+ *
+ * POST { date?, test?, dryRun? }
+ *   - `test` DEFAULTS TRUE. Test mode NEVER emails the real exhorter — it sends to
+ *     the requesting admin so the whole flow can be verified safely.
+ *   - `date` omitted → the next target Sunday (~2 weeks out) is computed; STILL
+ *     defaults to test.
+ *   - `dryRun` resolves + reports without sending.
+ *
+ * NO cron / auto-send here — that is slice B.
+ *
+ * TODO(multi-tenant, #124): gates on the GLOBAL admin/owner role. When multi-tenant
+ * lands, authorize against the caller's managedRegions for the host ecclesia.
+ */
+
+async function requireAdmin() {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const role = ((session.user as any).role as string) || ROLES.GUEST
+  if (role !== ROLES.ADMIN && role !== ROLES.OWNER) {
+    return { error: NextResponse.json({ error: 'Admin access required' }, { status: 403 }) }
+  }
+  return { email: session.user.email }
+}
+
+export async function POST(request: NextRequest) {
+  const gate = await requireAdmin()
+  if (gate.error) return gate.error
+
+  try {
+    const body = await request.json().catch(() => ({}))
+    const date: string = typeof body?.date === 'string' && body.date.trim()
+      ? body.date.trim()
+      : computeNextTargetSunday()
+    // SAFE DEFAULT: test is true unless explicitly set to boolean false.
+    const test: boolean = body?.test === false ? false : true
+    const dryRun: boolean = body?.dryRun === true
+
+    const report = await resolveAndSendExhorterHeadsUp({
+      date,
+      test,
+      dryRun,
+      requesterEmail: gate.email!,
+    })
+
+    return NextResponse.json({ ok: true, report })
+  } catch (error) {
+    console.error('Error sending exhorter heads-up:', error)
+    return NextResponse.json({ error: 'Failed to send exhorter heads-up' }, { status: 500 })
+  }
+}

--- a/apps/next/tests/exhorter-heads-up-render.test.tsx
+++ b/apps/next/tests/exhorter-heads-up-render.test.tsx
@@ -8,15 +8,16 @@ import ExhorterHeadsUp, {
 /**
  * Server-side render check for the ExhorterHeadsUp template (#124, slice A).
  * Renders with a fixture and asserts it does not throw and the key strings
- * (date / host / time / zoom / conditional lunch / footer) appear.
+ * (greeting / short host name / date / time / address / zoom / conditional
+ * lunch / RB signature / footer) appear.
  */
 
 const baseProps: ExhorterHeadsUpProps = {
-  firstName: 'Brad',
-  hostEcclesiaName: 'Toronto East Christadelphians',
+  exhorterName: 'Brad Stephens',
+  hostEcclesiaName: 'Toronto East',
+  address: '975 Cosburn Ave., East York, ON M4C 2W8, Canada',
   dateDisplay: 'Sunday, February 1, 2026',
   timeDisplay: '11:00am',
-  visiting: false,
   attendOptions: [
     {
       label: 'Toronto East Zoom',
@@ -26,6 +27,7 @@ const baseProps: ExhorterHeadsUpProps = {
       dialInNumber: '+1 647 374 4685',
     },
   ],
+  signatoryName: 'Ken Easson',
   emailPreferencesUrl: 'https://tee-admin.com/email-preferences?token=abc',
   identity: {
     name: 'Toronto East Christadelphians',
@@ -40,14 +42,32 @@ async function renderHtml(props: ExhorterHeadsUpProps): Promise<string> {
 }
 
 describe('ExhorterHeadsUp template render', () => {
-  it('renders without throwing and includes date, host, time, zoom', async () => {
+  it('renders formal greeting, short host name, date, time, address, zoom', async () => {
     const html = await renderHtml(baseProps)
-    expect(html).toContain('Toronto East Christadelphians')
+    expect(html).toContain('Dear Brother Brad Stephens,')
+    expect(html).toContain('Toronto East')
+    expect(html).not.toContain('Christadelphians on') // short name in the body sentence
     expect(html).toContain('Sunday, February 1, 2026')
     expect(html).toContain('11:00am')
-    expect(html).toContain('Brad')
+    expect(html).toContain('In person')
+    expect(html).toContain('975 Cosburn Ave.')
     expect(html).toContain('Toronto East Zoom')
     expect(html).toContain('586 952 386')
+  })
+
+  it('signs off with the Recording Brother and "Ecclesial Recorder"', async () => {
+    const html = await renderHtml(baseProps)
+    expect(html).toContain('With love in the LORD')
+    expect(html).toContain('Brother Ken Easson')
+    expect(html).toContain('Ecclesial Recorder')
+  })
+
+  it('omits the digital block when there are no attend options', async () => {
+    const html = await renderHtml({ ...baseProps, attendOptions: [] })
+    expect(html).not.toContain('Toronto East Zoom')
+    expect(html).not.toContain("If you can't be with us in person")
+    // in-person address still shown
+    expect(html).toContain('975 Cosburn Ave.')
   })
 
   it('includes the follow-up "what to expect" (theme/readings/hymns) line', async () => {
@@ -57,12 +77,16 @@ describe('ExhorterHeadsUp template render', () => {
     expect(html).toContain('hymn')
   })
 
-  it('shows the lunch line ONLY when visiting', async () => {
-    const visitingHtml = await renderHtml({ ...baseProps, visiting: true })
-    expect(visitingHtml).toContain('Lunch is provided')
+  it('renders the lunch line per lunchType, and omits it when undefined', async () => {
+    const potluck = await renderHtml({ ...baseProps, lunchType: 'potluck' })
+    expect(potluck).toContain('potluck fellowship lunch')
 
-    const memberHtml = await renderHtml({ ...baseProps, visiting: false })
-    expect(memberHtml).not.toContain('Lunch is provided')
+    const provided = await renderHtml({ ...baseProps, lunchType: 'provided' })
+    expect(provided).toContain('lunch will be provided')
+
+    const none = await renderHtml({ ...baseProps, lunchType: undefined })
+    expect(none).not.toContain('fellowship lunch')
+    expect(none).not.toContain('lunch will be provided')
   })
 
   it('footer: powered-by Echad Hub link and Email Preferences link', async () => {

--- a/apps/next/tests/exhorter-heads-up-render.test.tsx
+++ b/apps/next/tests/exhorter-heads-up-render.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@react-email/render'
+import React from 'react'
+import ExhorterHeadsUp, {
+  type ExhorterHeadsUpProps,
+} from '../../email-builder/emails/ExhorterHeadsUp'
+
+/**
+ * Server-side render check for the ExhorterHeadsUp template (#124, slice A).
+ * Renders with a fixture and asserts it does not throw and the key strings
+ * (date / host / time / zoom / conditional lunch / footer) appear.
+ */
+
+const baseProps: ExhorterHeadsUpProps = {
+  firstName: 'Brad',
+  hostEcclesiaName: 'Toronto East Christadelphians',
+  dateDisplay: 'Sunday, February 1, 2026',
+  timeDisplay: '11:00am',
+  visiting: false,
+  attendOptions: [
+    {
+      label: 'Toronto East Zoom',
+      url: 'https://us04web.zoom.us/j/586952386',
+      meetingId: '586 952 386',
+      password: '036110',
+      dialInNumber: '+1 647 374 4685',
+    },
+  ],
+  emailPreferencesUrl: 'https://tee-admin.com/email-preferences?token=abc',
+  identity: {
+    name: 'Toronto East Christadelphians',
+    addressLines: ['975 Cosburn Avenue', 'Toronto, On M4C 2W8', 'Canada'],
+    homeUrl: 'https://tee-admin.com',
+    homeLabel: 'Toronto East Christadelphians',
+  },
+}
+
+async function renderHtml(props: ExhorterHeadsUpProps): Promise<string> {
+  return render(<ExhorterHeadsUp {...props} />)
+}
+
+describe('ExhorterHeadsUp template render', () => {
+  it('renders without throwing and includes date, host, time, zoom', async () => {
+    const html = await renderHtml(baseProps)
+    expect(html).toContain('Toronto East Christadelphians')
+    expect(html).toContain('Sunday, February 1, 2026')
+    expect(html).toContain('11:00am')
+    expect(html).toContain('Brad')
+    expect(html).toContain('Toronto East Zoom')
+    expect(html).toContain('586 952 386')
+  })
+
+  it('includes the follow-up "what to expect" (theme/readings/hymns) line', async () => {
+    const html = await renderHtml(baseProps)
+    expect(html).toContain('theme')
+    expect(html).toContain('readings')
+    expect(html).toContain('hymn')
+  })
+
+  it('shows the lunch line ONLY when visiting', async () => {
+    const visitingHtml = await renderHtml({ ...baseProps, visiting: true })
+    expect(visitingHtml).toContain('Lunch is provided')
+
+    const memberHtml = await renderHtml({ ...baseProps, visiting: false })
+    expect(memberHtml).not.toContain('Lunch is provided')
+  })
+
+  it('footer: powered-by Echad Hub link and Email Preferences link', async () => {
+    const html = await renderHtml(baseProps)
+    expect(html).toContain('powered by')
+    expect(html).toContain('Echad Hub')
+    expect(html).toContain('https://echadhub.org')
+    expect(html).toContain('Email Preferences')
+    expect(html).toContain('https://tee-admin.com/email-preferences?token=abc')
+  })
+
+  it('does not ship an unsubstituted {{token}} placeholder', async () => {
+    const html = await renderHtml(baseProps)
+    expect(html).not.toContain('{{')
+  })
+})

--- a/apps/next/tests/exhorter-heads-up-service.test.ts
+++ b/apps/next/tests/exhorter-heads-up-service.test.ts
@@ -313,6 +313,42 @@ describe('resolveAndSendExhorterHeadsUp — idempotency (LIVE only)', () => {
   })
 })
 
+describe('resolveAndSendExhorterHeadsUp — date-only row (no DateTime)', () => {
+  it('renders a valid date from a non-ISO Date with no DateTime (regression)', async () => {
+    // Prod memorial rows can carry only a sheet-style `Date` ("August 9, 2026")
+    // and NO `DateTime`. The date-only formatter's parseDateOnly() splits on '-',
+    // so a non-dash value there rendered a literal "Invalid Date" in the body and
+    // subject. The service must feed the normalized ISO date instead.
+    h.getScheduleData.mockResolvedValue({
+      content: [
+        {
+          Date: 'August 9, 2026', // non-dash, sheet-style
+          // no DateTime
+          ServiceTimezone: 'America/Toronto',
+          Exhort: 'Brad Stephens',
+          Preside: 'Someone Else',
+          Key: 'memorial',
+        },
+      ],
+    })
+
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: '2026-08-09',
+      test: true,
+      requesterEmail: REQUESTER,
+    })
+
+    expect(report.status).toBe('sent')
+    const rendered = h.renderExhorterHeadsUp.mock.calls[0][0]
+    expect(rendered.dateDisplay).not.toContain('Invalid')
+    expect(rendered.dateDisplay).toContain('August')
+    expect(rendered.dateDisplay).toContain('2026')
+    // The subject interpolates the same value — it must not leak "Invalid Date".
+    expect(h.sendEmail.mock.calls[0][0].subject).not.toContain('Invalid Date')
+    expect(h.sendEmail.mock.calls[0][0].subject).toContain('August 9, 2026')
+  })
+})
+
 describe('resolveAndSendExhorterHeadsUp — dryRun', () => {
   it('resolves + reports without sending or claiming', async () => {
     const report = await resolveAndSendExhorterHeadsUp({

--- a/apps/next/tests/exhorter-heads-up-service.test.ts
+++ b/apps/next/tests/exhorter-heads-up-service.test.ts
@@ -1,0 +1,329 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import type { PersonRecord } from '@my/app/provider/dynamodb/types'
+
+/**
+ * Guard / resolve matrix for resolveAndSendExhorterHeadsUp (#124, slice A).
+ *
+ * All I/O is mocked (schedule read, directory, render, send, idempotency,
+ * preferences URL) so this exercises the decision logic hermetically. The real
+ * pure helpers (name resolver, home-ecclesia, timezone) run unmocked.
+ */
+
+const h = vi.hoisted(() => ({
+  getScheduleData: vi.fn(),
+  listAll: vi.fn(),
+  getById: vi.fn(),
+  sendEmail: vi.fn(),
+  renderExhorterHeadsUp: vi.fn(),
+  claim: vi.fn(),
+  release: vi.fn(),
+  generateEmailPreferencesUrl: vi.fn(),
+  fetchServiceOverrides: vi.fn(),
+}))
+
+vi.mock('@my/app/provider/dynamodb/schedule-service', () => ({
+  ScheduleService: vi.fn().mockImplementation(() => ({ getScheduleData: h.getScheduleData })),
+}))
+vi.mock('@my/app/provider/dynamodb/repositories/person-repository', () => ({
+  personRepository: { listAll: h.listAll, getById: h.getById },
+}))
+vi.mock('../utils/email/sesClient', () => ({ sendEmail: h.sendEmail }))
+vi.mock('../utils/email/exhorter-heads-up-render', () => ({
+  renderExhorterHeadsUp: h.renderExhorterHeadsUp,
+}))
+vi.mock('../utils/email/ecclesia-token', () => ({
+  generateEmailPreferencesUrl: h.generateEmailPreferencesUrl,
+}))
+vi.mock('@my/app/provider/dynamodb/repositories/exhorter-headsup-repository', () => ({
+  exhorterHeadsUpRepository: { claim: h.claim, release: h.release },
+}))
+vi.mock('@my/app/utils/service-overrides/merge', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@my/app/utils/service-overrides/merge')>()
+  return { ...actual, fetchServiceOverrides: h.fetchServiceOverrides }
+})
+
+import { resolveAndSendExhorterHeadsUp } from '../utils/email/exhorter-heads-up'
+
+const TARGET_DATE = '2026-02-01' // a Sunday
+const REQUESTER = 'admin@tee-admin.com'
+
+function personRecord(
+  over: Partial<PersonRecord> &
+    Pick<PersonRecord, 'personId' | 'firstName' | 'lastName' | 'ecclesia'>
+): PersonRecord {
+  const { personId, firstName, lastName, ecclesia } = over
+  return {
+    pkey: `PERSON#${personId}`,
+    skey: 'PROFILE',
+    gsi1pk: `EMAIL#${firstName}.${lastName}@example.com`.toLowerCase(),
+    gsi1sk: 'PERSON',
+    gsi2pk: `ECCLESIA#${ecclesia}`,
+    gsi2sk: `${lastName}#${firstName}#${personId}`.toLowerCase(),
+    gsi3pk: `NAME#${lastName}`.toLowerCase(),
+    gsi3sk: `${firstName}#${personId}`.toLowerCase(),
+    primaryEmail: `${firstName}.${lastName}@example.com`.toLowerCase(),
+    displayName: `${firstName} ${lastName}`,
+    memberStatus: 'member' as PersonRecord['memberStatus'],
+    ...over,
+  } as PersonRecord
+}
+
+const BRAD = personRecord({
+  personId: 'p-brad',
+  firstName: 'Brad',
+  lastName: 'Stephens',
+  ecclesia: 'Toronto East Ecclesia',
+  primaryEmail: 'brad@example.com',
+})
+
+function memorialSchedule(exhort: string) {
+  return {
+    content: [
+      {
+        Date: 'Feb 1, 2026',
+        DateTime: '2026-02-01T16:00:00.000Z',
+        ServiceTimezone: 'America/Toronto',
+        Exhort: exhort,
+        Preside: 'Someone Else',
+        Key: 'memorial',
+      },
+    ],
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getScheduleData.mockResolvedValue(memorialSchedule('Brad Stephens'))
+  h.listAll.mockResolvedValue({ items: [BRAD], lastEvaluatedKey: undefined })
+  h.getById.mockResolvedValue(BRAD)
+  h.renderExhorterHeadsUp.mockResolvedValue({ html: '<html></html>', text: 'text' })
+  h.sendEmail.mockResolvedValue(undefined)
+  h.claim.mockResolvedValue(true)
+  h.generateEmailPreferencesUrl.mockResolvedValue('https://tee-admin.com/email-preferences?token=x')
+  h.fetchServiceOverrides.mockResolvedValue(new Map())
+})
+
+describe('resolveAndSendExhorterHeadsUp — matched', () => {
+  it('LIVE sends to the real exhorter primaryEmail', async () => {
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: false,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.status).toBe('sent')
+    expect(report.sentTo).toBe('brad@example.com')
+    expect(report.personId).toBe('p-brad')
+    expect(report.visiting).toBe(false)
+    expect(h.sendEmail).toHaveBeenCalledTimes(1)
+    const arg = h.sendEmail.mock.calls[0][0]
+    expect(arg.to).toBe('brad@example.com')
+    expect(arg.from).toContain('communications@tee-admin.com')
+    expect(arg.replyTo).toBe('teerecbro@gmail.com')
+  })
+
+  it('TEST sends to the requester, NEVER the exhorter; no idempotency write', async () => {
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: true,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.status).toBe('sent')
+    expect(report.sentTo).toBe(REQUESTER)
+    expect(h.sendEmail).toHaveBeenCalledTimes(1)
+    expect(h.sendEmail.mock.calls[0][0].to).toBe(REQUESTER)
+    expect(h.sendEmail.mock.calls[0][0].to).not.toBe('brad@example.com')
+    expect(h.claim).not.toHaveBeenCalled()
+  })
+
+  it('defaults to TEST mode when test is omitted', async () => {
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.test).toBe(true)
+    expect(report.sentTo).toBe(REQUESTER)
+    expect(h.claim).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveAndSendExhorterHeadsUp — guards (no send)', () => {
+  it('placeholder Exhort → skipped:placeholder', async () => {
+    h.getScheduleData.mockResolvedValue(memorialSchedule('TBD'))
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: false,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.status).toBe('skipped:placeholder')
+    expect(h.sendEmail).not.toHaveBeenCalled()
+  })
+
+  it('unresolved name → unresolved (reported, not sent)', async () => {
+    h.getScheduleData.mockResolvedValue(memorialSchedule('Zxqwv Nomatch'))
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: false,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.status).toBe('unresolved')
+    expect(report.matchStatus).toBe('not-found')
+    expect(h.sendEmail).not.toHaveBeenCalled()
+  })
+
+  it('matched but empty primaryEmail → skipped:no-email', async () => {
+    h.getById.mockResolvedValue(
+      personRecord({
+        personId: 'p-brad',
+        firstName: 'Brad',
+        lastName: 'Stephens',
+        ecclesia: 'Toronto East Ecclesia',
+        primaryEmail: '',
+      })
+    )
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: false,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.status).toBe('skipped:no-email')
+    expect(h.sendEmail).not.toHaveBeenCalled()
+  })
+
+  it('no schedule row for the date → no-schedule-row', async () => {
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: '2026-03-15',
+      test: false,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.status).toBe('no-schedule-row')
+    expect(h.sendEmail).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveAndSendExhorterHeadsUp — visiting flag', () => {
+  it('non-home ecclesia member → visiting true', async () => {
+    h.getById.mockResolvedValue(
+      personRecord({
+        personId: 'p-brad',
+        firstName: 'Brad',
+        lastName: 'Stephens',
+        ecclesia: 'Hamilton Book Road',
+        primaryEmail: 'brad@example.com',
+      })
+    )
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: true,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.visiting).toBe(true)
+  })
+
+  it('memberStatus visitor → visiting true', async () => {
+    h.getById.mockResolvedValue(
+      personRecord({
+        personId: 'p-brad',
+        firstName: 'Brad',
+        lastName: 'Stephens',
+        ecclesia: 'Toronto East Ecclesia',
+        primaryEmail: 'brad@example.com',
+        memberStatus: 'visitor' as PersonRecord['memberStatus'],
+      })
+    )
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: true,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.visiting).toBe(true)
+  })
+
+  it('home-ecclesia member → visiting false', async () => {
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: true,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.visiting).toBe(false)
+  })
+})
+
+describe('resolveAndSendExhorterHeadsUp — zoom source', () => {
+  it('uses the default Zoom when no override', async () => {
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: true,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.zoomSource).toBe('default')
+    const attend = h.renderExhorterHeadsUp.mock.calls[0][0].attendOptions
+    expect(attend[0].label).toBe('Toronto East Zoom')
+  })
+
+  it('uses override attendOptions when present', async () => {
+    h.fetchServiceOverrides.mockResolvedValue(
+      new Map([
+        [
+          'memorial#2026-02-01',
+          {
+            serviceType: 'memorial',
+            date: '2026-02-01',
+            attendOptions: [{ id: 'a1', label: 'Toronto West Stream', mode: 'stream', url: 'https://tw' }],
+          },
+        ],
+      ])
+    )
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: true,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.zoomSource).toBe('override')
+    const attend = h.renderExhorterHeadsUp.mock.calls[0][0].attendOptions
+    expect(attend[0].label).toBe('Toronto West Stream')
+  })
+})
+
+describe('resolveAndSendExhorterHeadsUp — idempotency (LIVE only)', () => {
+  it('second live call is skipped:already-sent when claim fails', async () => {
+    h.claim.mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+
+    const first = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: false,
+      requesterEmail: REQUESTER,
+    })
+    const second = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: false,
+      requesterEmail: REQUESTER,
+    })
+
+    expect(first.status).toBe('sent')
+    expect(second.status).toBe('skipped:already-sent')
+    expect(h.sendEmail).toHaveBeenCalledTimes(1) // second never sent
+  })
+
+  it('releases the claim when the send throws (live)', async () => {
+    h.sendEmail.mockRejectedValueOnce(new Error('SES down'))
+    await expect(
+      resolveAndSendExhorterHeadsUp({ date: TARGET_DATE, test: false, requesterEmail: REQUESTER })
+    ).rejects.toThrow('SES down')
+    expect(h.release).toHaveBeenCalledWith('2026-02-01', 'p-brad')
+  })
+})
+
+describe('resolveAndSendExhorterHeadsUp — dryRun', () => {
+  it('resolves + reports without sending or claiming', async () => {
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: false,
+      dryRun: true,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.status).toBe('dry-run')
+    expect(report.personId).toBe('p-brad')
+    expect(h.sendEmail).not.toHaveBeenCalled()
+    expect(h.claim).not.toHaveBeenCalled()
+  })
+})

--- a/apps/next/tests/exhorter-heads-up-service.test.ts
+++ b/apps/next/tests/exhorter-heads-up-service.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 import type { PersonRecord } from '@my/app/provider/dynamodb/types'
 
 /**
@@ -112,6 +112,10 @@ function memorialRow(extra: Record<string, any> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Fix the clock BEFORE the target dates so tests aren't tripped by the
+  // past-date guard (and stay stable in CI as real time marches on).
+  vi.useFakeTimers({ toFake: ['Date'] })
+  vi.setSystemTime(new Date('2026-01-15T12:00:00Z'))
   h.getScheduleData.mockResolvedValue(memorialSchedule('Brad Stephens'))
   h.listAll.mockResolvedValue({ items: [BRAD], lastEvaluatedKey: undefined })
   h.getById.mockResolvedValue(BRAD)
@@ -131,6 +135,10 @@ beforeEach(() => {
     createdAt: new Date(0),
     updatedAt: new Date(0),
   })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
 })
 
 describe('resolveAndSendExhorterHeadsUp — matched', () => {
@@ -217,6 +225,19 @@ describe('resolveAndSendExhorterHeadsUp — guards (no send)', () => {
     })
     expect(report.status).toBe('skipped:no-email')
     expect(h.sendEmail).not.toHaveBeenCalled()
+  })
+
+  it('a date already in the past → skipped:past-date, never sends', async () => {
+    // Clock is fixed at 2026-01-15; this Sunday is before it.
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: '2026-01-04',
+      test: false,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.status).toBe('skipped:past-date')
+    expect(h.getScheduleData).not.toHaveBeenCalled() // guarded before any lookup
+    expect(h.sendEmail).not.toHaveBeenCalled()
+    expect(h.claim).not.toHaveBeenCalled()
   })
 
   it('no schedule row for the date → no-schedule-row', async () => {

--- a/apps/next/tests/exhorter-heads-up-service.test.ts
+++ b/apps/next/tests/exhorter-heads-up-service.test.ts
@@ -19,6 +19,7 @@ const h = vi.hoisted(() => ({
   release: vi.fn(),
   generateEmailPreferencesUrl: vi.fn(),
   fetchServiceOverrides: vi.fn(),
+  getEcclesiaByName: vi.fn(),
 }))
 
 vi.mock('@my/app/provider/dynamodb/schedule-service', () => ({
@@ -41,6 +42,7 @@ vi.mock('@my/app/utils/service-overrides/merge', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@my/app/utils/service-overrides/merge')>()
   return { ...actual, fetchServiceOverrides: h.fetchServiceOverrides }
 })
+vi.mock('../utils/dynamodb/locations', () => ({ getEcclesiaByName: h.getEcclesiaByName }))
 
 import { resolveAndSendExhorterHeadsUp } from '../utils/email/exhorter-heads-up'
 
@@ -91,6 +93,23 @@ function memorialSchedule(exhort: string) {
   }
 }
 
+/** A memorial row with arbitrary extra/overridden columns (Lunch, Activities…). */
+function memorialRow(extra: Record<string, any> = {}) {
+  return {
+    content: [
+      {
+        Date: 'Feb 1, 2026',
+        DateTime: '2026-02-01T16:00:00.000Z',
+        ServiceTimezone: 'America/Toronto',
+        Exhort: 'Brad Stephens',
+        Preside: 'Someone Else',
+        Key: 'memorial',
+        ...extra,
+      },
+    ],
+  }
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   h.getScheduleData.mockResolvedValue(memorialSchedule('Brad Stephens'))
@@ -101,6 +120,17 @@ beforeEach(() => {
   h.claim.mockResolvedValue(true)
   h.generateEmailPreferencesUrl.mockResolvedValue('https://tee-admin.com/email-preferences?token=x')
   h.fetchServiceOverrides.mockResolvedValue(new Map())
+  h.getEcclesiaByName.mockResolvedValue({
+    name: 'Toronto East Ecclesia',
+    country: 'Canada',
+    province: 'ON',
+    city: 'Toronto',
+    address: '975 Cosburn Ave., East York, ON M4C 2W8, Canada',
+    recordingBrotherName: 'Ken Easson',
+    recordingBrotherEmail: 'teerecbro@gmail.com',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  })
 })
 
 describe('resolveAndSendExhorterHeadsUp — matched', () => {
@@ -281,6 +311,130 @@ describe('resolveAndSendExhorterHeadsUp — zoom source', () => {
     expect(report.zoomSource).toBe('override')
     const attend = h.renderExhorterHeadsUp.mock.calls[0][0].attendOptions
     expect(attend[0].label).toBe('Toronto West Stream')
+  })
+})
+
+describe('resolveAndSendExhorterHeadsUp — content from directory', () => {
+  it('uses short ecclesia name, formal full name, hall address, RB signature', async () => {
+    h.getEcclesiaByName.mockResolvedValue({
+      name: 'Toronto East Ecclesia',
+      country: 'Canada',
+      province: 'ON',
+      city: 'Toronto',
+      address: '975 Cosburn Ave., East York, ON M4C 2W8, Canada',
+      recordingBrotherName: 'Ken Easson',
+      recordingBrotherEmail: 'custom-rb@example.com', // prove it's record-driven
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    })
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: true,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.status).toBe('sent')
+    const props = h.renderExhorterHeadsUp.mock.calls[0][0]
+    expect(props.hostEcclesiaName).toBe('Toronto East') // "Christadelphians"/"Ecclesia" trimmed
+    expect(props.exhorterName).toBe('Brad Stephens') // formal full name, not first-name-only
+    expect(props.address).toContain('975 Cosburn')
+    expect(props.signatoryName).toBe('Ken Easson')
+    const sent = h.sendEmail.mock.calls[0][0]
+    expect(sent.subject).toContain('Toronto East')
+    expect(sent.subject).not.toContain('Christadelphians')
+    expect(sent.replyTo).toBe('custom-rb@example.com')
+  })
+
+  it('composes address from parts when no `address` field; falls back Reply-To', async () => {
+    h.getEcclesiaByName.mockResolvedValue({
+      name: 'Toronto East Ecclesia',
+      country: 'Canada',
+      province: 'ON',
+      city: 'Toronto',
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    })
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: true,
+      requesterEmail: REQUESTER,
+    })
+    const props = h.renderExhorterHeadsUp.mock.calls[0][0]
+    expect(props.address).toBe('Toronto, ON') // composed from city/province
+    expect(props.signatoryName).toBeUndefined() // no RB name on record
+    expect(h.sendEmail.mock.calls[0][0].replyTo).toBe('teerecbro@gmail.com') // constant fallback
+  })
+})
+
+describe('resolveAndSendExhorterHeadsUp — lunch line (from row.Lunch)', () => {
+  it.each([
+    ['Potluck lunch at the hall', 'potluck'],
+    ['Lunch will be provided', 'provided'],
+    ['Sunday School Lunch/Brunch after the memorial', 'generic'],
+  ])('Lunch=%j → lunchType %s', async (lunch, expected) => {
+    h.getScheduleData.mockResolvedValue(memorialRow({ Lunch: lunch }))
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: true,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.status).toBe('sent')
+    expect(h.renderExhorterHeadsUp.mock.calls[0][0].lunchType).toBe(expected)
+  })
+
+  it('no Lunch value → no lunch line', async () => {
+    await resolveAndSendExhorterHeadsUp({ date: TARGET_DATE, test: true, requesterEmail: REQUESTER })
+    expect(h.renderExhorterHeadsUp.mock.calls[0][0].lunchType).toBeUndefined()
+  })
+})
+
+describe('resolveAndSendExhorterHeadsUp — special-occasion guard (no send)', () => {
+  it.each([
+    [
+      'relocation in Activities, blank Exhort',
+      { Exhort: '', Activities: 'We will be joining Toronto West For the Baptism of Rebekah Persaud-Amos' },
+    ],
+    [
+      'cancelled-at-hall in Lunch, exhorter present (the dangerous case)',
+      { Exhort: 'Brad Stephens', Lunch: 'Activities at the Hall are Cancelled, Please join us on Zoom or YouTube.' },
+    ],
+    [
+      'fraternal gathering',
+      { Exhort: '', Lunch: 'Toronto Fraternal Gathering', Activities: 'Please join us at the Toronto Fraternal Gathering' },
+    ],
+  ])('%s → skipped:needs-review, never sends', async (_name, extra) => {
+    h.getScheduleData.mockResolvedValue(memorialRow(extra))
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: false,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.status).toBe('skipped:needs-review')
+    expect(report.note).toBeTruthy()
+    expect(h.sendEmail).not.toHaveBeenCalled()
+    expect(h.claim).not.toHaveBeenCalled()
+  })
+
+  it('a normal potluck day is NOT flagged (sends)', async () => {
+    h.getScheduleData.mockResolvedValue(memorialRow({ Lunch: 'Potluck lunch at the hall' }))
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: true,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.status).toBe('sent')
+  })
+
+  it('a study weekend with provided lunch is NOT flagged (sends, provided lunch)', async () => {
+    h.getScheduleData.mockResolvedValue(
+      memorialRow({ Lunch: 'Lunch will be provided', Activities: 'tee study weekend' })
+    )
+    const report = await resolveAndSendExhorterHeadsUp({
+      date: TARGET_DATE,
+      test: true,
+      requesterEmail: REQUESTER,
+    })
+    expect(report.status).toBe('sent')
+    expect(h.renderExhorterHeadsUp.mock.calls[0][0].lunchType).toBe('provided')
   })
 })
 

--- a/apps/next/utils/email/exhorter-heads-up-render.tsx
+++ b/apps/next/utils/email/exhorter-heads-up-render.tsx
@@ -1,0 +1,57 @@
+import { render } from '@react-email/render'
+import ExhorterHeadsUp, {
+  type ExhorterHeadsUpAttendOption,
+} from 'email-builder/emails/ExhorterHeadsUp'
+import { resolveTenantFromEnv, type TenantConfig } from '@my/app/config/tenants'
+import { emailIdentityFromProfile } from '@my/app/types/brand-profile'
+import { resolveBrandProfile } from './resolve-brand-profile'
+
+/**
+ * Server-safe render for the exhorter heads-up email (#124, slice A).
+ *
+ * Mirrors the `get-email-content.tsx` pattern: the tenant-scoped brand identity
+ * is injected as a PROP (never via the client EmailIdentityProvider context), so
+ * this renders from an App Router server route. Kept in its own module so the
+ * send service can be unit-tested with this render mocked.
+ */
+
+export interface RenderExhorterHeadsUpInput {
+  firstName: string
+  hostEcclesiaName: string
+  dateDisplay: string
+  timeDisplay: string
+  visiting: boolean
+  attendOptions: ExhorterHeadsUpAttendOption[]
+  emailPreferencesUrl: string
+  tenant?: TenantConfig
+}
+
+export async function renderExhorterHeadsUp(
+  input: RenderExhorterHeadsUpInput
+): Promise<{ html: string; text: string }> {
+  const tenant = input.tenant ?? resolveTenantFromEnv()
+  const emailIdentity = {
+    ...emailIdentityFromProfile(await resolveBrandProfile({ tenant })),
+    homeUrl: `https://${tenant.senderDomain}`,
+    homeLabel: tenant.publicName,
+  }
+
+  const element = (
+    <ExhorterHeadsUp
+      firstName={input.firstName}
+      hostEcclesiaName={input.hostEcclesiaName}
+      dateDisplay={input.dateDisplay}
+      timeDisplay={input.timeDisplay}
+      visiting={input.visiting}
+      attendOptions={input.attendOptions}
+      emailPreferencesUrl={input.emailPreferencesUrl}
+      identity={emailIdentity}
+    />
+  )
+
+  const [html, text] = await Promise.all([
+    render(element),
+    render(element, { plainText: true }),
+  ])
+  return { html, text }
+}

--- a/apps/next/utils/email/exhorter-heads-up-render.tsx
+++ b/apps/next/utils/email/exhorter-heads-up-render.tsx
@@ -1,6 +1,7 @@
 import { render } from '@react-email/render'
 import ExhorterHeadsUp, {
   type ExhorterHeadsUpAttendOption,
+  type ExhorterHeadsUpLunch,
 } from 'email-builder/emails/ExhorterHeadsUp'
 import { resolveTenantFromEnv, type TenantConfig } from '@my/app/config/tenants'
 import { emailIdentityFromProfile } from '@my/app/types/brand-profile'
@@ -16,12 +17,19 @@ import { resolveBrandProfile } from './resolve-brand-profile'
  */
 
 export interface RenderExhorterHeadsUpInput {
-  firstName: string
+  /** Exhorter's full name for the formal "Dear Brother {name}" greeting. */
+  exhorterName: string
+  /** Host ecclesia SHORT name, e.g. "Toronto East". */
   hostEcclesiaName: string
+  /** Full street address of the meeting hall. */
+  address?: string
   dateDisplay: string
   timeDisplay: string
-  visiting: boolean
   attendOptions: ExhorterHeadsUpAttendOption[]
+  /** Fellowship lunch style, or undefined for no lunch line. */
+  lunchType?: ExhorterHeadsUpLunch
+  /** Recording Brother's full name for the signature. */
+  signatoryName?: string
   emailPreferencesUrl: string
   tenant?: TenantConfig
 }
@@ -38,12 +46,14 @@ export async function renderExhorterHeadsUp(
 
   const element = (
     <ExhorterHeadsUp
-      firstName={input.firstName}
+      exhorterName={input.exhorterName}
       hostEcclesiaName={input.hostEcclesiaName}
+      address={input.address}
       dateDisplay={input.dateDisplay}
       timeDisplay={input.timeDisplay}
-      visiting={input.visiting}
       attendOptions={input.attendOptions}
+      lunchType={input.lunchType}
+      signatoryName={input.signatoryName}
       emailPreferencesUrl={input.emailPreferencesUrl}
       identity={emailIdentity}
     />

--- a/apps/next/utils/email/exhorter-heads-up.ts
+++ b/apps/next/utils/email/exhorter-heads-up.ts
@@ -176,7 +176,12 @@ export async function resolveAndSendExhorterHeadsUp(
   const recipient = test ? requesterEmail : person.primaryEmail
 
   const tz = row.ServiceTimezone || DEFAULT_TIMEZONE
-  const dateDisplay = formatScheduleDateForEmail(row.DateTime, row.Date, tz)
+  // Use the normalized ISO date (YYYY-MM-DD) as the date-only fallback. The raw
+  // `row.Date` sheet value isn't guaranteed to be dash-delimited, and the
+  // date-only formatter's `parseDateOnly` splits on '-' — a non-ISO value there
+  // yields a literal "Invalid Date". `targetISO` IS this row's date (that's how
+  // the row was matched), so it's both correct and parseable.
+  const dateDisplay = formatScheduleDateForEmail(row.DateTime, targetISO, tz)
   const timeDisplay = row.DateTime ? formatTimeInTimezone(row.DateTime, tz) : '11:00am'
 
   const report: ExhorterHeadsUpReport = {

--- a/apps/next/utils/email/exhorter-heads-up.ts
+++ b/apps/next/utils/email/exhorter-heads-up.ts
@@ -113,6 +113,7 @@ export type ExhorterHeadsUpStatus =
   | 'skipped:no-email'
   | 'skipped:already-sent'
   | 'skipped:needs-review'
+  | 'skipped:past-date'
   | 'no-schedule-row'
 
 export interface ExhorterHeadsUpReport {
@@ -168,6 +169,15 @@ export async function resolveAndSendExhorterHeadsUp(
   const hostPublicName = tenant.publicName
 
   const base: ExhorterHeadsUpReport = { date: targetISO, test, status: 'no-schedule-row' }
+
+  // 0. Past-date guard: a heads-up is a *reminder ahead of time* — never send one
+  //    for a Sunday already in the past, whatever date was passed in. The default
+  //    path computes a future Sunday, but a manual/automated caller could pass an
+  //    older date; this makes a past send impossible regardless.
+  const todayISO = normalizeToISODate(new Date())
+  if (targetISO && targetISO < todayISO) {
+    return { ...base, status: 'skipped:past-date' }
+  }
 
   // 1. Find the memorial row for the target Sunday.
   const schedule = await scheduleService.getScheduleData('memorial')

--- a/apps/next/utils/email/exhorter-heads-up.ts
+++ b/apps/next/utils/email/exhorter-heads-up.ts
@@ -1,0 +1,266 @@
+import { ScheduleService } from '@my/app/provider/dynamodb/schedule-service'
+import { personRepository } from '@my/app/provider/dynamodb/repositories/person-repository'
+import { resolveScheduleName, isPlaceholderName } from '@my/app/utils/name-resolver'
+import { toDirectoryPerson } from '@my/app/utils/name-resolver-directory'
+import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
+import { resolveTenantFromEnv } from '@my/app/config/tenants'
+import {
+  fetchServiceOverrides,
+  normalizeToISODate,
+  overrideKey,
+} from '@my/app/utils/service-overrides/merge'
+import {
+  formatScheduleDateForEmail,
+  formatTimeInTimezone,
+  DEFAULT_TIMEZONE,
+} from '@my/app/utils/timezone'
+import type { PersonRecord } from '@my/app/provider/dynamodb/types'
+import type { ExhorterHeadsUpAttendOption } from 'email-builder/emails/ExhorterHeadsUp'
+import { sendEmail } from './sesClient'
+import { renderExhorterHeadsUp } from './exhorter-heads-up-render'
+import { exhorterHeadsUpRepository } from '@my/app/provider/dynamodb/repositories/exhorter-headsup-repository'
+import { generateEmailPreferencesUrl } from './ecclesia-token'
+
+/**
+ * Exhorter heads-up service (#124, slice A).
+ *
+ * Reads the memorial schedule, finds the target Sunday's `Exhort` name, resolves
+ * it to a directory PersonRecord, and sends a warm 1:1 reminder via `sendEmail()`.
+ *
+ * SAFETY (must hold):
+ *   - `test` defaults TRUE.
+ *   - In TEST mode the email is sent to the REQUESTER (the admin who triggered),
+ *     NEVER the real exhorter.
+ *   - Only a `matched` + non-placeholder + non-empty-email exhorter sends.
+ *   - Idempotency is LIVE-only (test writes nothing so tests can repeat).
+ *   - No cron / auto-send here (slice B).
+ */
+
+// From = the proven, SES-verified sender domain (SPF/DKIM). NEVER a personal
+// address here or the send fails auth → spam. Reply-To carries the human contact.
+const SENDER_LOCAL_PART = 'communications'
+// Reply-To = the HOST ecclesia's Recording Brother, so the exhorter's replies
+// reach whoever is coordinating that meeting. teerecbro@gmail.com is fine as a
+// Reply-To (no domain verification needed).
+// TODO(multi-tenant, #124): resolve Reply-To to the host ecclesia's Recording
+// Brother (RB office / ecclesia record / config) instead of the TEE constant.
+const REPLY_TO = 'teerecbro@gmail.com'
+
+// Fallback "ways to attend" — the SAME Zoom the memorial template hardcodes.
+// Used only when the occurrence has no per-occurrence `attendOptions` override.
+const DEFAULT_TEE_ZOOM: ExhorterHeadsUpAttendOption = {
+  label: 'Toronto East Zoom',
+  url: 'https://us04web.zoom.us/j/586952386?pwd=Z2svVG0zTmNlTWx2MTFoMlZIaDZLQT09',
+  meetingId: '586 952 386',
+  password: '036110',
+  platform: 'zoom',
+  dialInNumber: '+1 647 374 4685',
+}
+
+export type ExhorterHeadsUpStatus =
+  | 'sent'
+  | 'dry-run'
+  | 'unresolved'
+  | 'skipped:placeholder'
+  | 'skipped:no-email'
+  | 'skipped:already-sent'
+  | 'no-schedule-row'
+
+export interface ExhorterHeadsUpReport {
+  date: string
+  test: boolean
+  status: ExhorterHeadsUpStatus
+  exhortName?: string
+  personId?: string
+  visiting?: boolean
+  sentTo?: string
+  zoomSource?: 'override' | 'default'
+  /** When unresolved: the resolver outcome (typo | ambiguous | not-found). */
+  matchStatus?: string
+}
+
+export interface ResolveAndSendExhorterHeadsUpParams {
+  /** Target Sunday (ISO — matched against the memorial row's DateTime/Date). */
+  date: string
+  /** TEST mode — defaults TRUE. Test NEVER emails the real exhorter. */
+  test?: boolean
+  /** Resolve + report only, no send, no idempotency write. */
+  dryRun?: boolean
+  /** The admin who triggered — the TEST-mode recipient. */
+  requesterEmail: string
+}
+
+const scheduleService = new ScheduleService()
+
+/** Page through the whole directory (listAll is a paginated scan). */
+async function listAllPersons(): Promise<PersonRecord[]> {
+  const all: PersonRecord[] = []
+  let lastEvaluatedKey: Record<string, any> | undefined
+  do {
+    const result = await personRepository.listAll({ lastEvaluatedKey })
+    all.push(...result.items)
+    lastEvaluatedKey = result.lastEvaluatedKey
+  } while (lastEvaluatedKey)
+  return all
+}
+
+export async function resolveAndSendExhorterHeadsUp(
+  params: ResolveAndSendExhorterHeadsUpParams
+): Promise<ExhorterHeadsUpReport> {
+  const { requesterEmail } = params
+  const test = params.test ?? true // SAFE DEFAULT
+  const dryRun = params.dryRun ?? false
+  const targetISO = normalizeToISODate(params.date)
+
+  const tenant = resolveTenantFromEnv()
+  const hostCanonical = tenant.homeEcclesiaName ?? HOME_ECCLESIA.canonicalName
+  const hostPublicName = tenant.publicName
+
+  const base: ExhorterHeadsUpReport = { date: targetISO, test, status: 'no-schedule-row' }
+
+  // 1. Find the memorial row for the target Sunday.
+  const schedule = await scheduleService.getScheduleData('memorial')
+  const rows = (schedule?.content ?? []) as Array<Record<string, any>>
+  const row = rows.find((r) => normalizeToISODate(r.DateTime || r.Date) === targetISO)
+  if (!row) {
+    return base
+  }
+
+  const exhortName = String(row.Exhort ?? '').trim()
+  base.exhortName = exhortName
+
+  // 2. Placeholder guard ("TBD"/"attendees"/blank) — nothing to send.
+  if (isPlaceholderName(exhortName)) {
+    return { ...base, status: 'skipped:placeholder' }
+  }
+
+  // 3. Resolve the free-text name against the whole directory. Only an exact
+  //    `matched` proceeds — typo/ambiguous/not-found are reported, never sent.
+  const candidates = (await listAllPersons()).map(toDirectoryPerson)
+  const match = resolveScheduleName(exhortName, candidates)
+  if (match.status !== 'matched') {
+    return { ...base, status: 'unresolved', matchStatus: match.status }
+  }
+
+  // 4. Load the full record; an emailless (visiting) speaker has primaryEmail ''.
+  const person = await personRepository.getById(match.person.personId)
+  if (!person || !person.primaryEmail) {
+    return { ...base, status: 'skipped:no-email', personId: match.person.personId }
+  }
+
+  const personId = person.personId
+  const visiting =
+    person.memberStatus === 'visitor' || !HOME_ECCLESIA.isHomeEcclesia(person.ecclesia)
+
+  // 5. Ways to attend: the per-occurrence override if present, else the default Zoom.
+  const overrides = await fetchServiceOverrides(hostCanonical, ['memorial'], targetISO, targetISO)
+  const override = overrides.get(overrideKey('memorial', targetISO))
+  let attendOptions: ExhorterHeadsUpAttendOption[]
+  let zoomSource: 'override' | 'default'
+  if (override?.attendOptions?.length) {
+    attendOptions = override.attendOptions.map((o) => ({
+      label: o.label,
+      url: o.url,
+      meetingId: o.meetingId,
+      password: o.password,
+      platform: o.platform,
+      dialInNumber: o.dialInNumber,
+    }))
+    zoomSource = 'override'
+  } else {
+    attendOptions = [DEFAULT_TEE_ZOOM]
+    zoomSource = 'default'
+  }
+
+  // 6. Recipient: TEST → the requester (NEVER the real exhorter); LIVE → primaryEmail.
+  const recipient = test ? requesterEmail : person.primaryEmail
+
+  const tz = row.ServiceTimezone || DEFAULT_TIMEZONE
+  const dateDisplay = formatScheduleDateForEmail(row.DateTime, row.Date, tz)
+  const timeDisplay = row.DateTime ? formatTimeInTimezone(row.DateTime, tz) : '11:00am'
+
+  const report: ExhorterHeadsUpReport = {
+    ...base,
+    status: 'sent',
+    personId,
+    visiting,
+    sentTo: recipient,
+    zoomSource,
+  }
+
+  // 7. Dry run: resolve + report, no send, no idempotency write.
+  if (dryRun) {
+    return { ...report, status: 'dry-run' }
+  }
+
+  // 8. Idempotency (LIVE ONLY). Atomic claim BEFORE send prevents double-send on
+  //    a re-run / schedule edit. Test mode writes nothing so tests can repeat.
+  if (!test) {
+    const claimed = await exhorterHeadsUpRepository.claim({
+      date: targetISO,
+      personId,
+      sentTo: recipient,
+      createdBy: requesterEmail,
+    })
+    if (!claimed) {
+      return { ...report, status: 'skipped:already-sent' }
+    }
+  }
+
+  // 9. Resolve the recipient's Email Preferences link (real URL — this 1:1 send
+  //    does no {{token}} substitution), render, and send.
+  let emailPreferencesUrl: string
+  try {
+    emailPreferencesUrl = await generateEmailPreferencesUrl(recipient)
+  } catch (err) {
+    console.error('[exhorter-headsup] failed to mint preferences URL, using fallback:', err)
+    emailPreferencesUrl = `${process.env.NEXT_PUBLIC_AUTH_URL || 'https://tee-admin.com'}/email-preferences`
+  }
+
+  try {
+    const { html, text } = await renderExhorterHeadsUp({
+      firstName: person.firstName,
+      hostEcclesiaName: hostPublicName,
+      dateDisplay,
+      timeDisplay,
+      visiting,
+      attendOptions,
+      emailPreferencesUrl,
+      tenant,
+    })
+
+    const subject = `${test ? '[TEST] ' : ''}Your exhortation at ${hostPublicName} on ${dateDisplay}`
+    const from = `"${tenant.senderDisplayName}" <${SENDER_LOCAL_PART}@${tenant.senderDomain}>`
+
+    await sendEmail({
+      to: recipient,
+      subject,
+      body: html,
+      textBody: text,
+      tenant,
+      from,
+      replyTo: REPLY_TO,
+    })
+  } catch (err) {
+    // Send failed AFTER a live claim — release it so a manual retry can re-send.
+    if (!test) {
+      await exhorterHeadsUpRepository.release(targetISO, personId)
+    }
+    throw err
+  }
+
+  return report
+}
+
+/**
+ * Compute the next target Sunday (~2 weeks out) for the manual admin trigger when
+ * no explicit date is given. Returns an ISO YYYY-MM-DD (UTC). The heads-up is sent
+ * ~2 Saturdays before, so the default target is the SECOND upcoming Sunday.
+ */
+export function computeNextTargetSunday(from: Date = new Date()): string {
+  const d = new Date(Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate()))
+  // Advance to the next Sunday (excluding today), then +7 → second upcoming Sunday.
+  const daysToSunday = (7 - d.getUTCDay()) % 7 || 7
+  d.setUTCDate(d.getUTCDate() + daysToSunday + 7)
+  return normalizeToISODate(d)
+}

--- a/apps/next/utils/email/exhorter-heads-up.ts
+++ b/apps/next/utils/email/exhorter-heads-up.ts
@@ -15,7 +15,11 @@ import {
   DEFAULT_TIMEZONE,
 } from '@my/app/utils/timezone'
 import type { PersonRecord } from '@my/app/provider/dynamodb/types'
-import type { ExhorterHeadsUpAttendOption } from 'email-builder/emails/ExhorterHeadsUp'
+import type {
+  ExhorterHeadsUpAttendOption,
+  ExhorterHeadsUpLunch,
+} from 'email-builder/emails/ExhorterHeadsUp'
+import { getEcclesiaByName, type EcclesiaData } from '../dynamodb/locations'
 import { sendEmail } from './sesClient'
 import { renderExhorterHeadsUp } from './exhorter-heads-up-render'
 import { exhorterHeadsUpRepository } from '@my/app/provider/dynamodb/repositories/exhorter-headsup-repository'
@@ -40,11 +44,55 @@ import { generateEmailPreferencesUrl } from './ecclesia-token'
 // address here or the send fails auth → spam. Reply-To carries the human contact.
 const SENDER_LOCAL_PART = 'communications'
 // Reply-To = the HOST ecclesia's Recording Brother, so the exhorter's replies
-// reach whoever is coordinating that meeting. teerecbro@gmail.com is fine as a
-// Reply-To (no domain verification needed).
-// TODO(multi-tenant, #124): resolve Reply-To to the host ecclesia's Recording
-// Brother (RB office / ecclesia record / config) instead of the TEE constant.
+// reach whoever is coordinating that meeting. Now resolved per-ecclesia from the
+// directory (`recordingBrotherEmail`); this constant is only the fallback when
+// the record has no RB email. teerecbro@gmail.com is fine as a Reply-To (no
+// domain verification needed).
 const REPLY_TO = 'teerecbro@gmail.com'
+
+// A non-lunch note in the memorial row's `Lunch`/`Activities` free-text columns
+// signals the normal at-hall memorial DIDN'T happen — cancelled, online-only, or
+// relocated (joining another ecclesia / a fraternal gathering). On those days the
+// heads-up's core promise ("come exhort at {hall} at {time}") is WRONG, so we must
+// NOT auto-send — we flag for human review instead. Keyword-based (verified
+// against the live schedule: matches the 4 cancel/relocate days, and leaves the
+// "tee study weekend" + potluck days alone). STOPGAP: the durable fix is a
+// structured occurrence status on the service-override record (see #124 follow-up)
+// so we stop parsing free-text.
+const SPECIAL_OCCASION_RE = /(cancel|joining|join us at|fraternal gathering|elsewhere)/i
+
+/** Returns the free-text signal for a cancelled/relocated occurrence, else null. */
+export function detectSpecialOccasion(lunch?: string, activities?: string): string | null {
+  const blob = `${lunch ?? ''}  ${activities ?? ''}`
+  if (!SPECIAL_OCCASION_RE.test(blob)) return null
+  return activities?.trim() || lunch?.trim() || 'Special occasion — not the usual memorial'
+}
+
+/** Classify the row's `Lunch` value into an invite style, or undefined for none. */
+export function resolveLunchType(lunch?: string): ExhorterHeadsUpLunch | undefined {
+  const v = (lunch ?? '').trim().toLowerCase()
+  if (!v) return undefined
+  if (v.includes('potluck')) return 'potluck'
+  if (v.includes('provided')) return 'provided'
+  if (v.includes('lunch') || v.includes('brunch')) return 'generic'
+  return undefined
+}
+
+/** Trim a trailing "Christadelphians"/"Ecclesia" suffix → short display name. */
+export function shortEcclesiaName(name: string): string {
+  const short = name.replace(/\s+(christadelphians?|ecclesia)\s*$/i, '').trim()
+  return short || name
+}
+
+/** Best available full hall address for the "We're located at:" line. */
+export function resolveHallAddress(ecclesia: EcclesiaData | null): string | undefined {
+  if (!ecclesia) return undefined
+  if (ecclesia.address?.trim()) return ecclesia.address.trim()
+  const parts = [ecclesia.venue, ecclesia.city, ecclesia.province, ecclesia.postalCode]
+    .map((s) => s?.trim())
+    .filter((s): s is string => !!s)
+  return parts.length ? parts.join(', ') : undefined
+}
 
 // Fallback "ways to attend" — the SAME Zoom the memorial template hardcodes.
 // Used only when the occurrence has no per-occurrence `attendOptions` override.
@@ -64,6 +112,7 @@ export type ExhorterHeadsUpStatus =
   | 'skipped:placeholder'
   | 'skipped:no-email'
   | 'skipped:already-sent'
+  | 'skipped:needs-review'
   | 'no-schedule-row'
 
 export interface ExhorterHeadsUpReport {
@@ -77,6 +126,8 @@ export interface ExhorterHeadsUpReport {
   zoomSource?: 'override' | 'default'
   /** When unresolved: the resolver outcome (typo | ambiguous | not-found). */
   matchStatus?: string
+  /** When skipped:needs-review — the free-text signal a human should look at. */
+  note?: string
 }
 
 export interface ResolveAndSendExhorterHeadsUpParams {
@@ -129,7 +180,17 @@ export async function resolveAndSendExhorterHeadsUp(
   const exhortName = String(row.Exhort ?? '').trim()
   base.exhortName = exhortName
 
-  // 2. Placeholder guard ("TBD"/"attendees"/blank) — nothing to send.
+  // 2. Special-occasion guard: a cancel/relocate/online-only signal in the row's
+  //    free-text means the normal at-hall memorial isn't happening — the standard
+  //    "come exhort at {hall} at {time}" email would be wrong. Flag, never send.
+  //    Runs BEFORE the placeholder guard so relocation days (which often have a
+  //    blank Exhort) still surface the note for a human.
+  const specialNote = detectSpecialOccasion(row.Lunch, row.Activities)
+  if (specialNote) {
+    return { ...base, status: 'skipped:needs-review', note: specialNote }
+  }
+
+  // 3. Placeholder guard ("TBD"/"attendees"/blank) — nothing to send.
   if (isPlaceholderName(exhortName)) {
     return { ...base, status: 'skipped:placeholder' }
   }
@@ -172,7 +233,16 @@ export async function resolveAndSendExhorterHeadsUp(
     zoomSource = 'default'
   }
 
-  // 6. Recipient: TEST → the requester (NEVER the real exhorter); LIVE → primaryEmail.
+  // 6. Host ecclesia directory record → short name, hall address, and the
+  //    Recording Brother signature + Reply-To (retires the hardcoded TODO).
+  const ecclesia = await getEcclesiaByName(hostCanonical)
+  const shortName = shortEcclesiaName(hostPublicName)
+  const hallAddress = resolveHallAddress(ecclesia)
+  const signatoryName = ecclesia?.recordingBrotherName?.trim() || undefined
+  const replyTo = ecclesia?.recordingBrotherEmail?.trim() || REPLY_TO
+  const lunchType = resolveLunchType(row.Lunch)
+
+  // 7. Recipient: TEST → the requester (NEVER the real exhorter); LIVE → primaryEmail.
   const recipient = test ? requesterEmail : person.primaryEmail
 
   const tz = row.ServiceTimezone || DEFAULT_TIMEZONE
@@ -222,19 +292,26 @@ export async function resolveAndSendExhorterHeadsUp(
     emailPreferencesUrl = `${process.env.NEXT_PUBLIC_AUTH_URL || 'https://tee-admin.com'}/email-preferences`
   }
 
+  const exhorterName =
+    [person.firstName, person.lastName].filter(Boolean).join(' ').trim() ||
+    person.displayName ||
+    person.firstName
+
   try {
     const { html, text } = await renderExhorterHeadsUp({
-      firstName: person.firstName,
-      hostEcclesiaName: hostPublicName,
+      exhorterName,
+      hostEcclesiaName: shortName,
+      address: hallAddress,
       dateDisplay,
       timeDisplay,
-      visiting,
       attendOptions,
+      lunchType,
+      signatoryName,
       emailPreferencesUrl,
       tenant,
     })
 
-    const subject = `${test ? '[TEST] ' : ''}Your exhortation at ${hostPublicName} on ${dateDisplay}`
+    const subject = `${test ? '[TEST] ' : ''}Your exhortation at ${shortName} on ${dateDisplay}`
     const from = `"${tenant.senderDisplayName}" <${SENDER_LOCAL_PART}@${tenant.senderDomain}>`
 
     await sendEmail({
@@ -244,7 +321,7 @@ export async function resolveAndSendExhorterHeadsUp(
       textBody: text,
       tenant,
       from,
-      replyTo: REPLY_TO,
+      replyTo,
     })
   } catch (err) {
     // Send failed AFTER a live claim — release it so a manual retry can re-send.

--- a/apps/next/utils/email/sesClient.ts
+++ b/apps/next/utils/email/sesClient.ts
@@ -61,9 +61,27 @@ export interface SendEmailProps {
    * `resolveTenantFromEnv()` (DEPLOYMENT_NAME → 'tee' default).
    */
   tenant?: TenantConfig
+  /**
+   * Full From address (e.g. `"Toronto East Ecclesia" <communications@tee-admin.com>`).
+   * When omitted, defaults to the current behaviour: `noreply@{senderDomain}`.
+   * Backward-compatible — existing callers are unchanged.
+   */
+  from?: string
+  /**
+   * Reply-To address. When omitted, no Reply-To header is set (current behaviour).
+   */
+  replyTo?: string
 }
 
-export async function sendEmail({ to, subject, body, textBody, tenant }: SendEmailProps): Promise<void> {
+export async function sendEmail({
+  to,
+  subject,
+  body,
+  textBody,
+  tenant,
+  from,
+  replyTo,
+}: SendEmailProps): Promise<void> {
   if (!emailsEnabled()) {
     console.log(
       `[sendEmail] Skipped — EMAILS_ENABLED=false (deployment=${process.env.DEPLOYMENT_NAME ?? 'unknown'}, to=${to})`
@@ -75,7 +93,8 @@ export async function sendEmail({ to, subject, body, textBody, tenant }: SendEma
   const sesClient = getSesClient()
 
   const emailCmd = new SendEmailCommand({
-    FromEmailAddress: `"${resolvedTenant.senderDisplayName}" <noreply@${resolvedTenant.senderDomain}>`,
+    FromEmailAddress: from ?? `"${resolvedTenant.senderDisplayName}" <noreply@${resolvedTenant.senderDomain}>`,
+    ...(replyTo ? { ReplyToAddresses: [replyTo] } : {}),
     Destination: {
       ToAddresses: [to],
     },

--- a/packages/app/provider/dynamodb/repositories/exhorter-headsup-repository.ts
+++ b/packages/app/provider/dynamodb/repositories/exhorter-headsup-repository.ts
@@ -1,0 +1,83 @@
+import { PutCommand, DeleteCommand } from '@aws-sdk/lib-dynamodb'
+import { docClient, tableNames } from '../config'
+
+/**
+ * Idempotency guard for the exhorter heads-up email (#124, slice A).
+ *
+ * One record per (target Sunday, exhorter) in the app-managed `tee-admin` table:
+ *
+ *   pkey: EXHORTER_HEADSUP#{date}#{personId}
+ *   skey: SEND
+ *
+ * `claim()` is an atomic conditional put (attribute_not_exists) — mirrors the
+ * claim pattern in `send-queue-repository.ts` — so a re-run or a schedule edit
+ * can NEVER double-send to the same speaker for the same Sunday. LIVE sends only;
+ * TEST mode writes nothing (see resolveAndSendExhorterHeadsUp), so tests can
+ * repeat freely.
+ */
+
+function idempotencyPk(date: string, personId: string): string {
+  return `EXHORTER_HEADSUP#${date}#${personId}`
+}
+
+export interface ClaimHeadsUpInput {
+  date: string // ISO YYYY-MM-DD (target Sunday)
+  personId: string
+  sentTo: string
+  createdBy: string
+}
+
+class ExhorterHeadsUpRepository {
+  private tableName = tableNames.admin
+
+  /**
+   * Atomically claim the (date, personId) slot BEFORE sending. Returns true when
+   * the claim was written (safe to send), false when a record already exists
+   * (already sent — skip). Race-safe via the conditional put.
+   */
+  async claim(input: ClaimHeadsUpInput): Promise<boolean> {
+    const now = new Date().toISOString()
+    try {
+      await docClient.send(
+        new PutCommand({
+          TableName: this.tableName,
+          Item: {
+            pkey: idempotencyPk(input.date, input.personId),
+            skey: 'SEND',
+            date: input.date,
+            personId: input.personId,
+            sentTo: input.sentTo,
+            createdBy: input.createdBy,
+            createdAt: now,
+          },
+          ConditionExpression: 'attribute_not_exists(pkey)',
+        })
+      )
+      return true
+    } catch (error: any) {
+      if (error?.name === 'ConditionalCheckFailedException') {
+        return false // Already claimed / sent — skip.
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Release a claim — used when a send throws AFTER the claim, so a manual retry
+   * can re-send. Best-effort; a failed release is logged, not thrown.
+   */
+  async release(date: string, personId: string): Promise<void> {
+    try {
+      await docClient.send(
+        new DeleteCommand({
+          TableName: this.tableName,
+          Key: { pkey: idempotencyPk(date, personId), skey: 'SEND' },
+        })
+      )
+    } catch (error) {
+      console.error('[exhorter-headsup] failed to release claim (non-fatal):', error)
+    }
+  }
+}
+
+export const exhorterHeadsUpRepository = new ExhorterHeadsUpRepository()


### PR DESCRIPTION
Builds **Slice A** of #124 — the exhorter heads-up email. A warm **1:1 reminder** to whoever is scheduled to give the exhortation at an upcoming memorial, reaching **visiting speakers across ecclesias** via their resolved directory email.

This slice = **template + resolve-and-send service + a manual admin trigger that is TEST-MODE BY DEFAULT and never emails a real exhorter.** No cron / auto-send (deferred to slice B).

## What / why
The payoff of the name↔member resolver (#109): remind the scheduled exhorter ~2 weeks ahead, including visiting speakers. Slice A lets us verify the whole flow safely before any automation.

## How it works
- **`sendEmail()` (sesClient)** — gains optional `from` + `replyTo` (backward-compatible; existing callers unchanged). The heads-up sends **From `communications@{senderDomain}`** (the proven, SES-verified domain — SPF/DKIM) with **Reply-To the host RB** (`teerecbro@gmail.com`), so the exhorter's replies reach whoever is coordinating that meeting. `// TODO(multi-tenant, #124)` left where Reply-To should later resolve per-tenant.
- **`ExhorterHeadsUp` template** (`apps/email-builder/emails/`) — **server-safe** (identity as a prop, `EmailBrandLinkContent`, no `'use client'` imports). Greets by first name; states "You're scheduled to give the exhortation at ⟨host⟩ on ⟨Sunday⟩ at ⟨time⟩"; ways to attend (Zoom); a **visiting-only** "Lunch is provided — please plan to stay" line; a **"What to expect"** section foreshadowing the week-of follow-up (theme / readings / hymns); and an **email-scoped footer** ("TEE-Admin — powered by **Echad Hub**, and Christadelphian Initiative" + a real **Email Preferences** link).
  - *Footer note:* this 1:1 `sendEmail()` path does **no** `{{emailPreferencesUrl}}` token substitution (that lives only in the bulk `emailSend` path), so the template ships a **real** resolved preferences URL and deliberately does **not** reuse the shared `FooterContent`'s token link. The shared `FooterContent` is untouched.
- **`resolveAndSendExhorterHeadsUp` service** — reads `getScheduleData('memorial')`, matches the target Sunday, reads `Exhort`, resolves over `personRepository.listAll()`. **Guard order:** `isPlaceholderName` → `skipped:placeholder`; not `matched` → `unresolved` (reported, **never sends**); empty `primaryEmail` → `skipped:no-email`. `visiting = memberStatus==='visitor' || non-home ecclesia`. Zoom from the per-occurrence `attendOptions` override for that date, else the same constant the memorial template hardcodes. **Recipient: TEST → the requester (never the exhorter); LIVE → `primaryEmail`.** **Idempotency (LIVE only):** conditional-put claim `EXHORTER_HEADSUP#{date}#{personId}` (released if the send throws); test writes nothing so tests repeat. `dryRun` resolves + reports without sending.
- **`POST /api/admin/exhorter-heads-up`** — owner/admin gated (same pattern as other `app/api/admin/*` routes). Body `{ date?, test?, dryRun? }`; **`test` defaults true**. If `date` omitted, computes the next target Sunday (~2 weeks out), still test. Passes the session email as `requesterEmail`.

## Safety (holds)
test defaults true · test never sends to the real exhorter (only the requester) · only `matched` + non-placeholder + non-empty-email sends · idempotency live-only · no cron/auto-send · render verified server-safe.

## How verified
- **20 new unit tests pass** (`yarn vitest run` on the two new files):
  - Guard/resolve matrix: matched→exhorter (live) / →requester (test), placeholder→skip, unresolved→report (no send), no-email→skip, no-schedule-row, visiting flag (non-home / visitor / member), zoom source (default vs override), idempotency-skip on 2nd live call + release-on-send-failure, dryRun→no send/claim.
  - Server-side render with a fixture: does not throw; date/host/time/zoom/what-to-expect strings present; **lunch line present only when visiting**; footer Echad Hub + Email Preferences links present; no unsubstituted `{{token}}`.
- **`yarn workspace next-app typecheck` clean** (exit 0).
- **No real email sent.** Pre-existing unrelated auth/db test failures (13 files / 80 tests, identical on `main`) and `occurrenceDate` type noise are unchanged.

## What is NOT done (out of scope)
- **Slice B — Saturday-10am automation** (cron endpoint + trigger, target Sunday = send-Saturday + ~8 days). Deferred.
- The week-of follow-up email (theme/readings/hymns) — foreshadowed only.

Depends on #109 (resolver — shipped). Refs #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)