### PR TITLE
CONSOLIDATED_CMS Phase 0 — Post/Block model + redactor + legacy adapter (anon-PII fix) (#131)

### DIFF
--- a/apps/next/app/api/news/[newsId]/route.ts
+++ b/apps/next/app/api/news/[newsId]/route.ts
@@ -1,7 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getNewsItemById } from '@my/app/services/news-service'
 import { isNewsActive } from '@my/app/types/news'
+import { auth } from '@/utils/auth'
+import { resolveViewer } from '@/utils/resolve-viewer'
+import { redactNewsForViewer } from '@/utils/redact-news'
+import { checkFeatureFlagFromDB } from '@my/app/features/feature-flags/use-feature-flag-wrapper'
+import { FEATURE_FLAGS } from '@my/app/features/feature-flags/feature-flags'
 
+/**
+ * Public news detail. PII read boundary mirrors the list route: behind the
+ * CONSOLIDATED_CMS flag the item is scrubbed via the block model for the
+ * resolved viewer; flag OFF → returned unchanged (byte-identical).
+ */
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ newsId: string }> }
@@ -12,7 +22,15 @@ export async function GET(
     if (!news || !isNewsActive(news)) {
       return NextResponse.json({ error: 'News item not found' }, { status: 404 })
     }
-    return NextResponse.json(news)
+
+    const session = await auth()
+    const flagOn = await checkFeatureFlagFromDB(FEATURE_FLAGS.CONSOLIDATED_CMS, session as any)
+    if (!flagOn) {
+      return NextResponse.json(news)
+    }
+
+    const viewer = await resolveViewer()
+    return NextResponse.json(redactNewsForViewer(news, viewer))
   } catch (error) {
     console.error('Error fetching news:', error)
     return NextResponse.json({ error: 'Failed to fetch news' }, { status: 500 })

--- a/apps/next/app/api/news/route.ts
+++ b/apps/next/app/api/news/route.ts
@@ -1,16 +1,39 @@
 import { NextResponse } from 'next/server'
 import { listNewsItems } from '@my/app/services/news-service'
+import { auth } from '@/utils/auth'
+import { resolveViewer } from '@/utils/resolve-viewer'
+import { redactNewsForViewer } from '@/utils/redact-news'
+import { checkFeatureFlagFromDB } from '@my/app/features/feature-flags/use-feature-flag-wrapper'
+import { FEATURE_FLAGS } from '@my/app/features/feature-flags/feature-flags'
 
 /**
  * Public News API — returns active news items (expired items are filtered out).
- * In single-tenant deployments this returns all active news. Multi-tenant
- * resolution via news-sharing-resolver is wired into the data layer for
- * future MULTI_TENANT_INIT use.
+ *
+ * PII read boundary (Consolidated CMS Phase 0, epic #131): behind the
+ * CONSOLIDATED_CMS flag, each item is run through the unified block model
+ * (`legacyToPost` → `redactPost`) for the resolved viewer, then projected back
+ * onto the NewsItem shape so the client contract is unchanged. This scrubs the
+ * anon web view of PII-bearing news (e.g. a `medical` update's body + flyers
+ * default to member-only reach — anon sees title + summary only).
+ *
+ * FLAG-GATED + ADDITIVE: when the flag is OFF the raw items are returned exactly
+ * as before (byte-identical) — the shared path is not mutated for un-flagged
+ * reasons. Flip the flag to 'everyone' to ship the scrub to all readers.
  */
 export async function GET() {
   try {
     const items = await listNewsItems({ includeExpired: false })
-    return NextResponse.json(items)
+
+    const session = await auth()
+    const flagOn = await checkFeatureFlagFromDB(FEATURE_FLAGS.CONSOLIDATED_CMS, session as any)
+    if (!flagOn) {
+      // Flag OFF → unchanged legacy behaviour (byte-identical).
+      return NextResponse.json(items)
+    }
+
+    const viewer = await resolveViewer()
+    const redacted = items.map((item) => redactNewsForViewer(item, viewer))
+    return NextResponse.json(redacted)
   } catch (error) {
     console.error('Error listing news (public):', error)
     return NextResponse.json({ error: 'Failed to list news' }, { status: 500 })

--- a/apps/next/tests/legacy-to-post.test.ts
+++ b/apps/next/tests/legacy-to-post.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest'
+import { legacyToPost } from '@my/app/utils/legacy-to-post'
+import { redactPost } from '@my/app/utils/redact-post'
+import { ANONYMOUS_VIEWER, type Viewer } from '@my/app/utils/viewer-pii'
+import type { Event } from '@my/app/types/events'
+import type { NewsItem } from '@my/app/types/news'
+import type { LocationBlock, PersonBlock, TextBlock } from '@my/app/types/post'
+
+const anon = ANONYMOUS_VIEWER
+const member: Viewer = { assurance: 'authenticated', role: 'member', tenant: 'Toronto East', email: 'm@x.z' }
+
+const baseEvent = {
+  id: 'e1',
+  createdBy: 'author',
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-02'),
+  active: true,
+  documents: [],
+} as unknown as Event
+
+function person(blocks: PersonBlock[], role: PersonBlock['role']) {
+  return blocks.find((b) => b.role === role)
+}
+
+// ── Funeral ─────────────────────────────────────────────────────────────────
+describe('legacyToPost — funeral', () => {
+  const funeral = {
+    ...baseEvent,
+    type: 'funeral',
+    title: 'Funeral of Tom Perks',
+    serviceDate: new Date('2026-03-01T15:00:00Z'),
+    deceased: { title: 'Brother', firstName: 'Tom', lastName: 'Perks', age: 84, obituary: 'obit text' },
+    aboutDeceased: 'tribute text',
+    description: 'Private family notes',
+    documents: [{ id: 'd', documentType: 'upload', fileName: 'f', originalName: 'order.pdf', fileUrl: 'u', fileSize: 1, mimeType: 'application/pdf', uploadedAt: new Date(), uploadedBy: 'x' }],
+    locations: {
+      service: { name: 'Toronto East Hall', city: 'Toronto', province: 'ON', address: '123 Main St', postalCode: 'M1 1M1' },
+      visitation: { name: 'The Perks home', address: '5 Elm Ave', privateResidence: true },
+    },
+  } as unknown as Event
+
+  const post = legacyToPost(funeral)
+  const persons = post.blocks.filter((b): b is PersonBlock => b.kind === 'person')
+  const locations = post.blocks.filter((b): b is LocationBlock => b.kind === 'location')
+
+  it('maps deceased → PersonBlock with name + bio(obituary+about) + title + age', () => {
+    const d = person(persons, 'deceased')!
+    expect(d.people[0].firstName).toBe('Tom')
+    expect(d.people[0].lastName).toBe('Perks')
+    expect(d.people[0].title).toBe('Brother')
+    expect(d.people[0].age).toBe(84)
+    expect(d.people[0].bio).toContain('tribute text')
+    expect(d.people[0].bio).toContain('obit text')
+  })
+
+  it('funeral → PII-bearing occasion → description text + flyer default to members reach', () => {
+    const text = post.blocks.find((b): b is TextBlock => b.kind === 'text')!
+    expect(text.visibility).toBe('members')
+    expect(text.containsPii).toBe(true)
+    const flyer = post.blocks.find((b) => b.kind === 'flyer')!
+    expect(flyer.visibility).toBe('members')
+  })
+
+  it('maps FuneralLocations → labelled LocationBlocks; private residence flagged', () => {
+    const service = locations.find((l) => l.label === 'Service')!
+    expect(service.address).toBe('123 Main St')
+    const visitation = locations.find((l) => l.label === 'Visitation')!
+    expect(visitation.privateResidence).toBe(true)
+  })
+
+  it('redacted for anon: first name only, bio dropped, private residence + members blocks removed', () => {
+    const r = redactPost(post, anon)!
+    const d = r.blocks.filter((b): b is PersonBlock => b.kind === 'person').find((b) => b.role === 'deceased')!
+    expect(d.people[0]).not.toHaveProperty('lastName')
+    expect(d.people[0]).not.toHaveProperty('bio')
+    // private-residence visitation dropped; service floored to venue+city
+    const locs = r.blocks.filter((b): b is LocationBlock => b.kind === 'location')
+    expect(locs.map((l) => l.label)).toEqual(['Service'])
+    expect(locs[0]).not.toHaveProperty('address')
+    // members-only text + flyer removed
+    expect(r.blocks.some((b) => b.kind === 'text')).toBe(false)
+    expect(r.blocks.some((b) => b.kind === 'flyer')).toBe(false)
+  })
+
+  it('newsletter-email channel = member tier: full names, full location, bio, members blocks kept', () => {
+    const r = redactPost(post, anon, { channel: 'newsletter-email' })!
+    const d = r.blocks.filter((b): b is PersonBlock => b.kind === 'person').find((b) => b.role === 'deceased')!
+    expect(d.people[0].lastName).toBe('Perks')
+    expect(d.people[0].bio).toContain('obit text')
+    const locs = r.blocks.filter((b): b is LocationBlock => b.kind === 'location')
+    expect(locs.map((l) => l.label).sort()).toEqual(['Service', 'Visitation'])
+    expect(locs.find((l) => l.label === 'Service')!.address).toBe('123 Main St')
+    expect(r.blocks.some((b) => b.kind === 'text')).toBe(true)
+    expect(r.blocks.some((b) => b.kind === 'flyer')).toBe(true)
+  })
+})
+
+// ── Baptism ──────────────────────────────────────────────────────────────────
+describe('legacyToPost — baptism', () => {
+  const baptism = {
+    ...baseEvent,
+    type: 'baptism',
+    title: 'Baptism',
+    baptismDate: new Date('2026-09-01T18:00:00Z'),
+    candidate: { firstName: 'Joshua', lastName: 'Archibald', testimony: 'my testimony', baptismStatement: 'stmt' },
+    aboutCandidate: 'A private bio',
+    sponsors: [{ firstName: 'Gord', lastName: 'Easson', role: 'proposer' }],
+    location: { name: 'TE Hall', city: 'Toronto', address: '123 Main St' },
+  } as unknown as Event
+
+  const post = legacyToPost(baptism)
+  const persons = post.blocks.filter((b): b is PersonBlock => b.kind === 'person')
+
+  it('occasion is baptism', () => {
+    expect(post.occasion).toEqual(['baptism'])
+  })
+
+  it('candidate → PersonBlock with bio combining about + testimony + statement', () => {
+    const c = person(persons, 'candidate')!
+    expect(c.people[0].firstName).toBe('Joshua')
+    expect(c.people[0].bio).toContain('A private bio')
+    expect(c.people[0].bio).toContain('my testimony')
+    expect(c.people[0].bio).toContain('stmt')
+  })
+
+  it('sponsors → PersonBlock with sub-role label', () => {
+    const s = person(persons, 'sponsor')!
+    expect(s.people[0]).toMatchObject({ firstName: 'Gord', lastName: 'Easson', label: 'proposer' })
+  })
+
+  it('redacted for anon: candidate first-name only, bio gone', () => {
+    const r = redactPost(post, anon)!
+    const c = r.blocks.filter((b): b is PersonBlock => b.kind === 'person').find((b) => b.role === 'candidate')!
+    expect(c.people[0]).toEqual({ firstName: 'Joshua' })
+  })
+})
+
+// ── Engagement ───────────────────────────────────────────────────────────────
+describe('legacyToPost — engagement', () => {
+  const engagement = {
+    ...baseEvent,
+    type: 'engagement',
+    title: 'Engagement',
+    engagementProposed: 'Brother Gord Easson',
+    engagementTo: 'Sister Jessica Millar',
+    engagementAnnouncement: 'We are pleased to announce…',
+  } as unknown as Event
+
+  const post = legacyToPost(engagement)
+
+  it('free-text engagement names → members-only TextBlock (containsPii)', () => {
+    const text = post.blocks.find((b): b is TextBlock => b.kind === 'text')!
+    expect(text.visibility).toBe('members')
+    expect(text.containsPii).toBe(true)
+    expect(text.body).toContain('Gord Easson')
+    expect(text.body).toContain('Jessica Millar')
+  })
+
+  it('anon sees no engagement text at all', () => {
+    const r = redactPost(post, anon)!
+    expect(r.blocks.some((b) => b.kind === 'text')).toBe(false)
+  })
+
+  it('member sees the engagement text', () => {
+    const r = redactPost(post, member)!
+    expect(r.blocks.some((b) => b.kind === 'text')).toBe(true)
+  })
+})
+
+// ── News ─────────────────────────────────────────────────────────────────────
+describe('legacyToPost — news', () => {
+  const baseNews = {
+    id: 'n1',
+    ecclesiaId: 'Toronto East',
+    authorId: 'author',
+    title: 'Update',
+    publishedAt: new Date('2026-05-01'),
+    expiresAt: new Date('2026-05-22'),
+    durationWeeks: 3,
+    sharingScope: 'own',
+    createdAt: new Date('2026-05-01'),
+    updatedAt: new Date('2026-05-01'),
+  } as unknown as NewsItem
+
+  it('medical news → occasion [news,medical], body + flyer default members', () => {
+    const item: NewsItem = { ...baseNews, category: 'medical', body: 'Sister Jane is in hospital', documents: [{ id: 'd', documentType: 'upload', fileName: 'f', originalName: 'x.pdf', fileUrl: 'u', fileSize: 1, mimeType: 'application/pdf', uploadedAt: new Date(), uploadedBy: 'x' }] }
+    const post = legacyToPost(item)
+    expect(post.occasion).toEqual(['news', 'medical'])
+    const text = post.blocks.find((b): b is TextBlock => b.kind === 'text')!
+    expect(text.visibility).toBe('members')
+    expect(post.blocks.find((b) => b.kind === 'flyer')!.visibility).toBe('members')
+    // anon sees neither body nor flyer
+    const r = redactPost(post, anon)!
+    expect(r.blocks).toHaveLength(0)
+    // member sees both
+    expect(redactPost(post, member)!.blocks).toHaveLength(2)
+  })
+
+  it('general news → occasion [news], body stays public', () => {
+    const item: NewsItem = { ...baseNews, category: 'general', body: 'Hall repainted' }
+    const post = legacyToPost(item)
+    expect(post.occasion).toEqual(['news'])
+    const text = post.blocks.find((b): b is TextBlock => b.kind === 'text')!
+    expect(text.visibility).toBeUndefined()
+    expect(text.containsPii).toBe(false)
+    // anon still sees the body
+    expect(redactPost(post, anon)!.blocks.some((b) => b.kind === 'text')).toBe(true)
+  })
+
+  it('maps news lifecycle from publishedAt/expiresAt', () => {
+    const item: NewsItem = { ...baseNews, category: 'announcement', body: 'x' }
+    const post = legacyToPost(item)
+    expect(post.occasion).toEqual(['news', 'announcement'])
+    expect(post.lifecycle.publishDate).toBe(new Date('2026-05-01').toISOString())
+    expect(post.lifecycle.expiresAt).toBe(new Date('2026-05-22').toISOString())
+    expect(post.tenant).toBe('Toronto East')
+  })
+})

--- a/apps/next/tests/redact-post.test.ts
+++ b/apps/next/tests/redact-post.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from 'vitest'
+import { redactBlock, redactPost, canSee } from '@my/app/utils/redact-post'
+import { ANONYMOUS_VIEWER, type Viewer } from '@my/app/utils/viewer-pii'
+import type {
+  LinkBlock,
+  LocationBlock,
+  PersonBlock,
+  Post,
+  RegistrationBlock,
+  TextBlock,
+  TimeBlock,
+} from '@my/app/types/post'
+
+const anon = ANONYMOUS_VIEWER // anonymous / public-web
+const member: Viewer = { assurance: 'authenticated', role: 'member', tenant: 'Toronto East', email: 'm@x.z' }
+const admin: Viewer = { assurance: 'authenticated', role: 'admin', tenant: 'Toronto East', email: 'a@x.z' }
+// A recognized (email-token) viewer — capped at member reach on the web, but the
+// newsletter-email channel lifts them to member tier for PII.
+const recognized: Viewer = { assurance: 'recognized', role: 'member', tenant: 'Toronto East', email: 'r@x.z' }
+
+// ── PiiClass: name (PersonBlock) ─────────────────────────────────────────────
+describe('redactBlock — PiiClass name (PersonBlock)', () => {
+  const block: PersonBlock = {
+    id: 'p1',
+    kind: 'person',
+    role: 'candidate',
+    people: [{ firstName: 'Joshua', lastName: 'Archibald', ecclesia: 'Toronto East', title: 'Brother' }],
+  }
+
+  it('anon / public-web → first name only, no lastName on the object', () => {
+    const r = redactBlock(block, anon) as PersonBlock
+    expect(r.people[0]).toEqual({ firstName: 'Joshua', ecclesia: 'Toronto East', title: 'Brother' })
+    expect(r.people[0]).not.toHaveProperty('lastName')
+  })
+
+  it('authenticated member → full name', () => {
+    const r = redactBlock(block, member) as PersonBlock
+    expect(r.people[0].lastName).toBe('Archibald')
+  })
+
+  it('newsletter-email channel → full name even for a recognized viewer', () => {
+    const r = redactBlock(block, recognized, 'newsletter-email') as PersonBlock
+    expect(r.people[0].lastName).toBe('Archibald')
+  })
+})
+
+// ── PiiClass: bio (PersonBlock.bio) ──────────────────────────────────────────
+describe('redactBlock — PiiClass bio', () => {
+  const block: PersonBlock = {
+    id: 'p2',
+    kind: 'person',
+    role: 'deceased',
+    people: [{ firstName: 'Tom', lastName: 'Perks', bio: 'A long obituary', age: 84 }],
+  }
+
+  it('anon → bio omitted (name floored)', () => {
+    const r = redactBlock(block, anon) as PersonBlock
+    expect(r.people[0]).not.toHaveProperty('bio')
+    expect(r.people[0]).toEqual({ firstName: 'Tom', age: 84 })
+  })
+
+  it('member → bio shown', () => {
+    const r = redactBlock(block, member) as PersonBlock
+    expect(r.people[0].bio).toBe('A long obituary')
+  })
+
+  it('newsletter-email → bio shown', () => {
+    const r = redactBlock(block, recognized, 'newsletter-email') as PersonBlock
+    expect(r.people[0].bio).toBe('A long obituary')
+  })
+})
+
+// ── PiiClass: contact (PersonBlock.contact + RegistrationBlock) ──────────────
+describe('redactBlock — PiiClass contact', () => {
+  const person: PersonBlock = {
+    id: 'p3',
+    kind: 'person',
+    role: 'contact',
+    people: [{ firstName: 'Sue', lastName: 'Green', contact: '416-555-1212' }],
+  }
+  const reg: RegistrationBlock = {
+    id: 'r1',
+    kind: 'registration',
+    required: true,
+    registrationUrl: 'https://reg',
+    contactEmail: 'sue@x.z',
+    contactPhone: '416-555-1212',
+  }
+
+  it('anon → contact omitted from person', () => {
+    const r = redactBlock(person, anon) as PersonBlock
+    expect(r.people[0]).not.toHaveProperty('contact')
+  })
+
+  it('anon → registration email/phone dropped, url kept', () => {
+    const r = redactBlock(reg, anon) as RegistrationBlock
+    expect(r).not.toHaveProperty('contactEmail')
+    expect(r).not.toHaveProperty('contactPhone')
+    expect(r.registrationUrl).toBe('https://reg')
+    expect(r.required).toBe(true)
+  })
+
+  it('member → contact + registration email/phone shown', () => {
+    expect((redactBlock(person, member) as PersonBlock).people[0].contact).toBe('416-555-1212')
+    const r = redactBlock(reg, member) as RegistrationBlock
+    expect(r.contactEmail).toBe('sue@x.z')
+    expect(r.contactPhone).toBe('416-555-1212')
+  })
+
+  it('newsletter-email → contact shown', () => {
+    expect((redactBlock(person, recognized, 'newsletter-email') as PersonBlock).people[0].contact).toBe('416-555-1212')
+  })
+})
+
+// ── PiiClass: location-precise (LocationBlock) ───────────────────────────────
+describe('redactBlock — PiiClass location-precise', () => {
+  const block: LocationBlock = {
+    id: 'l1',
+    kind: 'location',
+    mode: 'geo',
+    label: 'Service',
+    venueName: 'Toronto East Hall',
+    city: 'Toronto',
+    province: 'ON',
+    country: 'Canada',
+    address: '123 Main St',
+    postalCode: 'M1 1M1',
+    lat: 43.7,
+    lng: -79.3,
+    directions: 'Turn left',
+    mapsUrl: 'https://maps',
+  }
+
+  it('anon → venue + city/province/country only; street/geo dropped', () => {
+    const r = redactBlock(block, anon) as LocationBlock
+    expect(r.venueName).toBe('Toronto East Hall')
+    expect(r.city).toBe('Toronto')
+    expect(r.province).toBe('ON')
+    expect(r.country).toBe('Canada')
+    expect(r.label).toBe('Service')
+    for (const k of ['address', 'postalCode', 'lat', 'lng', 'directions', 'mapsUrl']) {
+      expect(r).not.toHaveProperty(k)
+    }
+  })
+
+  it('member → full location', () => {
+    const r = redactBlock(block, member) as LocationBlock
+    expect(r.address).toBe('123 Main St')
+    expect(r.lat).toBe(43.7)
+  })
+
+  it('newsletter-email → full location for a recognized viewer', () => {
+    const r = redactBlock(block, recognized, 'newsletter-email') as LocationBlock
+    expect(r.address).toBe('123 Main St')
+  })
+
+  it('private residence → block dropped entirely for anon (returns null)', () => {
+    const home: LocationBlock = { id: 'l2', kind: 'location', mode: 'plain', venueName: 'The Smith home', address: '5 Elm', privateResidence: true }
+    expect(redactBlock(home, anon)).toBeNull()
+    expect(redactBlock(home, member)).not.toBeNull()
+    expect(redactBlock(home, recognized, 'newsletter-email')).not.toBeNull()
+  })
+})
+
+// ── PiiClass: none (TimeBlock / LinkBlock / TextBlock pass-through) ───────────
+describe('redactBlock — PiiClass none passes through', () => {
+  it('time block unchanged', () => {
+    const t: TimeBlock = { id: 't1', kind: 'time', label: 'Baptism', startsAt: '2026-09-01T18:00:00Z', timezone: 'America/Toronto' }
+    expect(redactBlock(t, anon)).toEqual(t)
+  })
+  it('link block unchanged', () => {
+    const l: LinkBlock = { id: 'k1', kind: 'link', url: 'https://x', label: 'More' }
+    expect(redactBlock(l, anon)).toEqual(l)
+  })
+  it('text block field passes through (protected by reach, not field scrub)', () => {
+    const tb: TextBlock = { id: 'x1', kind: 'text', body: 'hello', containsPii: false }
+    expect(redactBlock(tb, anon)).toEqual(tb)
+  })
+})
+
+// ── redactPost reach gating ──────────────────────────────────────────────────
+describe('redactPost — reach gating', () => {
+  const base: Omit<Post, 'visibility' | 'blocks'> = {
+    id: 'post1',
+    tenant: 'Toronto East',
+    authorId: 'author',
+    title: 'Test',
+    occasion: ['funeral'],
+    sharingScope: 'own',
+    lifecycle: {},
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    status: 'ready',
+  }
+
+  it('post-level members visibility → anon gets null', () => {
+    const post: Post = { ...base, visibility: 'members', blocks: [] }
+    expect(redactPost(post, anon)).toBeNull()
+    expect(redactPost(post, member)).not.toBeNull()
+  })
+
+  it('block-level members override → dropped for anon, kept for member', () => {
+    const post: Post = {
+      ...base,
+      visibility: 'public',
+      blocks: [
+        { id: 'pub', kind: 'text', body: 'public copy', containsPii: false },
+        { id: 'mem', kind: 'text', body: 'members copy', containsPii: true, visibility: 'members' },
+        { id: 'fly', kind: 'flyer', visibility: 'members', document: { id: 'd', documentType: 'upload', fileName: 'f', originalName: 'f.pdf', fileUrl: 'u', fileSize: 1, mimeType: 'application/pdf', uploadedAt: new Date(), uploadedBy: 'x' } },
+      ],
+    }
+    const rAnon = redactPost(post, anon)!
+    expect(rAnon.blocks.map((b) => b.id)).toEqual(['pub'])
+    const rMember = redactPost(post, member)!
+    expect(rMember.blocks.map((b) => b.id)).toEqual(['pub', 'mem', 'fly'])
+  })
+
+  it('newsletter-email channel lifts a recognized viewer to member reach', () => {
+    const post: Post = {
+      ...base,
+      visibility: 'public',
+      blocks: [{ id: 'mem', kind: 'text', body: 'members copy', containsPii: true, visibility: 'members' }],
+    }
+    // recognized on public web → member text dropped
+    expect(redactPost(post, recognized)!.blocks).toHaveLength(0)
+    // recognized via newsletter-email → member text kept
+    expect(redactPost(post, recognized, { channel: 'newsletter-email' })!.blocks).toHaveLength(1)
+  })
+
+  it('admins-only block hidden from a member but shown to admin', () => {
+    const post: Post = {
+      ...base,
+      visibility: 'public',
+      blocks: [{ id: 'adm', kind: 'text', body: 'admin note', containsPii: false, visibility: 'admins' }],
+    }
+    expect(redactPost(post, member)!.blocks).toHaveLength(0)
+    expect(redactPost(post, admin)!.blocks).toHaveLength(1)
+  })
+})
+
+// ── canSee tier matrix ───────────────────────────────────────────────────────
+describe('canSee', () => {
+  it('public reachable by everyone', () => {
+    expect(canSee('public', anon)).toBe(true)
+  })
+  it('members not reachable by anon on public web', () => {
+    expect(canSee('members', anon)).toBe(false)
+    expect(canSee('members', member)).toBe(true)
+  })
+  it('members reachable via newsletter-email regardless of viewer', () => {
+    expect(canSee('members', anon, 'newsletter-email')).toBe(true)
+  })
+  it('admins reachable only by admin+', () => {
+    expect(canSee('admins', member)).toBe(false)
+    expect(canSee('admins', admin)).toBe(true)
+    // newsletter-email caps at member tier, not admins
+    expect(canSee('admins', anon, 'newsletter-email')).toBe(false)
+  })
+})

--- a/apps/next/utils/redact-news.ts
+++ b/apps/next/utils/redact-news.ts
@@ -1,0 +1,29 @@
+/**
+ * News PII read boundary (Consolidated CMS Phase 0, epic #131).
+ *
+ * Runs a legacy NewsItem through the unified block model
+ * (`legacyToPost` → `redactPost`) for the resolved viewer, then projects the
+ * result back onto the NewsItem shape so the client contract is unchanged. Only
+ * `body` (a TextBlock) and `documents` (FlyerBlocks) can change: under a
+ * PII-bearing occasion (e.g. `medical`) those blocks default to member reach, so
+ * an anon reader sees the title + summary only.
+ *
+ * This is applied ONLY behind the CONSOLIDATED_CMS flag by the callers; with the
+ * flag OFF the raw item is returned unchanged (byte-identical).
+ */
+import type { NewsItem } from '@my/app/types/news'
+import type { Viewer } from '@my/app/utils/viewer-pii'
+import { legacyToPost } from '@my/app/utils/legacy-to-post'
+import { redactPost } from '@my/app/utils/redact-post'
+
+export function redactNewsForViewer(item: NewsItem, viewer: Viewer): NewsItem {
+  const post = redactPost(legacyToPost(item), viewer, { channel: 'public-web' })
+  if (!post) return { ...item, body: '', documents: [] }
+  const textBlock = post.blocks.find((b) => b.kind === 'text')
+  const hasFlyer = post.blocks.some((b) => b.kind === 'flyer')
+  return {
+    ...item,
+    body: textBlock && textBlock.kind === 'text' ? textBlock.body : '',
+    documents: hasFlyer ? item.documents : [],
+  }
+}

--- a/packages/app/features/feature-flags/feature-flags.ts
+++ b/packages/app/features/feature-flags/feature-flags.ts
@@ -4,6 +4,7 @@ export const FEATURE_FLAGS = {
   MULTI_TENANT_INIT: 'multi_tenant_init',
   IN_APP_NOTIFICATIONS: 'in_app_notifications',
   UNIVERSAL_EMAIL_LOGIN: 'universal_email_login',
+  CONSOLIDATED_CMS: 'consolidated_cms',
 } as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS[keyof typeof FEATURE_FLAGS]
@@ -39,6 +40,15 @@ export const DEFAULT_FEATURE_FLAG_CONFIGS: Record<string, FeatureFlagConfig> = {
     // as before until deliberately enabled.
     description: 'Add a per-recipient one-click sign-in link to the footer of every outgoing email',
     visibleTo: 'off',
+    users: [],
+  },
+  [FEATURE_FLAGS.CONSOLIDATED_CMS]: {
+    // Unified Post model (epic #131) Phase 0. Gates the block-model read boundary
+    // (legacyToPost + redactPost) at public read paths. OFF by default → existing
+    // response shape/format is byte-identical; flip to 'everyone' to ship the
+    // stricter anon-PII scrub to all readers.
+    description: 'Unified Post model: block-based PII redaction at public read boundaries',
+    visibleTo: 'owner',
     users: [],
   },
 }

--- a/packages/app/types/post.ts
+++ b/packages/app/types/post.ts
@@ -1,0 +1,206 @@
+/**
+ * Unified Post model — PII-aware by construction.
+ *
+ * One entity for News AND Events. "Event-shaped" vs "news-shaped" is DERIVED
+ * from `lifecycle`, not a type. Every block field that can hold PII carries a
+ * declared {@link PiiClass}, so redaction is a single server-side traversal
+ * (`redactPost`) instead of an audit of every string-interpolation site.
+ *
+ * Phase 0 of the Consolidated CMS epic (#131). See
+ * docs/UNIFIED_POST_MODEL_DESIGN.md §2–§3 for the design this file realizes.
+ *
+ * Cross-platform: pure types, no platform imports — safe to import from web,
+ * native, and email render paths.
+ */
+
+import type { DocumentAttachment, EventSharingScope, OnlineMeetingInfo } from './events'
+
+// Re-export so the post model is a single import surface for consumers. The
+// canonical PiiClass definition lives in viewer-pii.ts (the redaction primitive);
+// re-exporting avoids a second, divergable copy.
+export type { PiiClass } from '../utils/viewer-pii'
+
+/**
+ * Post reach ladder (design §8.4): public < recognized < members < admins.
+ * Maps onto the assurance tiers + access roles. Gates whether a viewer can see
+ * the post (or block) AT ALL — distinct from per-field PII scrubbing.
+ */
+export type Visibility = 'public' | 'recognized' | 'members' | 'admins'
+
+/**
+ * Geo reach of a post (own ecclesia / region / global). Reuses the existing
+ * event sharing scope so there is ONE sharing resolver for posts.
+ */
+export type SharingScope = EventSharingScope
+
+/**
+ * Occasion is DATA, not a code path (design §8.5). One generic post; occasion
+ * tags free-combine (e.g. `['wedding','shower']`). Legacy `EventType` values and
+ * news categories map onto these during adaptation — no new code per occasion.
+ */
+export type OccasionTag =
+  | 'baptism'
+  | 'wedding'
+  | 'shower'
+  | 'funeral'
+  | 'engagement'
+  | 'study-weekend'
+  | 'general'
+  | 'recurring'
+  | 'election-cycle'
+  | 'news'
+  | 'medical'
+  | 'announcement'
+
+export type BlockKind =
+  | 'text'
+  | 'person'
+  | 'location'
+  | 'time'
+  | 'flyer'
+  | 'registration'
+  | 'link'
+
+export interface BlockBase {
+  id: string
+  kind: BlockKind
+  /**
+   * Optional per-block override of {@link Post.visibility} (e.g. a flyer or an
+   * obituary text block set to `members`). When absent the block inherits the
+   * post's reach.
+   */
+  visibility?: Visibility
+}
+
+/**
+ * Rich text / markdown. Copy-paste-from-email lands here. Free prose can hide
+ * PII the redactor can't locate, so under a PII-bearing occasion this block
+ * defaults to `visibility: 'members'` (design §5, §8.3) — anon simply never sees
+ * it. `containsPii` drives a save-time author warning + future auto-detection.
+ */
+export interface TextBlock extends BlockBase {
+  kind: 'text'
+  body: string
+  containsPii: boolean
+}
+
+/** A person's field-classes: firstName always shown; lastName/bio/contact gated. */
+export interface BlockPerson {
+  firstName: string // pii:'name' — ALWAYS shown (first-name floor)
+  lastName?: string // pii:'name' — dropped below reveal tier
+  bio?: string // pii:'bio' — obituary / testimony / about — hidden below member
+  contact?: string // pii:'contact' — phone / personal email — hidden below member
+  ecclesia?: string // pii:'none'
+  title?: string // pii:'none' — honorific (Brother/Sister/…)
+  age?: number // pii:'none'
+  /** pii:'none' — sub-role label (e.g. 'proposer', 'best man'). */
+  label?: string
+}
+
+export interface PersonBlock extends BlockBase {
+  kind: 'person'
+  role: 'speaker' | 'candidate' | 'deceased' | 'bride' | 'groom' | 'sponsor' | 'contact' | 'other'
+  people: BlockPerson[]
+}
+
+/**
+ * Location — geo-aware address | plain text address | inherit-from-ecclesia.
+ * `venueName`/`city`/`province`/`country` are the anon-safe floor (pii:'none');
+ * `address`/`postalCode`/`lat`/`lng`/`directions`/`mapsUrl` are
+ * `location-precise` and coarsened/hidden for anon. A `privateResidence` block
+ * is dropped ENTIRELY for anon (design §8.1).
+ */
+export interface LocationBlock extends BlockBase {
+  kind: 'location'
+  mode: 'geo' | 'plain' | 'ecclesia'
+  ecclesiaRef?: string // when mode==='ecclesia'
+  label?: string // e.g. 'Service', 'Visitation', 'Ceremony', 'Reception'
+  venueName?: string // pii:'none'
+  city?: string // pii:'none' (coarse — safe floor)
+  province?: string // pii:'none'
+  country?: string // pii:'none'
+  address?: string // pii:'location-precise'
+  postalCode?: string // pii:'location-precise'
+  lat?: number // pii:'location-precise'
+  lng?: number // pii:'location-precise'
+  directions?: string // pii:'location-precise'
+  parkingInfo?: string // pii:'location-precise'
+  mapsUrl?: string // pii:'location-precise'
+  /** Author toggle: a private residence is hidden whole for anon (design §8.1). */
+  privateResidence?: boolean
+  onlineMeeting?: OnlineMeetingInfo // pii:'none' — virtual meeting link/details
+}
+
+/** Timezone-aware date/time. Presence of a FUTURE `startsAt` drives the event facet. */
+export interface TimeBlock extends BlockBase {
+  kind: 'time'
+  label?: string // e.g. 'Service', 'Baptism', a schedule item title
+  startsAt?: string // ISO-8601
+  endsAt?: string // ISO-8601
+  timezone?: string // IANA (e.g. 'America/Toronto')
+  display?: string // free-text time when no ISO value (e.g. '7:30pm')
+}
+
+/** PDF/image attachment. PII can be baked into pixels — unredactable — so under a
+ * PII-bearing occasion this defaults to `visibility: 'members'` (design §5). */
+export interface FlyerBlock extends BlockBase {
+  kind: 'flyer'
+  document: DocumentAttachment
+}
+
+export interface RegistrationBlock extends BlockBase {
+  kind: 'registration'
+  required?: boolean
+  deadline?: string // ISO-8601
+  registrationUrl?: string // pii:'none'
+  contactEmail?: string // pii:'contact'
+  contactPhone?: string // pii:'contact'
+  hasFee?: boolean
+  fee?: number
+  paymentInstructions?: string
+  notes?: string
+}
+
+export interface LinkBlock extends BlockBase {
+  kind: 'link'
+  url: string
+  label?: string
+}
+
+export type Block =
+  | TextBlock
+  | PersonBlock
+  | LocationBlock
+  | TimeBlock
+  | FlyerBlock
+  | RegistrationBlock
+  | LinkBlock
+
+export interface PostLifecycle {
+  publishDate?: string // when it becomes visible (source of truth)
+  startsAt?: string // a FUTURE start ⇒ event-shaped; absent/past ⇒ news-shaped
+  endsAt?: string
+  expiresAt?: string // news retrospective window
+}
+
+export interface Post {
+  id: string
+  tenant: string // owning ecclesia/org (today's ownerEcclesia / ecclesiaId)
+  authorId: string
+
+  title: string
+  occasion: OccasionTag[] // DATA, not a code path
+  summary?: string // short, PII-safe headline/teaser (public floor)
+
+  // Reach — coarse gate resolved vs viewer tier.
+  visibility: Visibility
+  sharingScope: SharingScope
+
+  lifecycle: PostLifecycle
+
+  blocks: Block[] // where all content (and all PII) lives
+
+  createdAt: string
+  updatedAt: string
+  status: 'draft' | 'ready' | 'archived'
+}

--- a/packages/app/utils/legacy-to-post.ts
+++ b/packages/app/utils/legacy-to-post.ts
@@ -1,0 +1,422 @@
+/**
+ * Phase 0 adapter — maps today's flat `Event` / `NewsItem` records into the
+ * unified {@link Post} block model WITH correct PII classes, so `redactPost` can
+ * scrub them without any storage migration or new authoring UI (design §7).
+ *
+ * This is where every PII field gets enumerated ONCE: a candidate/deceased/
+ * couple becomes a PersonBlock; an aboutCandidate/obituary becomes a `bio`; a
+ * LocationInfo becomes a LocationBlock (venue floor vs precise); dates/schedule
+ * become TimeBlocks; documents become FlyerBlocks; body/theme become a TextBlock.
+ *
+ * Pure + I/O-free. Cross-platform: no platform imports.
+ */
+
+import type {
+  Event,
+  EventType,
+  FuneralLocations,
+  LocationInfo,
+  RegistrationInfo,
+  ScheduleItem,
+} from '../types/events'
+import type { NewsItem } from '../types/news'
+import type {
+  Block,
+  FlyerBlock,
+  LocationBlock,
+  OccasionTag,
+  PersonBlock,
+  Post,
+  RegistrationBlock,
+  TextBlock,
+  TimeBlock,
+  Visibility,
+} from '../types/post'
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+let seq = 0
+/** Deterministic-enough virtual block id (adapter output is transient). */
+function bid(prefix: string): string {
+  seq += 1
+  return `${prefix}-${seq}`
+}
+
+function toIso(value: Date | string | undefined): string | undefined {
+  if (!value) return undefined
+  const d = value instanceof Date ? value : new Date(value)
+  const t = d.getTime()
+  return isNaN(t) ? (typeof value === 'string' ? value : undefined) : d.toISOString()
+}
+
+function joinBio(...parts: Array<string | undefined>): string | undefined {
+  const kept = parts.filter((p): p is string => !!p && p.trim().length > 0)
+  return kept.length ? kept.join('\n\n') : undefined
+}
+
+/**
+ * Occasions that can carry sensitive PII in FREE TEXT / pixels. Under these, a
+ * TextBlock and a FlyerBlock default to `members` reach (design §5, §8.3) — the
+ * redactor can't parse names out of prose or images, so anon simply doesn't see
+ * them.
+ */
+const PII_BEARING_OCCASIONS: ReadonlySet<OccasionTag> = new Set([
+  'funeral',
+  'baptism',
+  'engagement',
+  'medical',
+])
+
+function isPiiBearing(occasion: OccasionTag[]): boolean {
+  return occasion.some((o) => PII_BEARING_OCCASIONS.has(o))
+}
+
+const EVENT_TYPE_TO_OCCASION: Record<EventType, OccasionTag> = {
+  'study-weekend': 'study-weekend',
+  funeral: 'funeral',
+  wedding: 'wedding',
+  baptism: 'baptism',
+  engagement: 'engagement',
+  general: 'general',
+  recurring: 'recurring',
+  'election-cycle': 'election-cycle',
+}
+
+// ── location mapping ───────────────────────────────────────────────────────
+
+function locationInfoToBlock(
+  loc: LocationInfo | undefined,
+  label?: string
+): LocationBlock | undefined {
+  if (!loc) return undefined
+  const hasContent =
+    loc.name ||
+    loc.placeName ||
+    loc.address ||
+    loc.city ||
+    loc.onlineMeeting ||
+    loc.postalCode ||
+    typeof loc.lat === 'number'
+  if (!hasContent) return undefined
+  const block: LocationBlock = {
+    id: bid('loc'),
+    kind: 'location',
+    mode: loc.mode === 'online' ? 'plain' : 'geo',
+  }
+  if (label) block.label = label
+  const venue = loc.name || loc.placeName
+  if (venue) block.venueName = venue
+  if (loc.city) block.city = loc.city
+  if (loc.province) block.province = loc.province
+  if (loc.country) block.country = loc.country
+  if (loc.address) block.address = loc.address
+  if (loc.postalCode) block.postalCode = loc.postalCode
+  if (typeof loc.lat === 'number') block.lat = loc.lat
+  if (typeof loc.lng === 'number') block.lng = loc.lng
+  if (loc.directions) block.directions = loc.directions
+  if (loc.parkingInfo) block.parkingInfo = loc.parkingInfo
+  if (loc.mapsUrl) block.mapsUrl = loc.mapsUrl
+  if (loc.onlineMeeting) block.onlineMeeting = loc.onlineMeeting
+  if ((loc as { privateResidence?: boolean }).privateResidence) block.privateResidence = true
+  return block
+}
+
+const FUNERAL_LOCATION_LABELS: Record<keyof FuneralLocations, string> = {
+  service: 'Service',
+  viewing: 'Visitation',
+  visitation: 'Visitation',
+  burial: 'Burial',
+  graveside: 'Graveside',
+}
+
+function funeralLocationsToBlocks(locations: FuneralLocations): LocationBlock[] {
+  const out: LocationBlock[] = []
+  for (const key of Object.keys(locations) as Array<keyof FuneralLocations>) {
+    const block = locationInfoToBlock(locations[key], FUNERAL_LOCATION_LABELS[key])
+    if (block) out.push(block)
+  }
+  return out
+}
+
+// ── time mapping ───────────────────────────────────────────────────────────
+
+function scheduleItemToTimeBlock(item: ScheduleItem, tz?: string): TimeBlock {
+  const block: TimeBlock = { id: bid('time'), kind: 'time' }
+  const label = item.title || item.activity
+  if (label) block.label = label
+  const startsAt = toIso(item.startTime)
+  if (startsAt) block.startsAt = startsAt
+  const endsAt = item.endTime ? toIso(item.endTime) : undefined
+  if (endsAt) block.endsAt = endsAt
+  if (!startsAt && item.time) block.display = item.time
+  if (tz) block.timezone = tz
+  return block
+}
+
+function registrationToBlock(reg: RegistrationInfo | undefined): RegistrationBlock | undefined {
+  if (!reg) return undefined
+  const block: RegistrationBlock = { id: bid('reg'), kind: 'registration' }
+  if (reg.required !== undefined) block.required = reg.required === true || reg.required === 'true'
+  const deadline = toIso(reg.deadline)
+  if (deadline) block.deadline = deadline
+  if (reg.registrationUrl) block.registrationUrl = reg.registrationUrl
+  if (reg.contactEmail) block.contactEmail = reg.contactEmail
+  if (reg.contactPhone) block.contactPhone = reg.contactPhone
+  if (reg.hasFee !== undefined) block.hasFee = reg.hasFee
+  if (reg.fee !== undefined) block.fee = typeof reg.fee === 'string' ? Number(reg.fee) : reg.fee
+  if (reg.paymentInstructions) block.paymentInstructions = reg.paymentInstructions
+  if (reg.notes) block.notes = reg.notes
+  return block
+}
+
+// ── Event → Post ───────────────────────────────────────────────────────────
+
+/** The best "start" date for an event, across the type-specific date fields. */
+function eventStartDate(event: Event): string | undefined {
+  return toIso(
+    event.startDate ??
+      event.baptismDate ??
+      event.serviceDate ??
+      event.ceremonyDate ??
+      event.engagementDate ??
+      event.dateRange?.start
+  )
+}
+
+function eventToPost(event: Event): Post {
+  const occasion: OccasionTag[] = [EVENT_TYPE_TO_OCCASION[event.type] ?? 'general']
+  const piiBearing = isPiiBearing(occasion)
+  const memberFloor: Visibility | undefined = piiBearing ? 'members' : undefined
+
+  const blocks: Block[] = []
+
+  // ── People (name / bio class) ──
+  if (event.candidate) {
+    const person: PersonBlock['people'][number] = {
+      firstName: event.candidate.firstName,
+      lastName: event.candidate.lastName,
+    }
+    const bio = joinBio(
+      event.aboutCandidate,
+      event.candidate.testimony,
+      event.candidate.baptismStatement
+    )
+    if (bio) person.bio = bio
+    blocks.push({ id: bid('person'), kind: 'person', role: 'candidate', people: [person] })
+  }
+  if (event.deceased) {
+    const person: PersonBlock['people'][number] = {
+      firstName: event.deceased.firstName,
+      lastName: event.deceased.lastName,
+    }
+    if (event.deceased.title) person.title = event.deceased.title
+    if (typeof event.deceased.age === 'number') person.age = event.deceased.age
+    const bio = joinBio(event.aboutDeceased, event.deceased.obituary)
+    if (bio) person.bio = bio
+    blocks.push({ id: bid('person'), kind: 'person', role: 'deceased', people: [person] })
+  }
+  if (event.couple) {
+    blocks.push({
+      id: bid('person'),
+      kind: 'person',
+      role: 'bride',
+      people: [{ firstName: event.couple.bride.firstName, lastName: event.couple.bride.lastName }],
+    })
+    blocks.push({
+      id: bid('person'),
+      kind: 'person',
+      role: 'groom',
+      people: [{ firstName: event.couple.groom.firstName, lastName: event.couple.groom.lastName }],
+    })
+  }
+  if (event.sponsors?.length) {
+    blocks.push({
+      id: bid('person'),
+      kind: 'person',
+      role: 'sponsor',
+      people: event.sponsors.map((s) => ({
+        firstName: s.firstName,
+        lastName: s.lastName,
+        ...(s.role ? { label: s.role } : {}),
+      })),
+    })
+  }
+  if (event.speakers?.length) {
+    blocks.push({
+      id: bid('person'),
+      kind: 'person',
+      role: 'speaker',
+      people: event.speakers.map((s) => ({
+        firstName: s.firstName,
+        lastName: s.lastName,
+        ...(s.title ? { title: s.title } : {}),
+        ...(s.ecclesia ? { ecclesia: s.ecclesia } : {}),
+      })),
+    })
+  }
+  if (event.weddingParty?.length) {
+    blocks.push({
+      id: bid('person'),
+      kind: 'person',
+      role: 'other',
+      people: event.weddingParty.map((m) => ({
+        firstName: m.firstName,
+        lastName: m.lastName,
+        ...(m.role ? { label: m.role } : {}),
+      })),
+    })
+  }
+
+  // Engagement free-text names → members-only text block (can't structure a
+  // free-form "Brother Gord Easson" string safely).
+  const engagementText = joinBio(
+    event.engagementProposed && event.engagementTo
+      ? `${event.engagementProposed} & ${event.engagementTo}`
+      : event.engagementProposed || event.engagementTo,
+    event.engagementAnnouncement
+  )
+  if (engagementText) {
+    blocks.push({
+      id: bid('text'),
+      kind: 'text',
+      body: engagementText,
+      containsPii: true,
+      visibility: 'members',
+    })
+  }
+
+  // ── Locations (location-precise class) ──
+  const locBlock = locationInfoToBlock(event.location)
+  if (locBlock) blocks.push(locBlock)
+  const ceremony = locationInfoToBlock(event.ceremonyLocation, 'Ceremony')
+  if (ceremony) blocks.push(ceremony)
+  if (event.reception?.location) {
+    const rec = locationInfoToBlock(event.reception.location, 'Reception')
+    if (rec) blocks.push(rec)
+  }
+  if (event.locations) {
+    if (Array.isArray(event.locations)) {
+      for (const l of event.locations) {
+        const b = locationInfoToBlock(l)
+        if (b) blocks.push(b)
+      }
+    } else {
+      blocks.push(...funeralLocationsToBlocks(event.locations))
+    }
+  }
+  if (event.sections?.length) {
+    for (const s of event.sections) {
+      const b = locationInfoToBlock(s.location, s.title)
+      if (b) blocks.push(b)
+    }
+  }
+
+  // ── Times ──
+  const start = eventStartDate(event)
+  if (start) {
+    blocks.push({
+      id: bid('time'),
+      kind: 'time',
+      label: event.title,
+      startsAt: start,
+      ...(event.eventTimezone ? { timezone: event.eventTimezone } : {}),
+      ...(toIso(event.endDate) ? { endsAt: toIso(event.endDate) } : {}),
+    })
+  }
+  if (event.schedule?.length) {
+    for (const item of event.schedule) blocks.push(scheduleItemToTimeBlock(item, event.eventTimezone))
+  }
+
+  // ── Free text (theme / description) — members-only under PII occasions ──
+  const textBody = joinBio(event.theme, event.description)
+  if (textBody) {
+    const tb: TextBlock = { id: bid('text'), kind: 'text', body: textBody, containsPii: piiBearing }
+    if (memberFloor) tb.visibility = memberFloor
+    blocks.push(tb)
+  }
+
+  // ── Flyers (unredactable pixels) — members-only under PII occasions ──
+  for (const doc of event.documents ?? []) {
+    const fb: FlyerBlock = { id: bid('flyer'), kind: 'flyer', document: doc }
+    if (memberFloor) fb.visibility = memberFloor
+    blocks.push(fb)
+  }
+
+  // ── Registration (contact class) ──
+  const reg = registrationToBlock(event.registration)
+  if (reg) blocks.push(reg)
+
+  return {
+    id: event.id,
+    tenant: event.ownerEcclesia || event.hostingEcclesia?.name || '',
+    authorId: event.createdBy,
+    title: event.title,
+    occasion,
+    visibility: event.membersOnly ? 'members' : 'public',
+    sharingScope: event.sharingScope ?? 'own',
+    lifecycle: {
+      publishDate: toIso(event.publishDate),
+      startsAt: start,
+      endsAt: toIso(event.endDate),
+    },
+    blocks,
+    createdAt: toIso(event.createdAt) ?? '',
+    updatedAt: toIso(event.updatedAt) ?? '',
+    status: 'ready',
+  }
+}
+
+// ── NewsItem → Post ──────────────────────────────────────────────────────────
+
+function newsToPost(item: NewsItem): Post {
+  const occasion: OccasionTag[] =
+    item.category && item.category !== 'general'
+      ? ['news', item.category]
+      : ['news']
+  const piiBearing = isPiiBearing(occasion) // true for 'medical'
+  const memberFloor: Visibility | undefined = piiBearing ? 'members' : undefined
+
+  const blocks: Block[] = []
+  if (item.body) {
+    const tb: TextBlock = { id: bid('text'), kind: 'text', body: item.body, containsPii: piiBearing }
+    if (memberFloor) tb.visibility = memberFloor
+    blocks.push(tb)
+  }
+  for (const doc of item.documents ?? []) {
+    const fb: FlyerBlock = { id: bid('flyer'), kind: 'flyer', document: doc }
+    if (memberFloor) fb.visibility = memberFloor
+    blocks.push(fb)
+  }
+
+  return {
+    id: item.id,
+    tenant: item.ecclesiaId,
+    authorId: item.authorId,
+    title: item.title,
+    occasion,
+    visibility: 'public',
+    sharingScope: item.sharingScope,
+    lifecycle: {
+      publishDate: toIso(item.publishedAt),
+      expiresAt: toIso(item.expiresAt),
+    },
+    blocks,
+    createdAt: toIso(item.createdAt) ?? '',
+    updatedAt: toIso(item.updatedAt) ?? '',
+    status: 'ready',
+  }
+}
+
+/** True when the input is a legacy Event (vs a NewsItem). */
+function isLegacyEvent(input: Event | NewsItem): input is Event {
+  return (input as Event).type !== undefined && (input as NewsItem).ecclesiaId === undefined
+}
+
+/**
+ * Adapt a legacy flat record (Event OR NewsItem) into a unified {@link Post}
+ * with PII-classed blocks. The bridge that lets `redactPost` scrub today's data
+ * with no storage migration (design §7, Phase 0).
+ */
+export function legacyToPost(input: Event | NewsItem): Post {
+  return isLegacyEvent(input) ? eventToPost(input) : newsToPost(input)
+}

--- a/packages/app/utils/redact-post.ts
+++ b/packages/app/utils/redact-post.ts
@@ -1,0 +1,221 @@
+/**
+ * The single read boundary for the unified Post model (design §4).
+ *
+ * `redactPost(post, viewer, { channel })` walks a post's typed blocks and:
+ *   1. REACH-gates the post, then each block, by {@link Visibility} vs the
+ *      viewer's tier (channel-aware — the curated newsletter email is a member
+ *      audience, design §8.2). A block the viewer can't reach is dropped.
+ *   2. PII-scrubs each surviving block's fields by class (§4 table), reusing the
+ *      viewer-pii primitives so name/location/bio shaping lives in ONE place.
+ *
+ * Sanitation happens HERE, before serialization — a redacted post literally
+ * cannot carry a surname / street address / obituary (no ship-then-hide leak).
+ * Obtaining full data requires an explicit reveal-tier Viewer or the
+ * `newsletter-email` channel (design §4.1: the narrow, audited full-data door).
+ *
+ * Pure + I/O-free — unit-tests cleanly, runs in any context. Cross-platform:
+ * no platform imports.
+ */
+
+import type {
+  Block,
+  LocationBlock,
+  PersonBlock,
+  Post,
+  RegistrationBlock,
+  Visibility,
+} from '../types/post'
+import {
+  canRevealPii,
+  revealBio,
+  shapeLocation,
+  shapePersonName,
+  type Channel,
+  type Viewer,
+} from './viewer-pii'
+
+interface RedactOptions {
+  channel?: Channel
+}
+
+// Reach ranks — higher sees more. Mirrors the assurance/role ladder.
+const VISIBILITY_RANK: Record<Visibility, number> = {
+  public: 0,
+  recognized: 1,
+  members: 2,
+  admins: 3,
+}
+
+/**
+ * The reach tier a (viewer, channel) can see UP TO. Channel-aware: the curated
+ * `newsletter-email` renders at member tier (§8.2). Otherwise derived from the
+ * viewer's assurance + effective role (already capped for recognized viewers).
+ */
+function viewerReach(viewer: Viewer, channel: Channel): number {
+  if (channel === 'newsletter-email') return VISIBILITY_RANK.members
+  if (viewer.assurance === 'anonymous') return VISIBILITY_RANK.public
+  if (viewer.assurance === 'authenticated') {
+    if (viewer.role === 'owner' || viewer.role === 'admin') return VISIBILITY_RANK.admins
+    if (viewer.role === 'member' || viewer.role === 'recorder' || viewer.role === 'rep') {
+      return VISIBILITY_RANK.members
+    }
+    // Authenticated but below member (guest) — recognized floor.
+    return VISIBILITY_RANK.recognized
+  }
+  // recognized (valid email token, never above member) — recognized floor.
+  return VISIBILITY_RANK.recognized
+}
+
+/** Reach gate: may this (viewer, channel) see content at `visibility`? */
+export function canSee(
+  visibility: Visibility,
+  viewer: Viewer,
+  channel: Channel = 'public-web'
+): boolean {
+  return viewerReach(viewer, channel) >= VISIBILITY_RANK[visibility]
+}
+
+function redactPerson(block: PersonBlock, viewer: Viewer, channel: Channel): PersonBlock {
+  return {
+    ...block,
+    people: block.people.map((p) => {
+      // shapePersonName drops lastName below reveal tier — no View-Source leak.
+      const named = shapePersonName(p, viewer, channel)
+      const out: PersonBlock['people'][number] = {
+        firstName: named.firstName,
+      }
+      if (named.lastName) out.lastName = named.lastName
+      const bio = revealBio(p.bio, viewer, channel)
+      if (bio) out.bio = bio
+      // contact-class — dropped below reveal tier.
+      if (p.contact && canRevealPii(viewer, channel)) out.contact = p.contact
+      // pii:'none' — always carried.
+      if (p.ecclesia) out.ecclesia = p.ecclesia
+      if (p.title) out.title = p.title
+      if (typeof p.age === 'number') out.age = p.age
+      if (p.label) out.label = p.label
+      return out
+    }),
+  }
+}
+
+/**
+ * Shape a LocationBlock. Reuses `shapeLocation` for the venue+city floor and the
+ * private-residence drop. Returns `null` when the whole block must disappear
+ * (private residence, non-reveal viewer) so `redactPost` can filter it out.
+ */
+function redactLocation(
+  block: LocationBlock,
+  viewer: Viewer,
+  channel: Channel
+): LocationBlock | null {
+  const shaped = shapeLocation(
+    {
+      venueName: block.venueName,
+      city: block.city,
+      province: block.province,
+      address: block.address,
+      postalCode: block.postalCode,
+      lat: block.lat,
+      lng: block.lng,
+      privateResidence: block.privateResidence,
+    },
+    viewer,
+    channel
+  )
+  if (!shaped) return null // private residence, non-reveal — drop whole block
+
+  if (canRevealPii(viewer, channel)) return block // reveal tier keeps everything
+
+  // Non-reveal: rebuild carrying ONLY the safe floor + non-PII fields. Precise
+  // street/geo/directions/maps are omitted from the object entirely.
+  const out: LocationBlock = {
+    id: block.id,
+    kind: 'location',
+    mode: block.mode,
+  }
+  if (block.visibility) out.visibility = block.visibility
+  if (block.ecclesiaRef) out.ecclesiaRef = block.ecclesiaRef
+  if (block.label) out.label = block.label
+  if (shaped.venueName) out.venueName = shaped.venueName
+  if (shaped.city) out.city = shaped.city
+  if (shaped.province) out.province = shaped.province
+  if (block.country) out.country = block.country
+  if (block.onlineMeeting) out.onlineMeeting = block.onlineMeeting
+  return out
+}
+
+function redactRegistration(
+  block: RegistrationBlock,
+  viewer: Viewer,
+  channel: Channel
+): RegistrationBlock {
+  if (canRevealPii(viewer, channel)) return block
+  // contact-class — drop email/phone; keep the public registration url + logistics.
+  const { contactEmail: _e, contactPhone: _p, ...rest } = block
+  return rest
+}
+
+/**
+ * Scrub a single block's PII fields for a (viewer, channel). Returns `null` when
+ * the block must be removed (a private-residence location for a non-reveal
+ * viewer). Reach gating is done by the caller. Blocks with no PII-class fields
+ * (time, flyer, link, text) pass through unchanged — text/flyer are protected by
+ * their `visibility` reach gate, not by field scrubbing.
+ */
+export function redactBlock(
+  block: Block,
+  viewer: Viewer,
+  channel: Channel = 'public-web'
+): Block | null {
+  switch (block.kind) {
+    case 'person':
+      return redactPerson(block, viewer, channel)
+    case 'location':
+      return redactLocation(block, viewer, channel)
+    case 'registration':
+      return redactRegistration(block, viewer, channel)
+    case 'text':
+    case 'time':
+    case 'flyer':
+    case 'link':
+      return block
+  }
+}
+
+/**
+ * Redact a whole post for a (viewer, channel). Returns `null` when the viewer
+ * cannot reach the post at all. Otherwise: drops blocks the viewer can't reach,
+ * then PII-scrubs the survivors.
+ */
+export function redactPost(
+  post: Post,
+  viewer: Viewer,
+  opts: RedactOptions = {}
+): Post | null {
+  const channel: Channel = opts.channel ?? 'public-web'
+  if (!canSee(post.visibility, viewer, channel)) return null
+
+  const blocks: Block[] = []
+  for (const block of post.blocks) {
+    if (!canSee(block.visibility ?? post.visibility, viewer, channel)) continue
+    const redacted = redactBlock(block, viewer, channel)
+    if (redacted) blocks.push(redacted)
+  }
+
+  return { ...post, blocks }
+}
+
+/** Redact a list of posts, dropping any the viewer cannot reach. */
+export function redactPosts(
+  posts: Post[],
+  viewer: Viewer,
+  opts: RedactOptions = {}
+): Post[] {
+  const out: Post[] = []
+  for (const p of posts) {
+    const r = redactPost(p, viewer, opts)
+    if (r) out.push(r)
+  }
+  return out
+}


### PR DESCRIPTION
Phase 0 of #131 — implements `docs/UNIFIED_POST_MODEL_DESIGN.md` §7 Phase 0. Model + read boundary only (no editor, no storage migration). Behind **`CONSOLIDATED_CMS`** (defaults `owner`).

## What
- **Types** `packages/app/types/post.ts` — `Post`, `Block` union (Text/Person/Location/Time/Flyer/Registration/Link), `Visibility` (`public<recognized<members<admins`), `OccasionTag`. Re-exports `PiiClass` from `viewer-pii.ts` (single source).
- **Redactor** `packages/app/utils/redact-post.ts` — `redactPost`/`redactBlock`, **channel-aware** (`newsletter-email`→member tier per §8.2). Reach-gates post then blocks by `Visibility`, then PII-scrubs by class **reusing** `shapePersonName`/`shapeLocation`/`revealBio`/`canRevealPii`. Private-residence location dropped whole for anon.
- **Adapter** `packages/app/utils/legacy-to-post.ts` — `legacyToPost(Event|NewsItem)` → virtual blocks with correct PiiClasses (deceased/candidate/couple→PersonBlock, aboutX→bio, LocationInfo/FuneralLocations→LocationBlock, schedule/dates→TimeBlock, documents→FlyerBlock, EventType/category→occasion tags).
- **Wiring (flag-gated, additive)** — public **news** list + detail (`/api/news`, `/api/news/[newsId]`): flag OFF → **byte-identical** legacy response; flag ON → `resolveViewer`+`legacyToPost`→`redactPost`, projected back to the `NewsItem` shape. Net once flipped: anon `medical` news scrubs body+flyers (title/summary only).

## Why news only
The assurance epic (#84) already ships anon redaction on **events** (`redact-event.ts`) and **schedule** (`redact-schedule.ts`) — **news was the only leaking public boundary**. I deliberately did NOT re-route the already-safe events/schedule through a lossy Post→legacy round-trip (regression risk); that's Phase 1 when events move onto native block storage.

## Verify
- New tests **40 passing** (redact-post 25 across PiiClass×channel×tier; legacy-to-post 15). Full redaction suite **57 passing**. Typecheck clean.
- Flag defaults `owner` → flip to `everyone` to ship the news scrub to all anon readers.

## Follow-ups (tracked in #131)
Phase 1 native block storage (removes the legacy round-trip; lets events/schedule move onto the model), Phase 2 the one editor, display-rules cutover (fixes the shower-reminder class), multi-user sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)