### PR TITLE
Direct-recipient send: 1:1 permission-gated email to a specific requester (#127)

### DIFF
--- a/apps/next/app/api/email/send-one/route.ts
+++ b/apps/next/app/api/email/send-one/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '../../../../utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+import { pendingEmailNoteRepository } from '@my/app/provider/dynamodb/repositories/pending-email-note-repository'
+import { resolveTenantFromEnv } from '@my/app/config/tenants'
+import type { EmailReasonType } from '@my/app/types'
+import { getEmailContent } from '../../../../utils/email/get-email-content'
+import { buildEmailEnvelope } from '../../../../utils/email/email-send'
+import { sendEmail } from '../../../../utils/email/sesClient'
+
+/**
+ * POST /api/email/send-one — send ONE email to ONE explicitly-requesting person.
+ *
+ * The safe, permission-gated way to honour a specific request (e.g. someone who
+ * has opted out of the standing list but asked for this one email, or a visitor
+ * who wants a specific bulletin). It is deliberately NOT a broadcast:
+ *   - 1:1 only — renders the SAME content as the normal send for `reason` and
+ *     sends via `sendEmail()` to the single supplied address.
+ *   - It does NOT touch the SES contact list or the recipient's `sesSubscribed`
+ *     state — a one-off never re-subscribes anyone.
+ *   - It IGNORES test mode by design (the caller is sending real content to a
+ *     real, consenting recipient), so it is gated by an explicit permission
+ *     attestation that is RE-CHECKED here server-side.
+ *
+ * Body: { reason, to, recipientName?, note?, permission: true }
+ */
+
+const ALLOWED_REASONS: EmailReasonType[] = ['newsletter', 'recap', 'bible-class', 'sunday-school']
+
+// Pragmatic email shape check (server-side belt to the client's).
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export async function POST(request: NextRequest) {
+  // 1. Owner/admin only.
+  const session = await auth()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
+  const userRole = session.user.role
+  if (!userRole || ![ROLES.OWNER, ROLES.ADMIN].includes(userRole)) {
+    return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 })
+  }
+
+  let body: {
+    reason?: string
+    to?: string
+    recipientName?: string
+    note?: string
+    permission?: boolean
+  }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  // 2. Permission attestation is REQUIRED (re-checked server-side, not just UI).
+  if (body.permission !== true) {
+    return NextResponse.json(
+      { error: 'Permission attestation required — confirm you have the recipient’s permission.' },
+      { status: 403 }
+    )
+  }
+
+  // 3. Validate reason + recipient address.
+  const { reason, recipientName } = body
+  if (!reason || !ALLOWED_REASONS.includes(reason as EmailReasonType)) {
+    return NextResponse.json(
+      { error: `reason must be one of: ${ALLOWED_REASONS.join(', ')}` },
+      { status: 400 }
+    )
+  }
+  const to = (body.to ?? '').trim().toLowerCase()
+  if (!EMAIL_RE.test(to)) {
+    return NextResponse.json({ error: 'A valid recipient email is required' }, { status: 400 })
+  }
+  const typedReason = reason as EmailReasonType
+
+  // 4. Note: use the supplied note, else the type's pending note — so the copy
+  //    matches what the broadcast produced. We do NOT clear it (it belongs to the
+  //    real broadcast, not this side-send).
+  const noteText =
+    typeof body.note === 'string' && body.note.trim()
+      ? body.note.trim()
+      : (await pendingEmailNoteRepository.getNote(typedReason)) || undefined
+
+  // 5. Render the SAME content as the normal send, and build the SAME envelope
+  //    (canonical `communications@` sender + branded subject) as the broadcast.
+  const tenant = resolveTenantFromEnv()
+  let html: string | undefined
+  let text: string | undefined
+  try {
+    const content = await getEmailContent(typedReason, noteText)
+    html = content[0]
+    text = content[1]
+  } catch (err) {
+    console.error('[send-one] render failed:', err)
+    return NextResponse.json({ error: 'Failed to render email content' }, { status: 500 })
+  }
+  if (!html) {
+    return NextResponse.json(
+      { error: `No content available to send for "${typedReason}" right now` },
+      { status: 422 }
+    )
+  }
+
+  const { from, replyTo, subject } = buildEmailEnvelope(typedReason, tenant, { test: false })
+
+  // 6. Send 1:1. Audit BEFORE + AFTER so the intent is logged even if SES throws.
+  console.log(
+    `[send-one] ${session.user.email} → ${to} | reason=${typedReason} | hadNote=${!!noteText} | name=${recipientName ?? ''}`
+  )
+  try {
+    await sendEmail({ to, subject, body: html, textBody: text, tenant, from, replyTo })
+  } catch (err) {
+    console.error(`[send-one] SEND FAILED to ${to} (${typedReason}):`, err)
+    return NextResponse.json({ error: 'Send failed — see server logs' }, { status: 502 })
+  }
+
+  console.log(`[send-one] SENT to ${to} | reason=${typedReason} | by=${session.user.email}`)
+  return NextResponse.json({
+    ok: true,
+    to,
+    reason: typedReason,
+    subject,
+    hadNote: !!noteText,
+    sentBy: session.user.email,
+  })
+}

--- a/apps/next/app/api/people/route.ts
+++ b/apps/next/app/api/people/route.ts
@@ -239,11 +239,13 @@ function applyFilters(
     // Apply ecclesia filter if provided
     if (ecclesiaFilter && member.ecclesia !== ecclesiaFilter) return false
 
-    // Apply search filter if provided
+    // Apply search filter if provided. Null-guard every field: emailless
+    // members exist (e.g. visiting-speaker records with a NOEMAIL# sentinel and
+    // no primary email), and an unguarded `.toLowerCase()` 500s the whole search.
     if (searchQuery) {
-      const nameMatch = member.name.toLowerCase().includes(searchQuery)
+      const nameMatch = member.name?.toLowerCase().includes(searchQuery)
       const ecclesiaMatch = member.ecclesia?.toLowerCase().includes(searchQuery)
-      const emailMatch = member.email.toLowerCase().includes(searchQuery)
+      const emailMatch = member.email?.toLowerCase().includes(searchQuery)
       if (!nameMatch && !ecclesiaMatch && !emailMatch) return false
     }
 

--- a/apps/next/tests/send-one-route.test.ts
+++ b/apps/next/tests/send-one-route.test.ts
@@ -1,0 +1,136 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+
+/**
+ * Guard + envelope matrix for POST /api/email/send-one (Issue #127).
+ *
+ * The safety-critical bits: owner/admin only, permission attestation REQUIRED
+ * (re-checked server-side), reason/email validation, and — when it does send —
+ * a 1:1 send using the SAME canonical envelope (from/replyTo/subject) as the
+ * broadcast, WITHOUT clearing the type's pending note (that belongs to the real
+ * broadcast, not this side-send).
+ */
+
+const h = vi.hoisted(() => ({
+  auth: vi.fn(),
+  getEmailContent: vi.fn(),
+  buildEmailEnvelope: vi.fn(),
+  sendEmail: vi.fn(),
+  getNote: vi.fn(),
+  clearNote: vi.fn(),
+  resolveTenantFromEnv: vi.fn(),
+}))
+
+vi.mock('../utils/auth', () => ({ auth: h.auth }))
+vi.mock('../utils/email/get-email-content', () => ({ getEmailContent: h.getEmailContent }))
+vi.mock('../utils/email/email-send', () => ({ buildEmailEnvelope: h.buildEmailEnvelope }))
+vi.mock('../utils/email/sesClient', () => ({ sendEmail: h.sendEmail }))
+vi.mock('@my/app/provider/dynamodb/repositories/pending-email-note-repository', () => ({
+  pendingEmailNoteRepository: { getNote: h.getNote, clearNote: h.clearNote },
+}))
+vi.mock('@my/app/config/tenants', () => ({ resolveTenantFromEnv: h.resolveTenantFromEnv }))
+
+import { POST } from '../app/api/email/send-one/route'
+
+function req(body: any) {
+  return { json: async () => body } as any
+}
+
+const OWNER = { user: { email: 'owner@tee-admin.com', role: ROLES.OWNER } }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.auth.mockResolvedValue(OWNER)
+  h.getEmailContent.mockResolvedValue(['<html>news</html>', 'news text'])
+  h.buildEmailEnvelope.mockReturnValue({
+    from: '"Toronto East" <communications@tee-admin.com>',
+    replyTo: 'teerecbro@gmail.com',
+    subject: 'Toronto East Christadelphians Newsletter 2026-07-30',
+  })
+  h.sendEmail.mockResolvedValue(undefined)
+  h.getNote.mockResolvedValue(undefined)
+  h.resolveTenantFromEnv.mockReturnValue({ senderDomain: 'tee-admin.com', publicName: 'Toronto East Christadelphians' })
+})
+
+describe('POST /api/email/send-one — guards', () => {
+  it('401 when unauthenticated', async () => {
+    h.auth.mockResolvedValue(null)
+    const res = await POST(req({ reason: 'newsletter', to: 'a@b.com', permission: true }))
+    expect(res.status).toBe(401)
+    expect(h.sendEmail).not.toHaveBeenCalled()
+  })
+
+  it('403 when not owner/admin', async () => {
+    h.auth.mockResolvedValue({ user: { email: 'm@x.com', role: ROLES.MEMBER } })
+    const res = await POST(req({ reason: 'newsletter', to: 'a@b.com', permission: true }))
+    expect(res.status).toBe(403)
+    expect(h.sendEmail).not.toHaveBeenCalled()
+  })
+
+  it('403 when permission attestation is missing/false', async () => {
+    const res = await POST(req({ reason: 'newsletter', to: 'a@b.com' }))
+    expect(res.status).toBe(403)
+    const res2 = await POST(req({ reason: 'newsletter', to: 'a@b.com', permission: false }))
+    expect(res2.status).toBe(403)
+    expect(h.sendEmail).not.toHaveBeenCalled()
+  })
+
+  it('400 on an unsupported reason (e.g. business-meeting)', async () => {
+    const res = await POST(req({ reason: 'business-meeting', to: 'a@b.com', permission: true }))
+    expect(res.status).toBe(400)
+    expect(h.sendEmail).not.toHaveBeenCalled()
+  })
+
+  it('400 on an invalid email', async () => {
+    const res = await POST(req({ reason: 'newsletter', to: 'not-an-email', permission: true }))
+    expect(res.status).toBe(400)
+    expect(h.sendEmail).not.toHaveBeenCalled()
+  })
+
+  it('422 when there is no content to render', async () => {
+    h.getEmailContent.mockResolvedValue([])
+    const res = await POST(req({ reason: 'newsletter', to: 'a@b.com', permission: true }))
+    expect(res.status).toBe(422)
+    expect(h.sendEmail).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/email/send-one — sends', () => {
+  it('sends 1:1 with the canonical envelope and does NOT clear the pending note', async () => {
+    const res = await POST(
+      req({ reason: 'newsletter', to: 'Donna@Example.com', recipientName: 'Donna Webb', permission: true })
+    )
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.ok).toBe(true)
+    expect(json.to).toBe('donna@example.com') // normalized
+
+    expect(h.sendEmail).toHaveBeenCalledTimes(1)
+    const arg = h.sendEmail.mock.calls[0][0]
+    expect(arg.to).toBe('donna@example.com')
+    expect(arg.from).toContain('communications@tee-admin.com') // canonical sender, not noreply@
+    expect(arg.replyTo).toBe('teerecbro@gmail.com')
+    expect(arg.subject).toContain('Newsletter')
+    expect(arg.body).toContain('news')
+
+    // A one-off side-send must never clear the broadcast's pending note.
+    expect(h.clearNote).not.toHaveBeenCalled()
+  })
+
+  it('uses the type pending note when no note is supplied', async () => {
+    h.getNote.mockResolvedValue('Special reminder')
+    const res = await POST(req({ reason: 'newsletter', to: 'a@b.com', permission: true }))
+    expect(res.status).toBe(200)
+    expect(h.getNote).toHaveBeenCalledWith('newsletter')
+    // note is threaded into the render
+    expect(h.getEmailContent).toHaveBeenCalledWith('newsletter', 'Special reminder')
+    const json = await res.json()
+    expect(json.hadNote).toBe(true)
+  })
+
+  it('502 when SES send throws', async () => {
+    h.sendEmail.mockRejectedValue(new Error('SES down'))
+    const res = await POST(req({ reason: 'newsletter', to: 'a@b.com', permission: true }))
+    expect(res.status).toBe(502)
+  })
+})

--- a/apps/next/utils/email/email-send.tsx
+++ b/apps/next/utils/email/email-send.tsx
@@ -102,6 +102,29 @@ const senders = {
   },
 }
 
+/**
+ * The From / Reply-To / Subject envelope for a reason, branded per tenant.
+ *
+ * Exported so a 1:1 send (e.g. the direct-recipient send that honours a specific
+ * request) produces the SAME envelope as the broadcast — same canonical
+ * `communications@` sender, same branded subject + Toronto-dated suffix — so a
+ * one-off never sends from a different address (sender reputation is per-address).
+ * Mirrors the inline construction in `emailSend` below (lines ~226–231); keep in
+ * sync.
+ */
+export function buildEmailEnvelope(
+  reason: emailReasons,
+  tenant: TenantConfig,
+  opts: { test?: boolean } = {}
+): { from: string; replyTo: string; subject: string } {
+  const today = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Toronto' })
+  return {
+    from: `"${senderDisplayName(reason, tenant)}" <${SENDER_LOCAL_PART}@${tenant.senderDomain}>`,
+    replyTo: senders[reason]?.replyTo ?? REPLY_TO,
+    subject: `${opts.test ? '[TEST] ' : ''}${subjectFor(reason, tenant)} ${today}`,
+  }
+}
+
 export type emailSendProps = {
   reason: emailReasons
   emailHtml: string

--- a/apps/next/utils/email/sesClient.ts
+++ b/apps/next/utils/email/sesClient.ts
@@ -61,9 +61,18 @@ export interface SendEmailProps {
    * `resolveTenantFromEnv()` (DEPLOYMENT_NAME → 'tee' default).
    */
   tenant?: TenantConfig
+  /**
+   * Explicit From-address (e.g. the canonical `"Name" <communications@domain>`
+   * newsletter sender). When omitted, uses the tenant's `noreply@` transactional
+   * sender. Pass this for content that must go from the same address as its
+   * broadcast, so sender reputation stays on one address.
+   */
+  from?: string
+  /** Optional Reply-To (e.g. the Recording Brother). */
+  replyTo?: string
 }
 
-export async function sendEmail({ to, subject, body, textBody, tenant }: SendEmailProps): Promise<void> {
+export async function sendEmail({ to, subject, body, textBody, tenant, from, replyTo }: SendEmailProps): Promise<void> {
   if (!emailsEnabled()) {
     console.log(
       `[sendEmail] Skipped — EMAILS_ENABLED=false (deployment=${process.env.DEPLOYMENT_NAME ?? 'unknown'}, to=${to})`
@@ -75,10 +84,11 @@ export async function sendEmail({ to, subject, body, textBody, tenant }: SendEma
   const sesClient = getSesClient()
 
   const emailCmd = new SendEmailCommand({
-    FromEmailAddress: `"${resolvedTenant.senderDisplayName}" <noreply@${resolvedTenant.senderDomain}>`,
+    FromEmailAddress: from ?? `"${resolvedTenant.senderDisplayName}" <noreply@${resolvedTenant.senderDomain}>`,
     Destination: {
       ToAddresses: [to],
     },
+    ...(replyTo && { ReplyToAddresses: [replyTo] }),
     Content: {
       Simple: {
         Subject: {

--- a/packages/app/features/email-sender/direct-recipient-send.tsx
+++ b/packages/app/features/email-sender/direct-recipient-send.tsx
@@ -1,0 +1,399 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import {
+  Adapt,
+  Button,
+  Card,
+  Checkbox,
+  Heading,
+  Input,
+  Paragraph,
+  Select,
+  Separator,
+  Sheet,
+  Spinner,
+  Text,
+  XStack,
+  YStack,
+} from '@my/ui'
+import { Check, Search, Send, X, UserCheck } from '@tamagui/lucide-icons'
+import {
+  searchPeople,
+  sendToOneRecipient,
+  getPendingNote,
+  type DirectSendPerson,
+} from '../../provider/get-data'
+import { EmailReasonType, AuthSession } from '@my/app/types'
+
+/**
+ * Direct-recipient send (Issue #127). A permission-gated, 1:1 send for honouring
+ * a SPECIFIC request — someone who opted out of the standing list but asked for
+ * this one email, or a visitor who wants a specific bulletin.
+ *
+ * It deliberately IGNORES test mode (real content → the requesting person) and so
+ * requires an explicit permission attestation. It NEVER subscribes the recipient
+ * or touches the contact list — the server route (`/api/email/send-one`) does the
+ * actual 1:1 send and re-checks the attestation.
+ *
+ * Shared-package rule: no next-auth/next imports — `session` arrives as a prop.
+ */
+
+const REASON_OPTIONS: { id: EmailReasonType; label: string }[] = [
+  { id: 'newsletter', label: 'Newsletter' },
+  { id: 'recap', label: 'Memorial recap' },
+  { id: 'bible-class', label: 'Bible Class' },
+  { id: 'sunday-school', label: 'Sunday School' },
+]
+
+function reasonLabel(reason: string): string {
+  return REASON_OPTIONS.find((r) => r.id === reason)?.label ?? reason
+}
+
+export interface DirectRecipientSendProps {
+  session: AuthSession | null
+}
+
+export const DirectRecipientSend: React.FC<DirectRecipientSendProps> = ({ session }) => {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<DirectSendPerson[]>([])
+  const [searching, setSearching] = useState(false)
+
+  const [selected, setSelected] = useState<DirectSendPerson | null>(null)
+  const [toEmail, setToEmail] = useState<string>('')
+
+  const [reason, setReason] = useState<EmailReasonType | ''>('')
+  const [noteHasNote, setNoteHasNote] = useState<boolean | null>(null)
+
+  const [permission, setPermission] = useState(false)
+  const [confirming, setConfirming] = useState(false)
+  const [sending, setSending] = useState(false)
+  const [result, setResult] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+
+  // Debounced people search (name OR email). Skips while a person is selected.
+  useEffect(() => {
+    if (selected) return
+    const q = query.trim()
+    if (q.length < 2) {
+      setResults([])
+      return
+    }
+    let cancelled = false
+    setSearching(true)
+    const handle = setTimeout(async () => {
+      const people = await searchPeople(q)
+      if (!cancelled) {
+        setResults(people)
+        setSearching(false)
+      }
+    }, 300)
+    return () => {
+      cancelled = true
+      clearTimeout(handle)
+    }
+  }, [query, selected])
+
+  // When a type is chosen, fetch whether a note is attached (for the confirm).
+  useEffect(() => {
+    if (!reason) {
+      setNoteHasNote(null)
+      return
+    }
+    let cancelled = false
+    getPendingNote(reason).then((res) => {
+      if (!cancelled) setNoteHasNote(!!res.note)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [reason])
+
+  const selectPerson = (person: DirectSendPerson) => {
+    setSelected(person)
+    setToEmail(person.email)
+    setResults([])
+    setQuery(person.name)
+    setResult(null)
+  }
+
+  const clearPerson = () => {
+    setSelected(null)
+    setToEmail('')
+    setQuery('')
+    setConfirming(false)
+  }
+
+  const resetAll = () => {
+    setSelected(null)
+    setToEmail('')
+    setQuery('')
+    setReason('')
+    setPermission(false)
+    setConfirming(false)
+    setNoteHasNote(null)
+  }
+
+  const canReview = !!selected && !!toEmail && !!reason && permission && !sending
+
+  const doSend = async () => {
+    if (!selected || !toEmail || !reason) return
+    setSending(true)
+    setResult(null)
+    const res = await sendToOneRecipient({
+      reason,
+      to: toEmail,
+      recipientName: selected.name,
+      permission: true,
+    })
+    setSending(false)
+    setConfirming(false)
+    if (res.ok) {
+      setResult({
+        type: 'success',
+        text: `Sent ${reasonLabel(reason)} to ${selected.name} <${toEmail}>.`,
+      })
+      resetAll()
+    } else {
+      setResult({ type: 'error', text: res.error || 'Send failed.' })
+    }
+  }
+
+  return (
+    <Card elevate bordered padding="$4" backgroundColor="$blue2" borderColor="$blue6">
+      <YStack gap="$3">
+        <XStack gap="$2" alignItems="center">
+          <UserCheck size={18} color="$blue10" />
+          <Heading size={4} color="$blue11">
+            Send to a specific requester
+          </Heading>
+        </XStack>
+        <Text fontSize="$3" color="$blue10">
+          One-off send to a single person who has explicitly asked for an email — even if they’re not
+          on the mailing list. This ignores Test Mode and sends the real email to the address below.
+          It does not subscribe them or change any list.
+        </Text>
+
+        {/* 1. Recipient search */}
+        {selected ? (
+          <Card bordered padding="$3" backgroundColor="$background">
+            <XStack gap="$3" alignItems="center">
+              <YStack flex={1}>
+                <Text fontWeight="700">{selected.name}</Text>
+                <Text fontSize="$2" color="$color10">
+                  {selected.ecclesia ?? ''}
+                </Text>
+              </YStack>
+              <Button size="$2" chromeless icon={X} onPress={clearPerson}>
+                Change
+              </Button>
+            </XStack>
+
+            {/* Which address (when the person has more than one) */}
+            {selected.emails.length > 1 ? (
+              <YStack gap="$1" marginTop="$3">
+                <Text fontSize="$2" fontWeight="600">
+                  Send to which address
+                </Text>
+                <Select value={toEmail} onValueChange={setToEmail}>
+                  <Select.Trigger minWidth={260} iconAfter={null} backgroundColor="$background">
+                    <Select.Value placeholder="Choose an address…" />
+                  </Select.Trigger>
+                  <Adapt when="sm" platform="touch">
+                    <Sheet native modal dismissOnSnapToBottom>
+                      <Sheet.Frame>
+                        <Sheet.ScrollView>
+                          <Adapt.Contents />
+                        </Sheet.ScrollView>
+                      </Sheet.Frame>
+                      <Sheet.Overlay animation="lazy" enterStyle={{ opacity: 0 }} exitStyle={{ opacity: 0 }} />
+                    </Sheet>
+                  </Adapt>
+                  <Select.Content zIndex={200000 as any}>
+                    <Select.Viewport>
+                      <Select.Group>
+                        {selected.emails.map((addr, idx) => (
+                          <Select.Item key={addr} index={idx} value={addr}>
+                            <Select.ItemText>{addr}</Select.ItemText>
+                            <Select.ItemIndicator>
+                              <Check size={16} />
+                            </Select.ItemIndicator>
+                          </Select.Item>
+                        ))}
+                      </Select.Group>
+                    </Select.Viewport>
+                  </Select.Content>
+                </Select>
+              </YStack>
+            ) : (
+              <Text fontSize="$2" color="$color10" marginTop="$2">
+                {toEmail}
+              </Text>
+            )}
+          </Card>
+        ) : (
+          <YStack gap="$2">
+            <XStack gap="$2" alignItems="center">
+              <Search size={16} color="$blue10" />
+              <Text fontSize="$3" fontWeight="600">
+                Find the person (name or email)
+              </Text>
+            </XStack>
+            <Input
+              value={query}
+              onChangeText={setQuery}
+              placeholder="Start typing a name or email…"
+              backgroundColor="$background"
+            />
+            {searching ? (
+              <XStack gap="$2" alignItems="center" padding="$2">
+                <Spinner size="small" />
+                <Text fontSize="$2" color="$color10">
+                  Searching…
+                </Text>
+              </XStack>
+            ) : null}
+            {!searching && results.length > 0 ? (
+              <YStack gap="$1" borderWidth={1} borderColor="$borderColor" borderRadius="$3" padding="$2">
+                {results.slice(0, 8).map((person) => (
+                  <Button
+                    key={person.id}
+                    size="$3"
+                    chromeless
+                    justifyContent="flex-start"
+                    onPress={() => selectPerson(person)}
+                  >
+                    <YStack alignItems="flex-start">
+                      <Text fontWeight="600">{person.name}</Text>
+                      <Text fontSize="$2" color="$color10">
+                        {person.email}
+                        {person.ecclesia ? ` · ${person.ecclesia}` : ''}
+                      </Text>
+                    </YStack>
+                  </Button>
+                ))}
+              </YStack>
+            ) : null}
+            {!searching && query.trim().length >= 2 && results.length === 0 ? (
+              <Text fontSize="$2" color="$color10">
+                No matches — check the spelling, or try their email.
+              </Text>
+            ) : null}
+          </YStack>
+        )}
+
+        {/* 2. Email type */}
+        <YStack gap="$1">
+          <Text fontSize="$3" fontWeight="600">
+            Which email did they request?
+          </Text>
+          <Select value={reason} onValueChange={(v) => setReason(v as EmailReasonType)}>
+            <Select.Trigger minWidth={260} iconAfter={null} backgroundColor="$background">
+              <Select.Value placeholder="Select an email type…" />
+            </Select.Trigger>
+            <Adapt when="sm" platform="touch">
+              <Sheet native modal dismissOnSnapToBottom>
+                <Sheet.Frame>
+                  <Sheet.ScrollView>
+                    <Adapt.Contents />
+                  </Sheet.ScrollView>
+                </Sheet.Frame>
+                <Sheet.Overlay animation="lazy" enterStyle={{ opacity: 0 }} exitStyle={{ opacity: 0 }} />
+              </Sheet>
+            </Adapt>
+            <Select.Content zIndex={200000 as any}>
+              <Select.Viewport>
+                <Select.Group>
+                  {REASON_OPTIONS.map((opt, idx) => (
+                    <Select.Item key={opt.id} index={idx} value={opt.id}>
+                      <Select.ItemText>{opt.label}</Select.ItemText>
+                      <Select.ItemIndicator>
+                        <Check size={16} />
+                      </Select.ItemIndicator>
+                    </Select.Item>
+                  ))}
+                </Select.Group>
+              </Select.Viewport>
+            </Select.Content>
+          </Select>
+        </YStack>
+
+        {/* 3. Permission attestation (required) */}
+        <XStack gap="$3" alignItems="center">
+          <Checkbox
+            checked={permission}
+            onCheckedChange={(c) => setPermission(!!c)}
+            aria-label="Permission attestation"
+            size="$4"
+          >
+            <Checkbox.Indicator>
+              <Check />
+            </Checkbox.Indicator>
+          </Checkbox>
+          <Text flex={1} fontSize="$3">
+            I have received permission from the owner of this email address to send this email to them.
+          </Text>
+        </XStack>
+
+        <Separator />
+
+        {/* 4. Review → confirm → send */}
+        {confirming ? (
+          <Card bordered padding="$4" backgroundColor="$background" borderColor="$blue7">
+            <YStack gap="$2">
+              <Text fontSize="$3" color="$color10">
+                Please confirm:
+              </Text>
+              <Text>
+                <Text fontWeight="700">Sending to: </Text>
+                {selected?.name} &lt;{toEmail}&gt;
+              </Text>
+              <Text>
+                <Text fontWeight="700">Email Type: </Text>
+                {reasonLabel(reason)}
+              </Text>
+              <Text color="$color10">
+                {noteHasNote ? 'Includes the saved note for this email.' : 'No note attached.'}
+              </Text>
+              <XStack gap="$3" marginTop="$2">
+                <Button
+                  theme="blue"
+                  icon={sending ? undefined : Send}
+                  disabled={sending}
+                  onPress={doSend}
+                >
+                  {sending ? 'Sending…' : 'Send Now'}
+                </Button>
+                <Button chromeless disabled={sending} onPress={() => setConfirming(false)}>
+                  Cancel
+                </Button>
+              </XStack>
+            </YStack>
+          </Card>
+        ) : (
+          <Button
+            theme="blue"
+            icon={Send}
+            disabled={!canReview}
+            onPress={() => {
+              setResult(null)
+              setConfirming(true)
+            }}
+          >
+            Review &amp; Send
+          </Button>
+        )}
+
+        {result ? (
+          <Card
+            bordered
+            padding="$3"
+            backgroundColor={result.type === 'success' ? '$green2' : '$red2'}
+            borderColor={result.type === 'success' ? '$green7' : '$red7'}
+          >
+            <Text color={result.type === 'success' ? '$green11' : '$red11'}>{result.text}</Text>
+          </Card>
+        ) : null}
+      </YStack>
+    </Card>
+  )
+}

--- a/packages/app/features/email-sender/index.tsx
+++ b/packages/app/features/email-sender/index.tsx
@@ -24,6 +24,7 @@ import { ROLES } from '@my/app/provider/auth/auth-roles'
 import { Check, Send, Mail, AlertCircle, Newspaper, Calendar, Users } from '@tamagui/lucide-icons'
 import { sendEmail, sendNewsAlert, getContactsList, savePendingNote, getPendingNote, clearPendingNote, getRecentEvents, getActiveNews } from '../../provider/get-data'
 import { CustomEmailCreator } from '../custom-email-creator'
+import { DirectRecipientSend } from './direct-recipient-send'
 import { EmailListTypeKeys, EmailReasonType, AuthSession, AuthStatus } from '@my/app/types'
 import { Event } from '@my/app/types/events'
 import { NewsItem, isNewsActive } from '@my/app/types/news'
@@ -594,6 +595,11 @@ export const EmailSender: React.FC<EmailSenderProps> = ({ session, status = 'aut
               </Text>
             ) : null}
           </Card>
+
+          {/* Direct-recipient send (Issue #127) — one-off, permission-gated 1:1
+              send to someone who explicitly requested an email. Sits under TEST
+              MODE and ignores it by design. */}
+          <DirectRecipientSend session={session} />
 
           {/* Shared News + Events composer (Issue #57). One place to pick a
               News item OR an Event and send it to a chosen audience. */}

--- a/packages/app/provider/get-data.ts
+++ b/packages/app/provider/get-data.ts
@@ -184,6 +184,69 @@ export const clearPendingNote = async (
   return { ok: true }
 }
 
+export interface DirectSendPerson {
+  id: string
+  name: string
+  email: string
+  ecclesia?: string
+  emails: string[]
+}
+
+/**
+ * Lightweight name-or-email people search for the direct-recipient send.
+ * Cross-platform safe (API_PATH). Returns members (one row per person) with
+ * their known email addresses so the caller can pick which to send to.
+ */
+export const searchPeople = async (query: string): Promise<DirectSendPerson[]> => {
+  const q = query.trim()
+  if (q.length < 2) return []
+  const url = `${API_PATH}api/people?search=${encodeURIComponent(q)}&includeEmails=true`
+  const response = await fetch(url, { cache: 'no-store' })
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok || !Array.isArray(data?.members)) return []
+  return (data.members as any[]).map((m) => {
+    const extra = Array.isArray(m.emails)
+      ? m.emails.map((e: any) => (typeof e === 'string' ? e : e?.email)).filter(Boolean)
+      : []
+    const unique = Array.from(
+      new Set([m.email, ...extra].filter(Boolean).map((e: string) => e.toLowerCase()))
+    )
+    return {
+      id: m.id,
+      name: m.name,
+      email: m.email,
+      ecclesia: m.ecclesia,
+      emails: unique,
+    }
+  })
+}
+
+/**
+ * Send ONE email of a given type to ONE explicitly-requesting recipient.
+ * Bypasses TEST MODE by design; requires an explicit permission attestation
+ * (also re-checked server-side). Does NOT subscribe the recipient or touch the
+ * contact list.
+ */
+export const sendToOneRecipient = async (params: {
+  reason: emailReasons
+  to: string
+  recipientName?: string
+  permission: boolean
+}): Promise<{ ok: boolean; subject?: string; error?: string }> => {
+  const url = `${API_PATH}api/email/send-one`
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+    cache: 'no-store',
+  })
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok || !data?.ok) {
+    return { ok: false, error: data.error || `Request failed (${response.status})` }
+  }
+  return { ok: true, subject: data.subject }
+}
+
 /**
  * Recent admin events. Cross-platform safe (uses API_PATH, so it works under Expo,
  * not just web). Returns the raw array; callers apply their own filter (e.g. the


### PR DESCRIPTION
Closes #127.

## What
A **'Send to a specific requester'** panel on the Email Sender page (under TEST MODE) to send ONE email of a chosen type to ONE person who explicitly asked for it — even if they're **not on the mailing list**. Built for the case where a member opted out of the standing list but requested this one newsletter; also covers visiting brethren wanting a specific bulletin.

## How it's safe
- **1:1 only.** New route `POST /api/email/send-one` renders the *same* content as the normal send (`getEmailContent(reason)`) and sends via `sendEmail()` to the supplied address. It is **not** the topic broadcast.
- **Never re-subscribes / never mutates the contact list.** Donna stays opted-out; this is a one-off honoring her explicit request.
- **Ignores TEST MODE by design** → gated by an explicit **permission attestation** ("I have received permission…") that is **re-checked server-side** (403 without it). Owner/admin only. Validates reason + email.
- **Same canonical envelope as the broadcast** — new exported `buildEmailEnvelope` gives the 1:1 send the `communications@` sender + branded subject, so a one-off never sends from a different address (sender reputation stays on one address). `sendEmail()` gains optional `from`/`replyTo`.

## UI
Autocomplete (name **or** email, via `/api/people`) → pick person → email-type dropdown → required permission checkbox → confirm dialog (`Sending to: Name <email>` · type · note-state · **Send Now**).

## Also fixes
A pre-existing **`/api/people` 500**: the search filter did `member.email.toLowerCase()` with no null-guard → crashes now that emailless visiting-speaker records exist (`NOEMAIL#` sentinel). Null-guarded.

## Verified (dev, real creds)
- Guards: 401 / 403 (role) / 403 (no permission) / 400 (bad reason) / 400 (bad email) / 422 (no content).
- **Real send**: newsletter to my own inbox from `communications@tee-admin.com`, subject `Toronto East Christadelphians Newsletter 2026-07-30`.
- Search resolves the requester (Donna Webb → dmlwebb56@gmail.com).
- 9 route unit tests + typecheck green.

## Notes / follow-ups
- The confirm shows note/no-note from the type's pending note; the side-send **does not clear** it (belongs to the real broadcast).
- Durable audit log is currently structured `console.log` (who → whom, reason, time). A DynamoDB audit record could follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)