### PR TITLE
Identity: make primary/secondary emails per profile real — stop orphan duplicates (#129)

### DIFF
--- a/apps/next/app/api/user/emails/route.ts
+++ b/apps/next/app/api/user/emails/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { randomBytes } from 'crypto'
 import { auth } from '../../../../utils/auth'
 import { userRepository } from '@my/app/provider/dynamodb/repositories/user-repository'
+import { personRepository } from '@my/app/provider/dynamodb/repositories/person-repository'
 import { sendEmail } from '../../../../utils/email/sesClient'
 import { getPublicOptInCount } from '../../../../utils/email/public-topics'
 
@@ -197,13 +198,29 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Check if email already exists
+    const normalized = email.toLowerCase()
+
+    // Check if email already exists (legacy USER# store)
     const existing = await userRepository.getEmails(session.user.email)
-    if (existing.items.some(e => e.email.toLowerCase() === email.toLowerCase())) {
+    if (existing.items.some(e => e.email.toLowerCase() === normalized)) {
       return NextResponse.json(
         { error: 'This email address is already added' },
         { status: 409 }
       )
+    }
+
+    // Resolve the acting person, and guard against attaching an address that
+    // already belongs to a DIFFERENT person — silently doing so would merge two
+    // identities. (Resolves via any address now that getByEmail sees secondaries.)
+    const person = await personRepository.getByEmail(session.user.email.toLowerCase())
+    if (person) {
+      const owners = await personRepository.getAllPersonsByEmail(normalized)
+      if (owners.some(p => p.personId !== person.personId)) {
+        return NextResponse.json(
+          { error: 'That email is already associated with another person in the directory.' },
+          { status: 409 }
+        )
+      }
     }
 
     const emailId = generateEmailId()
@@ -211,11 +228,34 @@ export async function POST(request: NextRequest) {
 
     await userRepository.addEmail(session.user.email, {
       emailId,
-      email: email.toLowerCase(),
+      email: normalized,
       verified: false,
       order,
       isPrimary: false,
     })
+
+    // Mirror the address onto the PersonRecord as a SECONDARY EMAIL# item, so it
+    // resolves (via GSI1) to this person. Without this the verify/lookup flow
+    // can't find the owner and mints a duplicate orphan profile. Best-effort:
+    // never fail the request if this half hiccups (the USER# add already stuck).
+    if (person) {
+      try {
+        const pEmails = await personRepository.getEmails(person.personId)
+        const alreadyOnPerson = pEmails.some(e => e.email.toLowerCase() === normalized)
+        if (!alreadyOnPerson) {
+          await personRepository.addEmail(person.personId, {
+            email: normalized,
+            emailType: 'secondary',
+            order: pEmails.length,
+            verified: false,
+            sesSubscribed: false,
+            sesStatus: 'active',
+          })
+        }
+      } catch (err) {
+        console.error('[user/emails] failed to mirror secondary email to PersonRecord:', err)
+      }
+    }
 
     return NextResponse.json({
       success: true,

--- a/apps/next/tests/auth/unified-people-auth.test.ts
+++ b/apps/next/tests/auth/unified-people-auth.test.ts
@@ -83,7 +83,7 @@ describe('Unified People Auth Integration', () => {
     })
 
     it('should normalize email to lowercase for consistent lookups', async () => {
-      mockSend.mockResolvedValueOnce({ Items: [] })
+      mockSend.mockResolvedValueOnce({ Items: [] }).mockResolvedValueOnce({ Items: [] })
 
       await personRepository.getByEmail('Test@Example.COM')
 
@@ -181,7 +181,7 @@ describe('Unified People Auth Integration', () => {
     })
 
     it('should return false for non-existent email', async () => {
-      mockSend.mockResolvedValueOnce({ Items: [] })
+      mockSend.mockResolvedValueOnce({ Items: [] }).mockResolvedValueOnce({ Items: [] })
 
       const exists = await personRepository.emailExists('nonexistent@example.com')
 

--- a/apps/next/tests/db/person-repository.test.ts
+++ b/apps/next/tests/db/person-repository.test.ts
@@ -115,11 +115,28 @@ describe('PersonRepository', () => {
     })
 
     it('should return null when person not found', async () => {
-      mockSend.mockResolvedValueOnce({ Items: [] })
+      // primary query empty, then the secondary fallback query is also empty
+      mockSend.mockResolvedValueOnce({ Items: [] }).mockResolvedValueOnce({ Items: [] })
 
       const result = await repository.getByEmail('nonexistent@example.com')
 
       expect(result).toBeNull()
+    })
+
+    it('resolves a person by a SECONDARY email when it is not anyone’s primary', async () => {
+      // 1) primary fast-path: no PROFILE has this as its primary
+      mockSend.mockResolvedValueOnce({ Items: [] })
+      // 2) fallback getAllPersonsByEmail: an EMAIL# item points at PERSON#p1
+      mockSend.mockResolvedValueOnce({
+        Items: [{ pkey: 'PERSON#p1', skey: 'EMAIL#e1', gsi1sk: 'PERSON#p1', email: 'secondary@example.com' }],
+      })
+      // 3) getAllPersonsByEmail loads the owning PROFILE via getById
+      const profile = { pkey: 'PERSON#p1', skey: 'PROFILE', personId: 'p1', primaryEmail: 'primary@example.com' }
+      mockSend.mockResolvedValueOnce({ Item: profile })
+
+      const result = await repository.getByEmail('secondary@example.com')
+
+      expect(result).toEqual(profile)
     })
   })
 
@@ -258,7 +275,8 @@ describe('PersonRepository', () => {
       })
 
       it('should return null when person not found', async () => {
-        mockSend.mockResolvedValueOnce({ Items: [] })
+        // primary query + secondary fallback query both empty
+        mockSend.mockResolvedValueOnce({ Items: [] }).mockResolvedValueOnce({ Items: [] })
 
         const result = await repository.getByEmailForAuth('nonexistent@example.com')
 
@@ -358,7 +376,8 @@ describe('PersonRepository', () => {
       })
 
       it('should return false when email does not exist', async () => {
-        mockSend.mockResolvedValueOnce({ Items: [] })
+        // primary query + secondary fallback query both empty
+        mockSend.mockResolvedValueOnce({ Items: [] }).mockResolvedValueOnce({ Items: [] })
 
         const result = await repository.emailExists('nonexistent@example.com')
 

--- a/apps/next/tests/user-emails-route.test.ts
+++ b/apps/next/tests/user-emails-route.test.ts
@@ -1,0 +1,93 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+/**
+ * POST /api/user/emails — adding a secondary email (Issue #129).
+ *
+ * The fix: the address must be mirrored onto the PersonRecord as a SECONDARY
+ * EMAIL# item so it resolves (GSI1) to this person — otherwise the verify/lookup
+ * flow can't find the owner and mints a duplicate orphan profile. And attaching
+ * an address that already belongs to a DIFFERENT person is a collision (409).
+ */
+
+const h = vi.hoisted(() => ({
+  auth: vi.fn(),
+  u_getEmails: vi.fn(),
+  u_addEmail: vi.fn(),
+  p_getByEmail: vi.fn(),
+  p_getAllPersonsByEmail: vi.fn(),
+  p_getEmails: vi.fn(),
+  p_addEmail: vi.fn(),
+}))
+
+vi.mock('../utils/auth', () => ({ auth: h.auth }))
+vi.mock('@my/app/provider/dynamodb/repositories/user-repository', () => ({
+  userRepository: { getEmails: h.u_getEmails, addEmail: h.u_addEmail },
+}))
+vi.mock('@my/app/provider/dynamodb/repositories/person-repository', () => ({
+  personRepository: {
+    getByEmail: h.p_getByEmail,
+    getAllPersonsByEmail: h.p_getAllPersonsByEmail,
+    getEmails: h.p_getEmails,
+    addEmail: h.p_addEmail,
+  },
+}))
+vi.mock('../utils/email/sesClient', () => ({ sendEmail: vi.fn() }))
+vi.mock('../utils/email/public-topics', () => ({ getPublicOptInCount: vi.fn() }))
+
+import { POST } from '../app/api/user/emails/route'
+
+const req = (body: any) => ({ json: async () => body }) as any
+const ME = { user: { email: 'gord@yahoo.com' } }
+const GORD = { personId: 'gord-1', primaryEmail: 'gord@yahoo.com' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.auth.mockResolvedValue(ME)
+  h.u_getEmails.mockResolvedValue({ items: [] })
+  h.u_addEmail.mockResolvedValue(undefined)
+  h.p_getByEmail.mockResolvedValue(GORD)
+  h.p_getAllPersonsByEmail.mockResolvedValue([]) // address free
+  h.p_getEmails.mockResolvedValue([])
+  h.p_addEmail.mockResolvedValue(undefined)
+})
+
+describe('POST /api/user/emails', () => {
+  it('401 when unauthenticated', async () => {
+    h.auth.mockResolvedValue(null)
+    const res = await POST(req({ email: 'x@y.com' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('400 on an invalid email', async () => {
+    const res = await POST(req({ email: 'not-an-email' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('mirrors the address onto the PersonRecord as a SECONDARY email', async () => {
+    const res = await POST(req({ email: 'Gord@Gmail.com' }))
+    expect(res.status).toBe(200)
+    // legacy USER# store still written
+    expect(h.u_addEmail).toHaveBeenCalledTimes(1)
+    // NEW: PersonRecord EMAIL# item written, lowercased, as secondary
+    expect(h.p_addEmail).toHaveBeenCalledTimes(1)
+    const [pid, rec] = h.p_addEmail.mock.calls[0]
+    expect(pid).toBe('gord-1')
+    expect(rec.email).toBe('gord@gmail.com')
+    expect(rec.emailType).toBe('secondary')
+  })
+
+  it('409 when the address already belongs to a DIFFERENT person', async () => {
+    h.p_getAllPersonsByEmail.mockResolvedValue([{ personId: 'someone-else' }])
+    const res = await POST(req({ email: 'shared@example.com' }))
+    expect(res.status).toBe(409)
+    expect(h.u_addEmail).not.toHaveBeenCalled()
+    expect(h.p_addEmail).not.toHaveBeenCalled()
+  })
+
+  it('does not double-add when the person already has the address', async () => {
+    h.p_getEmails.mockResolvedValue([{ email: 'gord@gmail.com', emailType: 'secondary' }])
+    const res = await POST(req({ email: 'gord@gmail.com' }))
+    expect(res.status).toBe(200)
+    expect(h.p_addEmail).not.toHaveBeenCalled()
+  })
+})

--- a/packages/app/provider/dynamodb/repositories/person-repository.ts
+++ b/packages/app/provider/dynamodb/repositories/person-repository.ts
@@ -125,15 +125,37 @@ export class PersonRepository extends BaseRepository<PersonRecord> {
   }
 
   /**
-   * Get person by email via GSI1
+   * Get person by email via GSI1 — resolves ANY of the person's addresses.
+   *
+   * A profile's PRIMARY email is the PROFILE item (gsi1sk = 'PERSON'); SECONDARY
+   * emails are EMAIL# items (gsi1sk = 'PERSON#<uuid>'). Historically this only
+   * matched the primary, so a lookup by a secondary returned null — which let the
+   * verify-otp/add-email flows mint a duplicate "orphan" person for an address
+   * that already belonged to someone. We now try the primary fast-path, then fall
+   * back to resolving the address as a secondary.
+   *
+   * If an address is shared by more than one person (e.g. a couple), this returns
+   * a single best-effort owner (primary-owner if any, else the first) and logs —
+   * shared-address disambiguation is handled by the caller where it matters.
    */
   async getByEmail(email: string): Promise<PersonRecord | null> {
-    const result = await this.query(
+    const lower = email.toLowerCase()
+    // Fast path: the address is a PRIMARY (on a PROFILE item).
+    const primary = await this.query(
       'gsi1pk = :gsi1pk AND gsi1sk = :gsi1sk',
-      { ':gsi1pk': `EMAIL#${email.toLowerCase()}`, ':gsi1sk': 'PERSON' },
+      { ':gsi1pk': `EMAIL#${lower}`, ':gsi1sk': 'PERSON' },
       { indexName: 'gsi1' }
     )
-    return result.items[0] || null
+    if (primary.items[0]) return primary.items[0]
+
+    // Fallback: the address is a SECONDARY (EMAIL# item) — resolve to its profile.
+    const owners = await this.getAllPersonsByEmail(lower)
+    if (owners.length > 1) {
+      console.warn(
+        `[getByEmail] "${lower}" resolves to ${owners.length} persons (shared address); returning first`
+      )
+    }
+    return owners[0] || null
   }
 
   /**
@@ -743,12 +765,9 @@ export class PersonRepository extends BaseRepository<PersonRecord> {
    * Uses GSI1 for O(1) email lookup - replaces scan-based getUserFromDynamoDB
    */
   async getByEmailForAuth(email: string): Promise<PersonAuthData | null> {
-    let person = await this.getByEmail(email)
-    if (!person) {
-      // Fallback: check secondary emails via begins_with query
-      const persons = await this.getAllPersonsByEmail(email)
-      person = persons[0] || null
-    }
+    // getByEmail now resolves secondary addresses itself (primary fast-path, then
+    // EMAIL#-item fallback) — no need for a separate secondary lookup here.
+    const person = await this.getByEmail(email)
     if (!person) return null
 
     return {


### PR DESCRIPTION
Part of #129 (Slice 1) · feeds Epic #55.

## Problem
Email↔person was treated as one-to-one, so multi-email fragmented identity:
- Adding a **secondary** email wrote only the legacy `USER#` store — the PersonRecord never learned the address.
- `getByEmail` matched only **primary** addresses (`gsi1sk = 'PERSON'`), so a lookup by a secondary returned `null` → `verify-otp` minted a **duplicate 'orphan' person** (blank name, `ecclesia: Unknown`). This is how Gord's `flswag@gmail.com` and others got orphaned.

## Fix
- **`getByEmail` resolves any address** — primary fast-path, then a fallback that resolves **secondary** `EMAIL#` items to their owning profile. Shared address (a couple) → returns a single best-effort owner + logs. Consolidates the identical fallback `getByEmailForAuth` already hand-rolled (removed the duplicate).
- **`/api/user/emails` POST mirrors the address onto the PersonRecord** as a `secondary` `EMAIL#` item, so it resolves via GSI1 to that person. Guards a **cross-person collision** (address already owned by someone else) with a 409. Default send = primary is unchanged.

## Verified end-to-end (dev, Hacker Ken test account)
The `/api/auth/dev-token` route resolves via `getByEmail`, so it's a clean probe:
1. **Before** adding the secondary → resolving it **404s** (the exact orphan trigger).
2. Add via `/api/user/emails` → success.
3. **After** → resolves to `ken.easson+hacker@gmail.com`, role intact → **no orphan**.

Test data cleaned up afterward (verified back to 404).

## Tests
`getByEmail` secondary-resolution + `/api/user/emails` dual-write/collision. Not-found mocks topped up for the new fallback query. **25 pass, typecheck clean.**

⚠️ Two **pre-existing** failures in `unified-people-auth.test.ts` (`normalize`, `hashed password`) fail on clean `main` too — unrelated (`createFromCredentials` doesn't call `getByEmail`).

## Not in this slice (tracked in #129)
- **Set-primary** action (promote a secondary — re-designate the key).
- **verify-otp** hardening is effectively covered (it calls `getByEmail`, now fixed) but a defensive check could be added.
- Data reconciliation: merge the existing dups, attach Gord's `flswag@`, RB office addresses (#58), couples/shared emails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)