### PR TITLE
CONSOLIDATED_CMS Phase 1 — native Post storage (PostRepository + unified read) (#131)

### DIFF
--- a/apps/next/tests/db/post-repository.test.ts
+++ b/apps/next/tests/db/post-repository.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the DynamoDB document client (same pattern as person-repository.test.ts).
+// Use vi.hoisted so mockSend exists when vi.mock runs.
+const { mockSend } = vi.hoisted(() => {
+  return { mockSend: vi.fn() }
+})
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({
+      send: mockSend,
+    })),
+  },
+  QueryCommand: vi.fn().mockImplementation((params) => ({ type: 'QueryCommand', params })),
+  PutCommand: vi.fn().mockImplementation((params) => ({ type: 'PutCommand', params })),
+  GetCommand: vi.fn().mockImplementation((params) => ({ type: 'GetCommand', params })),
+  UpdateCommand: vi.fn().mockImplementation((params) => ({ type: 'UpdateCommand', params })),
+  DeleteCommand: vi.fn().mockImplementation((params) => ({ type: 'DeleteCommand', params })),
+  ScanCommand: vi.fn().mockImplementation((params) => ({ type: 'ScanCommand', params })),
+  BatchWriteCommand: vi.fn().mockImplementation((params) => ({ type: 'BatchWriteCommand', params })),
+}))
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}))
+
+vi.mock('uuid', () => ({
+  v4: vi.fn(() => 'test-post-uuid'),
+}))
+
+import {
+  PostRepository,
+  type CreatePostInput,
+} from '@my/app/provider/dynamodb/repositories/post-repository'
+import type { Post } from '@my/app/types/post'
+
+/** A stored PostRecord as DynamoDB would return it (keys + gsi + version). */
+function storedRecord(overrides: Partial<Post> = {}): Record<string, any> {
+  const post: Post = {
+    id: 'p1',
+    tenant: 'Toronto East',
+    authorId: 'author-1',
+    title: 'Baptism of Joshua',
+    occasion: ['baptism'],
+    visibility: 'public',
+    sharingScope: 'own',
+    lifecycle: { publishDate: '2026-08-01T00:00:00.000Z' },
+    blocks: [{ id: 'b1', kind: 'text', body: 'Rejoice', containsPii: false }],
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    status: 'ready',
+    ...overrides,
+  }
+  return {
+    pkey: `POST#${post.tenant}`,
+    skey: `POST#${post.id}`,
+    gsi1pk: `POST#${post.id}`,
+    gsi1sk: 'POST',
+    gsi2pk: `POSTS#${post.tenant}`,
+    gsi2sk: `${post.lifecycle.publishDate}#${post.id}`,
+    version: 1,
+    lastUpdated: post.updatedAt,
+    ...post,
+  }
+}
+
+describe('PostRepository', () => {
+  let repository: PostRepository
+
+  beforeEach(() => {
+    // clearAllMocks resets call history but KEEPS the command-constructor
+    // mockImplementations (restoreAllMocks would strip them, breaking the
+    // command-shape assertions in later tests).
+    vi.clearAllMocks()
+    repository = new PostRepository()
+  })
+
+  describe('createPost', () => {
+    it('writes ONE item with the POST# key scheme + overloaded GSIs, blocks embedded', async () => {
+      mockSend.mockResolvedValueOnce({}) // put
+
+      const input: CreatePostInput = {
+        tenant: 'Toronto East',
+        authorId: 'author-1',
+        title: 'Baptism of Joshua',
+        occasion: ['baptism'],
+        visibility: 'public',
+        sharingScope: 'own',
+        lifecycle: { publishDate: '2026-08-01T00:00:00.000Z' },
+        blocks: [{ id: 'b1', kind: 'text', body: 'Rejoice', containsPii: false }],
+        status: 'ready',
+      }
+
+      const result = await repository.createPost(input)
+
+      // ONE write only.
+      expect(mockSend).toHaveBeenCalledTimes(1)
+
+      // Key scheme is asserted on the actual PutCommand item.
+      const putCall = mockSend.mock.calls[0][0]
+      expect(putCall.type).toBe('PutCommand')
+      expect(putCall.params.TableName).toBe('tee-admin')
+      expect(putCall.params.Item).toMatchObject({
+        pkey: 'POST#Toronto East',
+        skey: 'POST#test-post-uuid',
+        gsi1pk: 'POST#test-post-uuid',
+        gsi1sk: 'POST',
+        gsi2pk: 'POSTS#Toronto East',
+        gsi2sk: '2026-08-01T00:00:00.000Z#test-post-uuid',
+        id: 'test-post-uuid',
+        tenant: 'Toronto East',
+        status: 'ready',
+      })
+      // blocks embedded as a native list (not a JSON string).
+      expect(Array.isArray(putCall.params.Item.blocks)).toBe(true)
+      expect(putCall.params.Item.blocks[0]).toMatchObject({ id: 'b1', kind: 'text' })
+
+      // Returned value is a clean domain Post (no storage keys leaked).
+      expect(result).toMatchObject({ id: 'test-post-uuid', tenant: 'Toronto East', status: 'ready' })
+      expect(result).not.toHaveProperty('pkey')
+      expect(result).not.toHaveProperty('gsi1pk')
+      expect(result.createdAt).toBe(result.updatedAt)
+    })
+
+    it('defaults status to draft, lifecycle/blocks to empty, sorts by createdAt when no publishDate', async () => {
+      mockSend.mockResolvedValueOnce({})
+
+      const result = await repository.createPost({
+        tenant: 'Ecclesia B',
+        authorId: 'a2',
+        title: 'Draft news',
+        occasion: ['news'],
+        visibility: 'public',
+        sharingScope: 'own',
+      })
+
+      expect(result.status).toBe('draft')
+      expect(result.blocks).toEqual([])
+      expect(result.lifecycle).toEqual({})
+
+      const item = mockSend.mock.calls[0][0].params.Item
+      // No publishDate → gsi2sk falls back to createdAt.
+      expect(item.gsi2sk).toBe(`${result.createdAt}#test-post-uuid`)
+    })
+  })
+
+  describe('getPost', () => {
+    it('looks up by id via gsi1 and returns a clean Post', async () => {
+      mockSend.mockResolvedValueOnce({ Items: [storedRecord()] })
+
+      const result = await repository.getPost('p1')
+
+      const queryCall = mockSend.mock.calls[0][0]
+      expect(queryCall.type).toBe('QueryCommand')
+      expect(queryCall.params.IndexName).toBe('gsi1')
+      expect(queryCall.params.ExpressionAttributeValues).toMatchObject({
+        ':gsi1pk': 'POST#p1',
+        ':gsi1sk': 'POST',
+      })
+      expect(result?.id).toBe('p1')
+      expect(result).not.toHaveProperty('pkey')
+      expect(result).not.toHaveProperty('gsi2sk')
+    })
+
+    it('returns null when not found', async () => {
+      mockSend.mockResolvedValueOnce({ Items: [] })
+      expect(await repository.getPost('missing')).toBeNull()
+    })
+  })
+
+  describe('listPosts', () => {
+    it('queries gsi2 by tenant, newest-first, and filters out archived by default', async () => {
+      mockSend.mockResolvedValueOnce({
+        Items: [
+          storedRecord({ id: 'p1', status: 'ready' }),
+          storedRecord({ id: 'p2', status: 'archived' }),
+        ],
+      })
+
+      const { posts } = await repository.listPosts({ tenant: 'Toronto East' })
+
+      const queryCall = mockSend.mock.calls[0][0]
+      expect(queryCall.params.IndexName).toBe('gsi2')
+      expect(queryCall.params.ExpressionAttributeValues).toMatchObject({
+        ':gsi2pk': 'POSTS#Toronto East',
+      })
+      expect(queryCall.params.ScanIndexForward).toBe(false) // newest-first
+      expect(posts).toHaveLength(1)
+      expect(posts[0].id).toBe('p1')
+    })
+
+    it('includes archived when includeArchived is set', async () => {
+      mockSend.mockResolvedValueOnce({
+        Items: [
+          storedRecord({ id: 'p1', status: 'ready' }),
+          storedRecord({ id: 'p2', status: 'archived' }),
+        ],
+      })
+
+      const { posts } = await repository.listPosts({
+        tenant: 'Toronto East',
+        includeArchived: true,
+      })
+      expect(posts).toHaveLength(2)
+    })
+  })
+
+  describe('updatePost', () => {
+    it('loads the post (gsi1), then updates via base keys and recomputes gsi2sk', async () => {
+      mockSend
+        .mockResolvedValueOnce({ Items: [storedRecord({ id: 'p1' })] }) // getPost
+        .mockResolvedValueOnce({
+          Attributes: storedRecord({ id: 'p1', title: 'Updated title' }),
+        }) // update
+
+      const result = await repository.updatePost('p1', {
+        title: 'Updated title',
+        lifecycle: { publishDate: '2026-09-01T00:00:00.000Z' },
+      })
+
+      expect(mockSend).toHaveBeenCalledTimes(2)
+      const updateCall = mockSend.mock.calls[1][0]
+      expect(updateCall.type).toBe('UpdateCommand')
+      // Updates target the base table keys, not the GSI.
+      expect(updateCall.params.Key).toEqual({
+        pkey: 'POST#Toronto East',
+        skey: 'POST#p1',
+      })
+      // gsi2sk was recomputed from the new publishDate and included in the update.
+      expect(Object.values(updateCall.params.ExpressionAttributeValues)).toContain(
+        '2026-09-01T00:00:00.000Z#p1'
+      )
+      expect(result.title).toBe('Updated title')
+    })
+
+    it('throws when the post does not exist', async () => {
+      mockSend.mockResolvedValueOnce({ Items: [] }) // getPost → none
+      await expect(repository.updatePost('missing', { title: 'x' })).rejects.toThrow(
+        /not found/
+      )
+    })
+  })
+
+  describe('archivePost', () => {
+    it('sets status to archived', async () => {
+      mockSend
+        .mockResolvedValueOnce({ Items: [storedRecord({ id: 'p1' })] }) // getPost
+        .mockResolvedValueOnce({
+          Attributes: storedRecord({ id: 'p1', status: 'archived' }),
+        }) // update
+
+      const result = await repository.archivePost('p1')
+
+      const updateCall = mockSend.mock.calls[1][0]
+      expect(Object.values(updateCall.params.ExpressionAttributeValues)).toContain('archived')
+      expect(result.status).toBe('archived')
+    })
+  })
+
+  describe('listAllPosts', () => {
+    it('scans for POST# items and drops archived by default', async () => {
+      mockSend.mockResolvedValueOnce({
+        Items: [
+          storedRecord({ id: 'p1', status: 'ready' }),
+          storedRecord({ id: 'p2', status: 'archived' }),
+        ],
+        LastEvaluatedKey: undefined,
+      })
+
+      const posts = await repository.listAllPosts()
+
+      const scanCall = mockSend.mock.calls[0][0]
+      expect(scanCall.type).toBe('ScanCommand')
+      expect(posts.map((p) => p.id)).toEqual(['p1'])
+    })
+  })
+})

--- a/apps/next/tests/services/post-service.test.ts
+++ b/apps/next/tests/services/post-service.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the data sources; keep legacyToPost + redactPost REAL so the test
+// exercises the actual merge + redaction pipeline.
+vi.mock('@my/app/provider/dynamodb/repositories/post-repository', () => ({
+  postRepository: {
+    listPosts: vi.fn(),
+    listAllPosts: vi.fn(),
+  },
+}))
+vi.mock('@my/app/services/event-service', () => ({
+  getPublishedEvents: vi.fn(),
+}))
+vi.mock('@my/app/services/news-service', () => ({
+  listNewsItems: vi.fn(),
+}))
+
+import { getPostsForViewer } from '@my/app/services/post-service'
+import { postRepository } from '@my/app/provider/dynamodb/repositories/post-repository'
+import { getPublishedEvents } from '@my/app/services/event-service'
+import { listNewsItems } from '@my/app/services/news-service'
+import { ANONYMOUS_VIEWER, type Viewer } from '@my/app/utils/viewer-pii'
+import type { Post, PersonBlock } from '@my/app/types/post'
+
+const member: Viewer = {
+  assurance: 'authenticated',
+  role: 'member',
+  tenant: 'Toronto East',
+  email: 'm@x.z',
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const nativePost: Post = {
+  id: 'native-1',
+  tenant: 'Toronto East',
+  authorId: 'author-1',
+  title: 'Native Wedding',
+  occasion: ['wedding'],
+  visibility: 'public',
+  sharingScope: 'own',
+  lifecycle: {},
+  blocks: [
+    { id: 'pb', kind: 'person', role: 'bride', people: [{ firstName: 'Mary', lastName: 'Jones' }] },
+  ],
+  createdAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+  status: 'ready',
+}
+
+// Legacy baptism Event → PersonBlock(candidate) with name + bio (aboutCandidate).
+const legacyEvent = {
+  id: 'ev-1',
+  type: 'baptism',
+  title: 'Baptism',
+  ownerEcclesia: 'Toronto East',
+  createdBy: 'x',
+  candidate: { firstName: 'Josh', lastName: 'Archibald' },
+  aboutCandidate: 'A heartfelt testimony',
+  createdAt: new Date('2026-07-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+}
+
+// Legacy 'medical' NewsItem → members-only TextBlock (PII-bearing occasion).
+const legacyNews = {
+  id: 'nw-1',
+  ecclesiaId: 'Toronto East',
+  authorId: 'x',
+  title: 'Health update',
+  category: 'medical',
+  body: 'Private medical details',
+  publishedAt: new Date('2026-07-01T00:00:00.000Z'),
+  expiresAt: new Date('2026-12-01T00:00:00.000Z'),
+  sharingScope: 'own',
+  createdAt: new Date('2026-07-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+}
+
+function byId(posts: Post[], id: string): Post {
+  const p = posts.find((x) => x.id === id)
+  if (!p) throw new Error(`post ${id} not in result`)
+  return p
+}
+function person(post: Post): PersonBlock['people'][number] {
+  const block = post.blocks.find((b): b is PersonBlock => b.kind === 'person')
+  if (!block) throw new Error(`no person block on ${post.id}`)
+  return block.people[0]
+}
+
+describe('getPostsForViewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(postRepository.listAllPosts as any).mockResolvedValue([nativePost])
+    ;(postRepository.listPosts as any).mockResolvedValue({ posts: [nativePost] })
+    ;(getPublishedEvents as any).mockResolvedValue([legacyEvent])
+    ;(listNewsItems as any).mockResolvedValue([legacyNews])
+  })
+
+  it('merges native + legacy (events & news) into one set', async () => {
+    const posts = await getPostsForViewer(member)
+    expect(posts.map((p) => p.id).sort()).toEqual(['ev-1', 'native-1', 'nw-1'])
+    // Legacy came through the adapter (news defaults to includeExpired:false).
+    expect(getPublishedEvents).toHaveBeenCalledTimes(1)
+    expect(listNewsItems).toHaveBeenCalledWith({ includeExpired: false })
+    expect(postRepository.listAllPosts).toHaveBeenCalledTimes(1)
+  })
+
+  it('redacts PII for an anonymous viewer (first-name floor, bio + members-only text dropped)', async () => {
+    const posts = await getPostsForViewer(ANONYMOUS_VIEWER)
+
+    // native person: first name only, no surname.
+    expect(person(byId(posts, 'native-1'))).toEqual({ firstName: 'Mary' })
+
+    // legacy baptism candidate: first name only, obituary/testimony bio dropped.
+    const candidate = person(byId(posts, 'ev-1'))
+    expect(candidate.firstName).toBe('Josh')
+    expect(candidate).not.toHaveProperty('lastName')
+    expect(candidate).not.toHaveProperty('bio')
+
+    // legacy medical news: the members-only body TextBlock is not reachable by anon.
+    const news = byId(posts, 'nw-1')
+    expect(news.blocks.some((b) => b.kind === 'text')).toBe(false)
+  })
+
+  it('reveals full PII for an authenticated member', async () => {
+    const posts = await getPostsForViewer(member)
+
+    expect(person(byId(posts, 'native-1')).lastName).toBe('Jones')
+
+    const candidate = person(byId(posts, 'ev-1'))
+    expect(candidate.lastName).toBe('Archibald')
+    expect(candidate.bio).toBe('A heartfelt testimony')
+
+    const news = byId(posts, 'nw-1')
+    const text = news.blocks.find((b) => b.kind === 'text')
+    expect(text && text.kind === 'text' ? text.body : null).toBe('Private medical details')
+  })
+
+  it('scopes to a tenant via listPosts and filters legacy by tenant', async () => {
+    ;(getPublishedEvents as any).mockResolvedValue([
+      legacyEvent,
+      { ...legacyEvent, id: 'ev-other', ownerEcclesia: 'Hamilton' },
+    ])
+
+    const posts = await getPostsForViewer(member, { tenant: 'Toronto East' })
+
+    expect(postRepository.listPosts).toHaveBeenCalledWith(
+      expect.objectContaining({ tenant: 'Toronto East' })
+    )
+    expect(postRepository.listAllPosts).not.toHaveBeenCalled()
+    // The Hamilton event is filtered out; Toronto East legacy + native remain.
+    expect(posts.map((p) => p.id).sort()).toEqual(['ev-1', 'native-1', 'nw-1'])
+  })
+})

--- a/apps/next/utils/redact-news.ts
+++ b/apps/next/utils/redact-news.ts
@@ -12,6 +12,7 @@
  * flag OFF the raw item is returned unchanged (byte-identical).
  */
 import type { NewsItem } from '@my/app/types/news'
+import type { TextBlock } from '@my/app/types/post'
 import type { Viewer } from '@my/app/utils/viewer-pii'
 import { legacyToPost } from '@my/app/utils/legacy-to-post'
 import { redactPost } from '@my/app/utils/redact-post'
@@ -19,11 +20,12 @@ import { redactPost } from '@my/app/utils/redact-post'
 export function redactNewsForViewer(item: NewsItem, viewer: Viewer): NewsItem {
   const post = redactPost(legacyToPost(item), viewer, { channel: 'public-web' })
   if (!post) return { ...item, body: '', documents: [] }
-  const textBlock = post.blocks.find((b) => b.kind === 'text')
+  // The type-predicate narrows the find result to TextBlock, so no re-check is needed.
+  const textBlock = post.blocks.find((b): b is TextBlock => b.kind === 'text')
   const hasFlyer = post.blocks.some((b) => b.kind === 'flyer')
   return {
     ...item,
-    body: textBlock && textBlock.kind === 'text' ? textBlock.body : '',
+    body: textBlock ? textBlock.body : '',
     documents: hasFlyer ? item.documents : [],
   }
 }

--- a/packages/app/provider/dynamodb/index.ts
+++ b/packages/app/provider/dynamodb/index.ts
@@ -4,17 +4,20 @@ export * from './types'
 export * from './repositories/schedule-repository'
 export * from './repositories/admin-repository'
 export * from './repositories/person-repository'
+export * from './repositories/post-repository'
 export * from './table-definitions'
 
 // Repository instances (singletons)
 import { ScheduleRepository } from './repositories/schedule-repository'
 import { AdminRepository } from './repositories/admin-repository'
 import { PersonRepository } from './repositories/person-repository'
+import { PostRepository } from './repositories/post-repository'
 
 // Export repository instances
 export const scheduleRepo = new ScheduleRepository()
 export const adminRepo = new AdminRepository()
 export const personRepo = new PersonRepository()
+export const postRepo = new PostRepository()
 
 // Convenience methods for common operations
 export const DynamoDataLayer = {

--- a/packages/app/provider/dynamodb/repositories/post-repository.ts
+++ b/packages/app/provider/dynamodb/repositories/post-repository.ts
@@ -1,0 +1,276 @@
+import { v4 as uuidv4 } from 'uuid'
+import { BaseRepository } from './base-repository'
+import type { Post } from '@my/app/types/post'
+
+/**
+ * PostRepository — native storage for the unified {@link Post} model
+ * (Consolidated CMS epic #131, Phase 1). See docs/UNIFIED_POST_MODEL_DESIGN.md
+ * §2 (Post), §7 (Phase 1 = "Persist posts as blocks; adapter-read legacy during
+ * transition").
+ *
+ * Storage — ONE item per post in the `tee-admin` table with `blocks` embedded as
+ * a native list (posts are small; no schedule-style JSON-string serialization).
+ * Mirrors the person-repository conventions: lowercase `pkey`/`skey` attribute
+ * names, `POST#`-prefixed key values, overloaded GSIs, uuid ids.
+ *
+ * Key scheme (mirrors the adjacency-list + overloaded-GSI pattern):
+ *   base   pkey = POST#{tenant}    skey = POST#{postId}   — list-by-tenant + unique item
+ *   gsi1   gsi1pk = POST#{postId}  gsi1sk = POST          — O(1) getPost(postId) (like getByEmail)
+ *   gsi2   gsi2pk = POSTS#{tenant} gsi2sk = {sortDate}#{postId}
+ *          — chronological list by lifecycle.publishDate (falls back to createdAt),
+ *            the same idea the events GSI uses ({date}#{id}). `sortDate` lets
+ *            listPosts return newest-first without a scan.
+ *
+ * Cross-platform: no `next-auth` / `next/*` imports (server-only via BaseRepository).
+ */
+
+/** Stored shape: the domain {@link Post} plus DynamoDB key + overloaded-GSI attributes. */
+export interface PostRecord extends Post {
+  pkey: string
+  skey: string
+  gsi1pk: string
+  gsi1sk: string
+  gsi2pk: string
+  gsi2sk: string
+  version?: number
+  lastUpdated?: string
+}
+
+export interface CreatePostInput {
+  tenant: string
+  authorId: string
+  title: string
+  occasion: Post['occasion']
+  summary?: string
+  visibility: Post['visibility']
+  sharingScope: Post['sharingScope']
+  lifecycle?: Post['lifecycle']
+  blocks?: Post['blocks']
+  status?: Post['status']
+}
+
+/** Fields a caller may patch. Keys, id, tenant and createdAt are immutable here. */
+export type UpdatePostInput = Partial<
+  Pick<
+    Post,
+    | 'title'
+    | 'occasion'
+    | 'summary'
+    | 'visibility'
+    | 'sharingScope'
+    | 'lifecycle'
+    | 'blocks'
+    | 'status'
+  >
+>
+
+export interface ListPostsOptions {
+  tenant: string
+  /** Include archived posts. Default false — archived are filtered out. */
+  includeArchived?: boolean
+  /** Only return posts with this status (e.g. 'ready'). */
+  status?: Post['status']
+  /** Newest-first by default (false). Pass true for oldest-first. */
+  oldestFirst?: boolean
+  limit?: number
+  lastEvaluatedKey?: Record<string, any>
+}
+
+export interface ListPostsResult {
+  posts: Post[]
+  lastEvaluatedKey?: Record<string, any>
+}
+
+/** The date a post sorts by in gsi2: its publishDate, else its createdAt. */
+function sortDate(lifecycle: Post['lifecycle'] | undefined, createdAt: string): string {
+  return lifecycle?.publishDate || createdAt
+}
+
+/**
+ * Repository for native Post records on the `tee-admin` table (lowercase
+ * pkey/skey keys, POST#-prefixed values).
+ */
+export class PostRepository extends BaseRepository<PostRecord> {
+  constructor() {
+    super('admin', false) // false = lowercase keys (pkey, skey)
+  }
+
+  protected buildSheetPK(_sheetId: string): string {
+    throw new Error('buildSheetPK not applicable for PostRepository')
+  }
+
+  private static basePk(tenant: string): string {
+    return `POST#${tenant}`
+  }
+
+  private static baseSk(postId: string): string {
+    return `POST#${postId}`
+  }
+
+  /** Build the overloaded-GSI attributes for a post. */
+  private static gsiKeys(post: Post): {
+    gsi1pk: string
+    gsi1sk: string
+    gsi2pk: string
+    gsi2sk: string
+  } {
+    return {
+      gsi1pk: `POST#${post.id}`,
+      gsi1sk: 'POST',
+      gsi2pk: `POSTS#${post.tenant}`,
+      gsi2sk: `${sortDate(post.lifecycle, post.createdAt)}#${post.id}`,
+    }
+  }
+
+  /** Strip storage attributes → a clean domain Post (no key/gsi/version leakage). */
+  private static toPost(record: PostRecord): Post {
+    const {
+      pkey: _pkey,
+      skey: _skey,
+      gsi1pk: _g1p,
+      gsi1sk: _g1s,
+      gsi2pk: _g2p,
+      gsi2sk: _g2s,
+      version: _version,
+      lastUpdated: _lastUpdated,
+      ...post
+    } = record
+    return post
+  }
+
+  /**
+   * Create a new post. Generates a uuid id and createdAt/updatedAt/status,
+   * embeds `blocks` as a native list.
+   */
+  async createPost(input: CreatePostInput): Promise<Post> {
+    const id = uuidv4()
+    const now = new Date().toISOString()
+
+    const post: Post = {
+      id,
+      tenant: input.tenant,
+      authorId: input.authorId,
+      title: input.title,
+      occasion: input.occasion,
+      summary: input.summary,
+      visibility: input.visibility,
+      sharingScope: input.sharingScope,
+      lifecycle: input.lifecycle ?? {},
+      blocks: input.blocks ?? [],
+      createdAt: now,
+      updatedAt: now,
+      status: input.status ?? 'draft',
+    }
+
+    const record: PostRecord = {
+      pkey: PostRepository.basePk(post.tenant),
+      skey: PostRepository.baseSk(post.id),
+      ...PostRepository.gsiKeys(post),
+      ...post,
+      version: 0,
+    }
+
+    await this.put(record)
+    return post
+  }
+
+  /** Get a single post by id via gsi1 (O(1) — no tenant required). */
+  async getPost(postId: string): Promise<Post | null> {
+    const result = await this.query(
+      'gsi1pk = :gsi1pk AND gsi1sk = :gsi1sk',
+      { ':gsi1pk': `POST#${postId}`, ':gsi1sk': 'POST' },
+      { indexName: 'gsi1' }
+    )
+    const record = result.items[0]
+    return record ? PostRepository.toPost(record) : null
+  }
+
+  /**
+   * List a tenant's posts, chronologically by publishDate (newest-first by
+   * default) via gsi2. Archived posts are excluded unless `includeArchived`.
+   */
+  async listPosts(options: ListPostsOptions): Promise<ListPostsResult> {
+    const result = await this.query(
+      'gsi2pk = :gsi2pk',
+      { ':gsi2pk': `POSTS#${options.tenant}` },
+      {
+        indexName: 'gsi2',
+        limit: options.limit,
+        lastEvaluatedKey: options.lastEvaluatedKey,
+        scanIndexForward: options.oldestFirst ?? false,
+      }
+    )
+
+    let posts = result.items.map(PostRepository.toPost)
+    if (options.status) {
+      posts = posts.filter((p) => p.status === options.status)
+    } else if (!options.includeArchived) {
+      posts = posts.filter((p) => p.status !== 'archived')
+    }
+
+    return { posts, lastEvaluatedKey: result.lastEvaluatedKey }
+  }
+
+  /**
+   * Update a post. Re-derives the gsi2 sort key (it encodes publishDate) so a
+   * publish-scheduling change re-sorts correctly, mirroring how updatePerson
+   * rebuilds GSI keys. Always bumps updatedAt.
+   */
+  async updatePost(postId: string, patch: UpdatePostInput): Promise<Post> {
+    const current = await this.getPost(postId)
+    if (!current) throw new Error(`Post ${postId} not found`)
+
+    const merged: Post = {
+      ...current,
+      ...patch,
+      updatedAt: new Date().toISOString(),
+    }
+
+    const updates: Partial<PostRecord> = {
+      ...patch,
+      updatedAt: merged.updatedAt,
+      gsi2sk: `${sortDate(merged.lifecycle, merged.createdAt)}#${merged.id}`,
+    }
+
+    const record = await this.update(
+      PostRepository.basePk(current.tenant),
+      PostRepository.baseSk(current.id),
+      updates
+    )
+    return PostRepository.toPost(record)
+  }
+
+  /** Archive a post (soft delete) — drops it out of the default list view. */
+  async archivePost(postId: string): Promise<Post> {
+    return this.updatePost(postId, { status: 'archived' })
+  }
+
+  /**
+   * List every native post across all tenants (scan). Used by the unified read
+   * when no tenant is scoped. The native store is small during the Phase 1
+   * transition, so a scan is acceptable here.
+   */
+  async listAllPosts(options?: { includeArchived?: boolean }): Promise<Post[]> {
+    const posts: Post[] = []
+    let lastKey: Record<string, any> | undefined
+
+    do {
+      const result = await this.scan({
+        filterExpression: 'begins_with(pkey, :prefix) AND begins_with(skey, :prefix)',
+        expressionAttributeValues: { ':prefix': 'POST#' },
+        lastEvaluatedKey: lastKey,
+      })
+      for (const record of result.items) {
+        const post = PostRepository.toPost(record)
+        if (!options?.includeArchived && post.status === 'archived') continue
+        posts.push(post)
+      }
+      lastKey = result.lastEvaluatedKey
+    } while (lastKey)
+
+    return posts
+  }
+}
+
+// Export singleton instance
+export const postRepository = new PostRepository()

--- a/packages/app/services/post-service.ts
+++ b/packages/app/services/post-service.ts
@@ -1,0 +1,90 @@
+import type { Post } from '@my/app/types/post'
+import type { Channel, Viewer } from '@my/app/utils/viewer-pii'
+import { redactPosts } from '@my/app/utils/redact-post'
+import { legacyToPost } from '@my/app/utils/legacy-to-post'
+import { postRepository } from '@my/app/provider/dynamodb/repositories/post-repository'
+import { getPublishedEvents } from '@my/app/services/event-service'
+import { listNewsItems } from '@my/app/services/news-service'
+
+/**
+ * Unified Post read service (Consolidated CMS epic #131, Phase 1).
+ *
+ * `getPostsForViewer` is the doc's "ONE read API + redactor"
+ * (docs/UNIFIED_POST_MODEL_DESIGN.md §6): it returns the merged, PII-redacted set
+ * of
+ *   1. NATIVE posts from {@link PostRepository} (the Phase 1 storage), and
+ *   2. LEGACY events + news adapted through {@link legacyToPost} (adapter-read
+ *      during the transition, §7 Phase 1),
+ * every item passed through {@link redactPost} for the (viewer, channel) so the
+ * caller never has to scrub PII itself. Native and legacy are DISJOINT today
+ * (nothing has been migrated), so the merge is a concat — no dedupe needed yet;
+ * once Phase 3 migrates records this becomes a real "one current definition"
+ * merge keyed on post id.
+ *
+ * FLAG-GATED WIRE-IN (deferred to Phase 2): this service is additive and is NOT
+ * yet wired into any existing public read path, so nothing here changes current
+ * responses — the flag-OFF behaviour of every shipped surface is byte-identical
+ * by construction. Phase 2 (the block editor) is the first real consumer; when a
+ * caller wires this into an existing read path (e.g. `/api/events/public`,
+ * `/api/events/feed`) it MUST gate on the CONSOLIDATED_CMS flag
+ * (`checkFeatureFlagFromDB`) exactly as `/api/news` already does for the Phase 0
+ * redactor, and fall back to the legacy response when the flag is OFF.
+ *
+ * Cross-platform: no `next-auth` / `next/*` imports (server-only via the repos).
+ */
+
+export interface GetPostsOptions {
+  /** Redaction channel — 'public-web' (default) hard-redacts; 'newsletter-email' is member-tier. */
+  channel?: Channel
+  /** Scope to a single tenant (ecclesia/org). Omit to include all tenants. */
+  tenant?: string
+  /** Include archived native posts / inactive legacy records. Default false. */
+  includeArchived?: boolean
+}
+
+/** Load native posts, honoring the optional tenant scope. */
+async function loadNativePosts(opts: GetPostsOptions): Promise<Post[]> {
+  if (opts.tenant) {
+    const { posts } = await postRepository.listPosts({
+      tenant: opts.tenant,
+      includeArchived: opts.includeArchived,
+    })
+    return posts
+  }
+  return postRepository.listAllPosts({ includeArchived: opts.includeArchived })
+}
+
+/**
+ * Load legacy events + news and adapt them into the Post model via
+ * `legacyToPost`. Optionally scoped to a tenant (post.tenant is derived from the
+ * legacy record's owning ecclesia).
+ */
+async function loadLegacyPosts(opts: GetPostsOptions): Promise<Post[]> {
+  const [events, news] = await Promise.all([
+    getPublishedEvents(),
+    listNewsItems({ includeExpired: false }),
+  ])
+
+  const adapted = [...events, ...news].map((record) => legacyToPost(record))
+  if (!opts.tenant) return adapted
+  return adapted.filter((post) => post.tenant === opts.tenant)
+}
+
+/**
+ * THE unified read: merged native + legacy posts, each redacted for the viewer.
+ * Posts the viewer cannot reach are dropped by `redactPosts`.
+ */
+export async function getPostsForViewer(
+  viewer: Viewer,
+  options: GetPostsOptions = {}
+): Promise<Post[]> {
+  const [native, legacy] = await Promise.all([
+    loadNativePosts(options),
+    loadLegacyPosts(options),
+  ])
+
+  // Disjoint today → concat is the correct merge. redactPosts reach-gates and
+  // PII-scrubs, dropping anything the viewer can't see.
+  const merged = [...native, ...legacy]
+  return redactPosts(merged, viewer, { channel: options.channel })
+}

--- a/packages/app/utils/legacy-to-post.ts
+++ b/packages/app/utils/legacy-to-post.ts
@@ -35,6 +35,10 @@ import type {
 
 // ── helpers ──────────────────────────────────────────────────────────────
 
+// Intentional module-level counter: `legacyToPost` output is transient (an
+// in-memory adapter view, never persisted), so a process-wide incrementing
+// counter for virtual block ids is fine — it just needs to be unique within a
+// single adapted post, not stable across calls or processes.
 let seq = 0
 /** Deterministic-enough virtual block id (adapter output is transient). */
 function bid(prefix: string): string {


### PR DESCRIPTION
Phase 1 of #131 — the persistence contract the editor (Phase 2) writes to and reads from. Additive; no existing read path changed (flag-OFF byte-identical by construction).

## What
- **`PostRepository`** (`packages/app/provider/dynamodb/repositories/post-repository.ts`) — one item per post in `tee-admin`, `blocks` embedded. Mirrors `person-repository` (`pkey`/`skey`, uuid ids, GSI reuse):
  - `pkey: POST#{tenant}`, `skey: POST#{postId}`
  - `gsi1`: `POST#{postId}` / `POST` → O(1) `getPost(postId)`
  - `gsi2`: `POSTS#{tenant}` / `{publishDate||createdAt}#{postId}` → chronological `listPosts` (`updatePost` recomputes `gsi2sk` on lifecycle change). `POST#`/`POSTS#` never collide with person `EMAIL#`/`ECCLESIA#`.
  - `createPost`/`getPost`/`listPosts`/`updatePost`/`archivePost`/`listAllPosts`; reads strip storage keys → clean `Post`.
- **`getPostsForViewer`** (`packages/app/services/post-service.ts`) — the doc's 'one read API + redactor': native posts + `legacyToPost(events+news)`, all through `redactPost(post, viewer, { channel })`. (Native/legacy disjoint today → concat; Phase 3 makes it id-keyed dedupe.)
- **Phase-0 nits folded**: `redact-news.ts` redundant `kind` re-check removed via a `(b): b is TextBlock` predicate; `legacy-to-post.ts` comment on the intentional transient block-id counter.

## Not wired into live routes (intentional)
The service is additive; Phase 2 (editor) is the first real consumer. Leaving it un-wired keeps every existing path byte-identical. TODO in the service documents the flag-gated wire-in (`checkFeatureFlagFromDB`, exactly as `/api/news` already does).

## Verify
- New tests **14/14** (repository CRUD asserts the captured key scheme; service merges native+legacy and redacts anon vs member). Phase-0 suites **40/40** still pass. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)