### PR TITLE
CONSOLIDATED_CMS Phase 2a — the one editor: block-registry keystone + Text/Time blocks (#131)

### DIFF
--- a/apps/next/app/admin/(admin-plus)/posts/[id]/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/posts/[id]/page.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { YStack, XStack, Text, Spinner, Heading, Button } from '@my/ui'
+import { PostEditor, createEmptyPost, validateForPublish } from '@my/ui/src/post-editor'
+import { useAdminAccess } from '@/hooks/use-admin-access'
+import { useHydrated } from '@my/app/hooks/use-hydrated'
+import { getPost, createPost, updatePost } from '@my/app/provider/get-data'
+import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
+import type { Post } from '@my/app/types/post'
+
+/**
+ * /admin/posts/[id] — the unified Post block editor (Consolidated CMS Phase 2a).
+ *
+ * ONE page/component for CREATE and EDIT (the one-editor principle):
+ *   - id === 'new'  → start from `createEmptyPost` (an empty draft),
+ *   - otherwise     → `getPost(id)` loads the existing Post,
+ * and BOTH render the SAME `<PostEditor>`. Session (author) comes from the
+ * platform (`useAdminAccess`) and is passed IN — the editor never reaches out.
+ *
+ * Autosave: debounced PUT (POST on first save of a brand-new draft to mint the
+ * id). Publish validates (title + >=1 block) then flips status → 'ready'.
+ * Flag-gated at the API (owner/admin + CONSOLIDATED_CMS); the page mirrors the
+ * admin-access gate the other /admin pages use.
+ */
+export default function AdminPostEditorPage() {
+  const isHydrated = useHydrated()
+  const { hasAccess, isLoading, user } = useAdminAccess()
+  const router = useRouter()
+  const params = useParams<{ id: string }>()
+  const routeId = params?.id
+
+  const [post, setPost] = useState<Post | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+
+  // The server-assigned id once the draft has been created (starts '' for new).
+  const savedIdRef = useRef<string>('')
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const inFlightRef = useRef(false)
+
+  const authorId = user?.email || 'unknown'
+
+  // ---- Load (or seed an empty draft) ---------------------------------------
+  useEffect(() => {
+    if (!hasAccess || !routeId) return
+    let cancelled = false
+
+    if (routeId === 'new') {
+      setPost(createEmptyPost(HOME_ECCLESIA.canonicalName, authorId))
+      savedIdRef.current = ''
+      return
+    }
+
+    getPost(routeId)
+      .then((loaded) => {
+        if (cancelled) return
+        setPost(loaded)
+        savedIdRef.current = loaded.id
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setLoadError(err instanceof Error ? err.message : 'Failed to load post')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [hasAccess, routeId, authorId])
+
+  // ---- Persist (create-then-update) ----------------------------------------
+  const persist = useCallback(async (next: Post): Promise<Post | null> => {
+    if (inFlightRef.current) return null
+    inFlightRef.current = true
+    setSaveState('saving')
+    try {
+      let result: Post
+      if (savedIdRef.current) {
+        result = await updatePost(savedIdRef.current, next)
+      } else {
+        result = await createPost(next)
+        savedIdRef.current = result.id
+      }
+      setSaveState('saved')
+      return result
+    } catch (err) {
+      console.error('Post save failed:', err)
+      setSaveState('error')
+      return null
+    } finally {
+      inFlightRef.current = false
+    }
+  }, [])
+
+  // ---- Controlled change → debounced autosave ------------------------------
+  const handleChange = useCallback(
+    (next: Post) => {
+      setPost(next)
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      debounceRef.current = setTimeout(() => {
+        void persist(next)
+      }, 1000)
+    },
+    [persist]
+  )
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [])
+
+  // ---- Publish (validate-on-publish only) ----------------------------------
+  const handlePublish = useCallback(
+    async (toPublish: Post) => {
+      const errors = validateForPublish(toPublish)
+      if (errors.length > 0) return // editor already surfaces these inline
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      const ready: Post = { ...toPublish, status: 'ready' }
+      const result = await persist(ready)
+      if (result) {
+        // Same editor stays mounted (one-editor principle) — status is now
+        // 'ready'. A dedicated posts list / router redirect is a later slice.
+        setPost(result)
+      }
+    },
+    [persist]
+  )
+
+  // ---- Gates ---------------------------------------------------------------
+  if (!isHydrated || isLoading || !hasAccess) {
+    return (
+      <YStack flex={1} justifyContent="center" alignItems="center" padding="$4">
+        <Spinner size="large" />
+        <Text marginTop="$4">Loading...</Text>
+      </YStack>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <YStack flex={1} padding="$4" gap="$3">
+        <Heading size="$7">Post</Heading>
+        <Text color="$red10">{loadError}</Text>
+        <XStack>
+          <Button variant="outlined" onPress={() => router.push('/admin')}>
+            Back
+          </Button>
+        </XStack>
+      </YStack>
+    )
+  }
+
+  if (!post) {
+    return (
+      <YStack flex={1} justifyContent="center" alignItems="center" padding="$4">
+        <Spinner size="large" />
+        <Text marginTop="$4">Loading post...</Text>
+      </YStack>
+    )
+  }
+
+  const saveLabel =
+    saveState === 'saving'
+      ? 'Saving…'
+      : saveState === 'saved'
+        ? 'All changes saved'
+        : saveState === 'error'
+          ? 'Save failed — retrying on next edit'
+          : ''
+
+  return (
+    <YStack flex={1} padding="$4" gap="$3">
+      <XStack justifyContent="space-between" alignItems="center">
+        <Heading size="$7">{routeId === 'new' ? 'New post' : 'Edit post'}</Heading>
+        <Text
+          fontSize="$2"
+          color={saveState === 'error' ? '$red10' : '$color10'}
+          minHeight={16}
+        >
+          {saveLabel}
+        </Text>
+      </XStack>
+
+      <PostEditor value={post} onChange={handleChange} onPublish={handlePublish} />
+    </YStack>
+  )
+}

--- a/apps/next/app/admin/(admin-plus)/ui-ux/brand/post-editor/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/ui-ux/brand/post-editor/page.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { PostEditorShowcase } from '@my/ui/src/branding'
+import { useAdminAccess } from '@/hooks/use-admin-access'
+import { YStack, Text, Spinner } from '@my/ui'
+import { useHydrated } from '@my/app/hooks/use-hydrated'
+
+/**
+ * /admin/ui-ux/brand/post-editor — the /brand dev surface for the unified Post
+ * block editor (Consolidated CMS Phase 2a). Mounts the PostEditor on an
+ * in-memory draft so it can be developed in isolation. Admin/Owner only.
+ */
+export default function BrandPostEditorPage() {
+  const isHydrated = useHydrated()
+  const { hasAccess, isLoading } = useAdminAccess()
+
+  if (!isHydrated || isLoading || !hasAccess) {
+    return (
+      <YStack flex={1} justifyContent="center" alignItems="center" padding="$4">
+        <Spinner size="large" />
+        <Text marginTop="$4">Loading...</Text>
+      </YStack>
+    )
+  }
+
+  return <PostEditorShowcase />
+}

--- a/apps/next/app/api/admin/posts/[id]/route.ts
+++ b/apps/next/app/api/admin/posts/[id]/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '../../../../../utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+import { postRepository } from '@my/app/provider/dynamodb/repositories/post-repository'
+import { checkFeatureFlagFromDB } from '@my/app/features/feature-flags/use-feature-flag-wrapper'
+import { FEATURE_FLAGS } from '@my/app/features/feature-flags/feature-flags'
+import type { UpdatePostInput } from '@my/app/provider/dynamodb/repositories/post-repository'
+
+/**
+ * Admin Posts API (single) — Consolidated CMS Phase 2a.
+ *   GET → load one post by id (edit case)
+ *   PUT → update one post (the block editor's autosave target)
+ *
+ * Same three-way gate as the collection route: authenticated → owner/admin →
+ * CONSOLIDATED_CMS flag ON (else 404).
+ */
+
+async function authorize(): Promise<{ ok: true } | { ok: false; res: NextResponse }> {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return { ok: false, res: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const role = (session.user as any).role
+  if (role !== ROLES.OWNER && role !== ROLES.ADMIN) {
+    return { ok: false, res: NextResponse.json({ error: 'Admin access required' }, { status: 403 }) }
+  }
+  const flagOn = await checkFeatureFlagFromDB(FEATURE_FLAGS.CONSOLIDATED_CMS, session as any)
+  if (!flagOn) {
+    return { ok: false, res: NextResponse.json({ error: 'Not found' }, { status: 404 }) }
+  }
+  return { ok: true }
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const gate = await authorize()
+  if (!gate.ok) return gate.res
+
+  try {
+    const { id } = await params
+    const post = await postRepository.getPost(id)
+    if (!post) return NextResponse.json({ error: 'Post not found' }, { status: 404 })
+    return NextResponse.json(post)
+  } catch (error) {
+    console.error('Error loading post:', error)
+    return NextResponse.json({ error: 'Failed to load post' }, { status: 500 })
+  }
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const gate = await authorize()
+  if (!gate.ok) return gate.res
+
+  try {
+    const { id } = await params
+    const body = await request.json()
+
+    // Only allow the caller to patch the editable fields (keys/id/tenant/
+    // createdAt/authorId are immutable here).
+    const patch: UpdatePostInput = {}
+    if (body.title !== undefined) patch.title = body.title
+    if (body.occasion !== undefined) patch.occasion = body.occasion
+    if (body.summary !== undefined) patch.summary = body.summary
+    if (body.visibility !== undefined) patch.visibility = body.visibility
+    if (body.sharingScope !== undefined) patch.sharingScope = body.sharingScope
+    if (body.lifecycle !== undefined) patch.lifecycle = body.lifecycle
+    if (body.blocks !== undefined) patch.blocks = body.blocks
+    if (body.status !== undefined) patch.status = body.status
+
+    const post = await postRepository.updatePost(id, patch)
+    return NextResponse.json(post)
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('not found')) {
+      return NextResponse.json({ error: 'Post not found' }, { status: 404 })
+    }
+    console.error('Error updating post:', error)
+    return NextResponse.json({ error: 'Failed to update post' }, { status: 500 })
+  }
+}

--- a/apps/next/app/api/admin/posts/route.ts
+++ b/apps/next/app/api/admin/posts/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '../../../../utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+import { postRepository } from '@my/app/provider/dynamodb/repositories/post-repository'
+import { checkFeatureFlagFromDB } from '@my/app/features/feature-flags/use-feature-flag-wrapper'
+import { FEATURE_FLAGS } from '@my/app/features/feature-flags/feature-flags'
+import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
+import type { Post } from '@my/app/types/post'
+
+/**
+ * Admin Posts API — native unified-Post storage (Consolidated CMS epic #131,
+ * Phase 2a). The save/load backend for the block editor.
+ *
+ *   GET  → list a tenant's posts (newest-first, includes drafts + archived)
+ *   POST → create a post
+ *
+ * Gated three ways, in order: authenticated → owner/admin → CONSOLIDATED_CMS
+ * feature flag ON. With the flag OFF the routes 404 (the feature does not exist
+ * for un-flagged users), so nothing about the current app changes.
+ */
+
+/** Shared gate → returns either an error response or the authorized session. */
+async function authorize(): Promise<
+  { ok: true; session: NonNullable<Awaited<ReturnType<typeof auth>>> } | { ok: false; res: NextResponse }
+> {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return { ok: false, res: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const role = (session.user as any).role
+  if (role !== ROLES.OWNER && role !== ROLES.ADMIN) {
+    return { ok: false, res: NextResponse.json({ error: 'Admin access required' }, { status: 403 }) }
+  }
+  const flagOn = await checkFeatureFlagFromDB(FEATURE_FLAGS.CONSOLIDATED_CMS, session as any)
+  if (!flagOn) {
+    return { ok: false, res: NextResponse.json({ error: 'Not found' }, { status: 404 }) }
+  }
+  return { ok: true, session }
+}
+
+export async function GET(request: NextRequest) {
+  const gate = await authorize()
+  if (!gate.ok) return gate.res
+
+  try {
+    const tenant =
+      new URL(request.url).searchParams.get('tenant') || HOME_ECCLESIA.canonicalName
+    const { posts } = await postRepository.listPosts({ tenant, includeArchived: true })
+    return NextResponse.json(posts)
+  } catch (error) {
+    console.error('Error listing posts (admin):', error)
+    return NextResponse.json({ error: 'Failed to list posts' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const gate = await authorize()
+  if (!gate.ok) return gate.res
+
+  try {
+    const body = (await request.json()) as Partial<Post>
+    const post = await postRepository.createPost({
+      tenant: body.tenant || HOME_ECCLESIA.canonicalName,
+      authorId: gate.session.user.email!,
+      title: body.title ?? '',
+      occasion: body.occasion ?? ['general'],
+      summary: body.summary,
+      visibility: body.visibility ?? 'public',
+      sharingScope: body.sharingScope ?? 'own',
+      lifecycle: body.lifecycle,
+      blocks: body.blocks,
+      status: body.status ?? 'draft',
+    })
+    return NextResponse.json(post, { status: 201 })
+  } catch (error) {
+    console.error('Error creating post:', error)
+    return NextResponse.json({ error: 'Failed to create post' }, { status: 500 })
+  }
+}

--- a/apps/next/tests/post-editor-reducer.test.ts
+++ b/apps/next/tests/post-editor-reducer.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import {
+  postReducer,
+  createEmptyPost,
+  validateForPublish,
+} from '@my/ui/src/post-editor/post-reducer'
+import type { Block, Post, TextBlock, TimeBlock } from '@my/app/types/post'
+
+/**
+ * Reducer-level tests for the PostEditor's pure state transitions
+ * (Consolidated CMS Phase 2a). The editor is a controlled component; all its
+ * behaviour flows through `postReducer`, so these cover add / remove / reorder /
+ * patch-block + patch-post + the create-case factory + publish validation
+ * without rendering.
+ */
+
+const text = (id: string, body = ''): TextBlock => ({ id, kind: 'text', body, containsPii: false })
+const time = (id: string): TimeBlock => ({ id, kind: 'time' })
+
+function draft(blocks: Block[] = []): Post {
+  return { ...createEmptyPost('tee', 'author@x.com'), blocks }
+}
+
+describe('createEmptyPost', () => {
+  it('produces an empty, unsaved draft (id === "") ready for the SAME editor as edit', () => {
+    const p = createEmptyPost('tee', 'author@x.com')
+    expect(p.id).toBe('')
+    expect(p.tenant).toBe('tee')
+    expect(p.authorId).toBe('author@x.com')
+    expect(p.status).toBe('draft')
+    expect(p.visibility).toBe('public')
+    expect(p.sharingScope).toBe('own')
+    expect(p.occasion).toEqual(['general'])
+    expect(p.blocks).toEqual([])
+    expect(typeof p.createdAt).toBe('string')
+  })
+})
+
+describe('validateForPublish', () => {
+  it('requires a title and at least one block', () => {
+    expect(validateForPublish(draft())).toEqual([
+      'A title is required',
+      'Add at least one block',
+    ])
+  })
+  it('passes with a title + a block', () => {
+    const p: Post = { ...draft([text('a', 'hello')]), title: 'Hi' }
+    expect(validateForPublish(p)).toEqual([])
+  })
+  it('treats whitespace-only titles as empty', () => {
+    const p: Post = { ...draft([text('a')]), title: '   ' }
+    expect(validateForPublish(p)).toContain('A title is required')
+  })
+})
+
+describe('postReducer', () => {
+  it('patch-post merges header fields immutably', () => {
+    const p = draft()
+    const next = postReducer(p, { type: 'patch-post', patch: { title: 'New', visibility: 'members' } })
+    expect(next.title).toBe('New')
+    expect(next.visibility).toBe('members')
+    expect(p.title).toBe('') // original untouched
+    expect(next).not.toBe(p)
+  })
+
+  it('add-block appends the provided block', () => {
+    const next = postReducer(draft(), { type: 'add-block', block: text('a') })
+    expect(next.blocks.map((b) => b.id)).toEqual(['a'])
+  })
+
+  it('remove-block drops by id', () => {
+    const next = postReducer(draft([text('a'), text('b')]), { type: 'remove-block', id: 'a' })
+    expect(next.blocks.map((b) => b.id)).toEqual(['b'])
+  })
+
+  it('move-block up/down reorders; no-ops at the edges', () => {
+    const p = draft([text('a'), text('b'), text('c')])
+    const down = postReducer(p, { type: 'move-block', id: 'a', direction: 'down' })
+    expect(down.blocks.map((b) => b.id)).toEqual(['b', 'a', 'c'])
+
+    const up = postReducer(p, { type: 'move-block', id: 'c', direction: 'up' })
+    expect(up.blocks.map((b) => b.id)).toEqual(['a', 'c', 'b'])
+
+    const noop = postReducer(p, { type: 'move-block', id: 'a', direction: 'up' })
+    expect(noop.blocks.map((b) => b.id)).toEqual(['a', 'b', 'c'])
+    expect(noop).toBe(p) // edge move returns the same reference
+
+    const unknown = postReducer(p, { type: 'move-block', id: 'zzz', direction: 'down' })
+    expect(unknown).toBe(p)
+  })
+
+  it('patch-block merges into the matching block only, preserving kind + id', () => {
+    const p = draft([text('a', 'old'), time('b')])
+    const next = postReducer(p, {
+      type: 'patch-block',
+      id: 'a',
+      patch: { body: 'new', containsPii: true } as Partial<Block>,
+    })
+    const a = next.blocks[0] as TextBlock
+    expect(a).toMatchObject({ id: 'a', kind: 'text', body: 'new', containsPii: true })
+    expect(next.blocks[1]).toEqual(time('b')) // other block untouched
+    expect((p.blocks[0] as TextBlock).body).toBe('old') // original untouched
+  })
+
+  it('patch-block with a full replacement block (editor onChange contract) replaces fields', () => {
+    const p = draft([text('a', 'old')])
+    const replacement: TextBlock = { id: 'a', kind: 'text', body: 'replaced', containsPii: false }
+    const next = postReducer(p, { type: 'patch-block', id: 'a', patch: replacement })
+    expect(next.blocks[0]).toEqual(replacement)
+  })
+})

--- a/apps/next/tests/post-editor-registry.test.ts
+++ b/apps/next/tests/post-editor-registry.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  registerBlock,
+  getBlockDef,
+  listBlockDefs,
+  clearBlockRegistry,
+} from '@my/ui/src/post-editor/registry'
+import type { TextBlock, TimeBlock } from '@my/app/types/post'
+
+/**
+ * Block registry contract (Consolidated CMS Phase 2a). The registry is the
+ * editor's extensibility seam — register / get / list, in registration order.
+ * A no-op component stands in for a real Editor so the test stays free of any
+ * Tamagui/React rendering.
+ */
+
+const NoopEditor = () => null
+
+beforeEach(() => {
+  clearBlockRegistry()
+})
+
+describe('block registry', () => {
+  it('register → get returns the same definition (with kind filled in)', () => {
+    registerBlock<TextBlock>('text', {
+      label: 'Text',
+      make: () => ({ id: 'x', kind: 'text', body: '', containsPii: false }),
+      Editor: NoopEditor,
+    })
+
+    const def = getBlockDef('text')
+    expect(def).toBeDefined()
+    expect(def!.kind).toBe('text')
+    expect(def!.label).toBe('Text')
+    expect(def!.make().kind).toBe('text')
+  })
+
+  it('make() yields a fresh block each call (unique ids when a generator is used)', () => {
+    let n = 0
+    registerBlock<TimeBlock>('time', {
+      label: 'Date & time',
+      make: () => ({ id: `t${n++}`, kind: 'time' }),
+      Editor: NoopEditor,
+    })
+    const a = getBlockDef('time')!.make()
+    const b = getBlockDef('time')!.make()
+    expect(a.id).not.toBe(b.id)
+  })
+
+  it('listBlockDefs returns all defs in registration order', () => {
+    registerBlock<TextBlock>('text', {
+      label: 'Text',
+      make: () => ({ id: 'x', kind: 'text', body: '', containsPii: false }),
+      Editor: NoopEditor,
+    })
+    registerBlock<TimeBlock>('time', {
+      label: 'Date & time',
+      make: () => ({ id: 'y', kind: 'time' }),
+      Editor: NoopEditor,
+    })
+    expect(listBlockDefs().map((d) => d.kind)).toEqual(['text', 'time'])
+  })
+
+  it('re-registering the same kind overrides the definition', () => {
+    registerBlock<TextBlock>('text', {
+      label: 'First',
+      make: () => ({ id: 'x', kind: 'text', body: '', containsPii: false }),
+      Editor: NoopEditor,
+    })
+    registerBlock<TextBlock>('text', {
+      label: 'Second',
+      make: () => ({ id: 'x', kind: 'text', body: '', containsPii: false }),
+      Editor: NoopEditor,
+    })
+    expect(getBlockDef('text')!.label).toBe('Second')
+    expect(listBlockDefs()).toHaveLength(1)
+  })
+
+  it('getBlockDef returns undefined for an unregistered kind', () => {
+    expect(getBlockDef('person')).toBeUndefined()
+  })
+})

--- a/apps/next/tests/posts-route.test.ts
+++ b/apps/next/tests/posts-route.test.ts
@@ -1,0 +1,106 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+
+/**
+ * Guard matrix for the admin Posts API (Consolidated CMS Phase 2a). The
+ * safety-critical bits: three-way gate in order — authenticated → owner/admin →
+ * CONSOLIDATED_CMS flag ON (else 404) — on BOTH create (POST) and list (GET).
+ * Only when all three pass does it touch the repository.
+ */
+
+const h = vi.hoisted(() => ({
+  auth: vi.fn(),
+  checkFlag: vi.fn(),
+  listPosts: vi.fn(),
+  createPost: vi.fn(),
+}))
+
+vi.mock('../utils/auth', () => ({ auth: h.auth }))
+vi.mock('@my/app/features/feature-flags/use-feature-flag-wrapper', () => ({
+  checkFeatureFlagFromDB: h.checkFlag,
+}))
+vi.mock('@my/app/provider/dynamodb/repositories/post-repository', () => ({
+  postRepository: { listPosts: h.listPosts, createPost: h.createPost },
+}))
+
+import { GET, POST } from '../app/api/admin/posts/route'
+
+const OWNER = { user: { email: 'owner@tee-admin.com', role: ROLES.OWNER } }
+const MEMBER = { user: { email: 'm@x.com', role: ROLES.MEMBER } }
+
+function getReq() {
+  return { url: 'http://localhost/api/admin/posts' } as any
+}
+function postReq(body: any) {
+  return { url: 'http://localhost/api/admin/posts', json: async () => body } as any
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.auth.mockResolvedValue(OWNER)
+  h.checkFlag.mockResolvedValue(true)
+  h.listPosts.mockResolvedValue({ posts: [{ id: 'p1' }] })
+  h.createPost.mockResolvedValue({ id: 'new-id', title: 'Hi' })
+})
+
+describe('GET /api/admin/posts — gate', () => {
+  it('401 when unauthenticated', async () => {
+    h.auth.mockResolvedValue(null)
+    const res = await GET(getReq())
+    expect(res.status).toBe(401)
+    expect(h.listPosts).not.toHaveBeenCalled()
+  })
+
+  it('403 when not owner/admin', async () => {
+    h.auth.mockResolvedValue(MEMBER)
+    const res = await GET(getReq())
+    expect(res.status).toBe(403)
+    expect(h.listPosts).not.toHaveBeenCalled()
+  })
+
+  it('404 when the CONSOLIDATED_CMS flag is OFF (feature hidden)', async () => {
+    h.checkFlag.mockResolvedValue(false)
+    const res = await GET(getReq())
+    expect(res.status).toBe(404)
+    expect(h.listPosts).not.toHaveBeenCalled()
+  })
+
+  it('200 returns the tenant posts when authorized + flag ON', async () => {
+    const res = await GET(getReq())
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([{ id: 'p1' }])
+    expect(h.listPosts).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('POST /api/admin/posts — gate + create', () => {
+  it('401 when unauthenticated', async () => {
+    h.auth.mockResolvedValue(null)
+    const res = await POST(postReq({ title: 'Hi' }))
+    expect(res.status).toBe(401)
+    expect(h.createPost).not.toHaveBeenCalled()
+  })
+
+  it('403 when not owner/admin', async () => {
+    h.auth.mockResolvedValue(MEMBER)
+    const res = await POST(postReq({ title: 'Hi' }))
+    expect(res.status).toBe(403)
+    expect(h.createPost).not.toHaveBeenCalled()
+  })
+
+  it('404 when the flag is OFF', async () => {
+    h.checkFlag.mockResolvedValue(false)
+    const res = await POST(postReq({ title: 'Hi' }))
+    expect(res.status).toBe(404)
+    expect(h.createPost).not.toHaveBeenCalled()
+  })
+
+  it('201 creates with the author derived from the session', async () => {
+    const res = await POST(postReq({ title: 'Hi', blocks: [] }))
+    expect(res.status).toBe(201)
+    expect(h.createPost).toHaveBeenCalledTimes(1)
+    const arg = h.createPost.mock.calls[0][0]
+    expect(arg.authorId).toBe('owner@tee-admin.com') // never trusts a client-supplied author
+    expect(arg.title).toBe('Hi')
+  })
+})

--- a/packages/app/provider/get-data.ts
+++ b/packages/app/provider/get-data.ts
@@ -11,6 +11,7 @@ import {
 import { CreateUpdateListType } from '../types'
 import type { Event } from '@my/app/types/events'
 import type { NewsItem } from '@my/app/types/news'
+import type { Post } from '@my/app/types/post'
 
 // Use shared EmailReasonType instead of importing from next-app
 type emailReasons = EmailReasonType
@@ -480,4 +481,59 @@ export const unarchiveEmail = async (pkey: string, email: string): Promise<any> 
   }
 
   return data
+}
+
+// -----------------------------------------------------------------------------
+// Unified Post model — block-editor save/load (Consolidated CMS epic #131,
+// Phase 2a). Cross-platform (API_PATH) client helpers over /api/admin/posts.
+// The API itself is owner/admin- + CONSOLIDATED_CMS-flag-gated.
+// -----------------------------------------------------------------------------
+
+/** List a tenant's posts (drafts + archived included). */
+export const listPosts = async (tenant?: string): Promise<Post[]> => {
+  const qs = tenant ? `?tenant=${encodeURIComponent(tenant)}` : ''
+  const url = `${API_PATH}api/admin/posts${qs}`
+  const response = await fetch(url, { cache: 'no-store' })
+  if (!response.ok) throw new Error(`Failed to list posts (${response.status})`)
+  return await response.json()
+}
+
+/** Load a single post by id (edit case). */
+export const getPost = async (id: string): Promise<Post> => {
+  const url = `${API_PATH}api/admin/posts/${encodeURIComponent(id)}`
+  const response = await fetch(url, { cache: 'no-store' })
+  if (!response.ok) throw new Error(`Failed to load post (${response.status})`)
+  return await response.json()
+}
+
+/** Create a new post; returns the persisted Post (with its assigned id). */
+export const createPost = async (input: Partial<Post>): Promise<Post> => {
+  const url = `${API_PATH}api/admin/posts`
+  const response = await fetch(url, {
+    cache: 'no-store',
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}))
+    throw new Error(data.error || `Failed to create post (${response.status})`)
+  }
+  return await response.json()
+}
+
+/** Update an existing post (the editor's autosave target). */
+export const updatePost = async (id: string, patch: Partial<Post>): Promise<Post> => {
+  const url = `${API_PATH}api/admin/posts/${encodeURIComponent(id)}`
+  const response = await fetch(url, {
+    cache: 'no-store',
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  })
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}))
+    throw new Error(data.error || `Failed to update post (${response.status})`)
+  }
+  return await response.json()
 }

--- a/packages/ui/src/branding/index.ts
+++ b/packages/ui/src/branding/index.ts
@@ -7,6 +7,7 @@ export * from './brand-colors'
 export * from './brand-typography'
 export * from './component-showcase'
 export * from './components-showcase'
+export * from './post-editor-showcase'
 export * from './navigation-testing'
 // feature-playground removed — replaced by packages/ui/src/admin/feature-flag-manager.tsx
 export * from '../navigation/navigation-showcase'

--- a/packages/ui/src/branding/post-editor-showcase.tsx
+++ b/packages/ui/src/branding/post-editor-showcase.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useState } from 'react'
+import { YStack, XStack, H2, Paragraph, Separator, Button, Text } from '@my/ui'
+import { PostEditor, createEmptyPost } from '../post-editor'
+import type { Post } from '@my/app/types/post'
+
+/**
+ * /brand showcase for the PostEditor (Consolidated CMS Phase 2a).
+ *
+ * The primary dev surface for the block editor, per design §3.1 ("showcased in
+ * isolation in /brand"). Holds an in-memory draft Post and drives the editor via
+ * the `value` / `onChange` contract only — no persistence, no data fetching — so
+ * the module can be developed and reviewed in isolation. The live JSON panel is
+ * the proof the editor mutates ONLY through that contract.
+ */
+export function PostEditorShowcase() {
+  const [post, setPost] = useState<Post>(() =>
+    createEmptyPost('demo-ecclesia', 'showcase@tee-admin.com')
+  )
+
+  return (
+    <YStack padding="$4" gap="$4" maxWidth={860} width="100%" alignSelf="center">
+      <YStack gap="$2">
+        <H2>Post Editor</H2>
+        <Paragraph color="$color10">
+          One editor for create AND edit. This mounts an in-memory empty draft — the
+          exact same component that edits a loaded post. Controlled via value/onChange
+          only; nothing is persisted here.
+        </Paragraph>
+        <XStack>
+          <Button
+            size="$3"
+            variant="outlined"
+            onPress={() => setPost(createEmptyPost('demo-ecclesia', 'showcase@tee-admin.com'))}
+          >
+            Reset draft
+          </Button>
+        </XStack>
+      </YStack>
+
+      <PostEditor
+        value={post}
+        onChange={setPost}
+        onPublish={(p) => {
+          // Showcase only — surface the publish payload, do not persist.
+          // eslint-disable-next-line no-console
+          console.log('[PostEditorShowcase] publish', p)
+        }}
+      />
+
+      <Separator />
+
+      <YStack gap="$2">
+        <Text fontSize="$3" fontWeight="600">
+          Live Post value (the value/onChange contract)
+        </Text>
+        <YStack
+          backgroundColor="$color2"
+          borderColor="$borderColor"
+          borderWidth={1}
+          borderRadius="$3"
+          padding="$3"
+        >
+          <Text fontSize="$2">{JSON.stringify(post, null, 2)}</Text>
+        </YStack>
+      </YStack>
+    </YStack>
+  )
+}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -42,3 +42,6 @@ export * from './directory'
 
 // Roster member-pickers (#110, Slice B)
 export * from './roster'
+
+// Unified Post editor (Consolidated CMS epic #131, Phase 2a)
+export * from './post-editor'

--- a/packages/ui/src/post-editor/blocks/text-block-editor.tsx
+++ b/packages/ui/src/post-editor/blocks/text-block-editor.tsx
@@ -1,0 +1,72 @@
+import { YStack, XStack, Label, Text, TextArea } from 'tamagui'
+import type { TextBlock, Visibility } from '@my/app/types/post'
+import type { BlockEditorProps } from '../registry'
+import { genId } from '../post-reducer'
+import { PlainSelect } from '../plain-select'
+import { PlainCheckbox } from '../plain-checkbox'
+import { BLOCK_VISIBILITY_OPTIONS, INHERIT_VISIBILITY } from '../options'
+
+/**
+ * TextBlock editor — one of the two hardest shapes (free prose that can hide
+ * PII the redactor can't locate; design §5). Exposes:
+ *  - a multiline markdown `body`,
+ *  - a per-block `visibility` OVERRIDE (so an obituary/testimony paragraph can be
+ *    pinned to `members` even on a public post), and
+ *  - the `containsPii` author flag that drives the save-time warning.
+ *
+ * Fully controlled: emits the full next block via `onChange`.
+ */
+export function makeTextBlock(): TextBlock {
+  return { id: genId(), kind: 'text', body: '', containsPii: false }
+}
+
+export function TextBlockEditor({ block, onChange }: BlockEditorProps<TextBlock>) {
+  return (
+    <YStack gap="$3">
+      <YStack gap="$2">
+        <Label htmlFor={`${block.id}-body`} fontSize="$3" fontWeight="600">
+          Body (markdown)
+        </Label>
+        <TextArea
+          id={`${block.id}-body`}
+          value={block.body}
+          onChangeText={(body) => onChange({ ...block, body })}
+          placeholder="Write the text… supports # headings, **bold**, and links."
+          minHeight={120}
+          numberOfLines={5}
+        />
+      </YStack>
+
+      <XStack gap="$4" flexWrap="wrap" alignItems="flex-end">
+        <YStack minWidth={200} flex={1}>
+          <PlainSelect
+            id={`${block.id}-visibility`}
+            label="Visibility (this block)"
+            value={block.visibility ?? INHERIT_VISIBILITY}
+            options={BLOCK_VISIBILITY_OPTIONS}
+            onValueChange={(v) =>
+              onChange({
+                ...block,
+                visibility: v === INHERIT_VISIBILITY ? undefined : (v as Visibility),
+              })
+            }
+          />
+        </YStack>
+
+        <YStack minHeight={44} justifyContent="center">
+          <PlainCheckbox
+            checked={block.containsPii}
+            onCheckedChange={(checked) => onChange({ ...block, containsPii: checked })}
+            label="This text mentions people (contains PII)"
+          />
+        </YStack>
+      </XStack>
+
+      {block.containsPii ? (
+        <Text fontSize="$2" color="$orange10">
+          Flagged as containing PII — consider a Person block, or keep this block members-only.
+        </Text>
+      ) : null}
+    </YStack>
+  )
+}

--- a/packages/ui/src/post-editor/blocks/time-block-editor.tsx
+++ b/packages/ui/src/post-editor/blocks/time-block-editor.tsx
@@ -1,0 +1,130 @@
+import { YStack, XStack, Label, Text, Input } from 'tamagui'
+import type { TimeBlock } from '@my/app/types/post'
+import type { BlockEditorProps } from '../registry'
+import { genId } from '../post-reducer'
+import { PlainSelect } from '../plain-select'
+import {
+  DEFAULT_TIMEZONE,
+  TIMEZONE_OPTIONS,
+  formatScheduleDateTime,
+} from '@my/app/utils/timezone'
+
+/**
+ * TimeBlock editor — the second of the two hardest shapes. A time is what makes
+ * a post "event-shaped" (a future `startsAt` drives the event facet; design §6).
+ *
+ * The stored value is ALWAYS UTC (`startsAt`, ISO-8601) with an IANA `timezone`
+ * — the codebase's storage convention (see utils/timezone.ts). The input edits a
+ * wall-clock date/time IN the selected timezone; we convert wall-clock⇄UTC here
+ * so what the author types in Toronto is stored as the correct instant. Display
+ * below is rendered via the shared `formatScheduleDateTime`.
+ *
+ * 2a keeps a plain text `YYYY-MM-DDTHH:mm` input for cross-platform safety (a
+ * native date/time picker is 2b/2c polish). Fully controlled.
+ */
+export function makeTimeBlock(): TimeBlock {
+  return { id: genId(), kind: 'time', label: '', timezone: DEFAULT_TIMEZONE }
+}
+
+/** Wall-clock 'YYYY-MM-DDTHH:mm' in `timeZone` → UTC ISO instant. */
+function wallTimeToUtc(local: string, timeZone: string): string | undefined {
+  if (!local) return undefined
+  // Treat the wall-clock string as if it were UTC, then subtract the zone's
+  // offset at that instant to get the true UTC instant.
+  const asUtc = new Date(`${local}:00Z`)
+  if (Number.isNaN(asUtc.getTime())) return undefined
+  const inZone = new Date(asUtc.toLocaleString('en-US', { timeZone }))
+  const inUtc = new Date(asUtc.toLocaleString('en-US', { timeZone: 'UTC' }))
+  const offset = inZone.getTime() - inUtc.getTime()
+  return new Date(asUtc.getTime() - offset).toISOString()
+}
+
+/** UTC ISO instant → wall-clock 'YYYY-MM-DDTHH:mm' in `timeZone` (for the input). */
+function utcToWallTime(iso: string | undefined, timeZone: string): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).formatToParts(d)
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? ''
+  const hour = get('hour') === '24' ? '00' : get('hour')
+  return `${get('year')}-${get('month')}-${get('day')}T${hour}:${get('minute')}`
+}
+
+export function TimeBlockEditor({ block, onChange }: BlockEditorProps<TimeBlock>) {
+  const timezone = block.timezone || DEFAULT_TIMEZONE
+  const wallValue = utcToWallTime(block.startsAt, timezone)
+
+  const preview = block.startsAt
+    ? formatScheduleDateTime({
+        dateTime: block.startsAt,
+        eventTimezone: timezone,
+        userTimezone: timezone,
+      }).fullDisplay
+    : ''
+
+  return (
+    <YStack gap="$3">
+      <YStack gap="$2">
+        <Label htmlFor={`${block.id}-label`} fontSize="$3" fontWeight="600">
+          Label
+        </Label>
+        <Input
+          id={`${block.id}-label`}
+          value={block.label ?? ''}
+          onChangeText={(label) => onChange({ ...block, label })}
+          placeholder="e.g. Service, Baptism, Reception"
+        />
+      </YStack>
+
+      <XStack gap="$4" flexWrap="wrap">
+        <YStack gap="$2" minWidth={220} flex={1}>
+          <Label htmlFor={`${block.id}-starts`} fontSize="$3" fontWeight="600">
+            Starts (local wall time)
+          </Label>
+          <Input
+            id={`${block.id}-starts`}
+            value={wallValue}
+            onChangeText={(local) =>
+              onChange({ ...block, startsAt: wallTimeToUtc(local, timezone) })
+            }
+            placeholder="YYYY-MM-DDTHH:mm"
+            autoCapitalize="none"
+          />
+        </YStack>
+
+        <YStack minWidth={200} flex={1}>
+          <PlainSelect
+            id={`${block.id}-tz`}
+            label="Timezone"
+            value={timezone}
+            options={TIMEZONE_OPTIONS.map((t) => ({ value: t.value, label: t.label }))}
+            onValueChange={(tz) => {
+              // Keep the same wall-clock instant the author sees; re-derive the
+              // UTC value against the newly chosen zone.
+              const next = block.startsAt ? wallTimeToUtc(wallValue, tz) : block.startsAt
+              onChange({ ...block, timezone: tz, startsAt: next })
+            }}
+          />
+        </YStack>
+      </XStack>
+
+      {preview ? (
+        <Text fontSize="$2" color="$color10">
+          Stored UTC: {block.startsAt} · Shows as: {preview}
+        </Text>
+      ) : (
+        <Text fontSize="$2" color="$color10">
+          Enter a date/time (24-hour). Stored in UTC; shown in the chosen timezone.
+        </Text>
+      )}
+    </YStack>
+  )
+}

--- a/packages/ui/src/post-editor/index.ts
+++ b/packages/ui/src/post-editor/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Post editor — self-contained, cross-platform Tamagui module for the unified
+ * Post model (Consolidated CMS epic #131, Phase 2a). One editor for create AND
+ * edit; the ONLY contract to the page is `value` / `onChange`.
+ *
+ * See docs/UNIFIED_POST_MODEL_DESIGN.md §3 (blocks) + §3.1 (packaging).
+ */
+export { PostEditor, type PostEditorProps } from './post-editor'
+
+// Pure model helpers (also unit-testable in isolation).
+export {
+  postReducer,
+  createEmptyPost,
+  validateForPublish,
+  genId,
+  type PostAction,
+} from './post-reducer'
+
+// Block registry — the extensibility seam.
+export {
+  registerBlock,
+  getBlockDef,
+  listBlockDefs,
+  clearBlockRegistry,
+  type BlockDef,
+  type BlockEditorProps,
+} from './registry'
+export { registerDefaultBlocks } from './register-default-blocks'
+
+// Reference block editors + factories (for direct reuse / registration).
+export { TextBlockEditor, makeTextBlock } from './blocks/text-block-editor'
+export { TimeBlockEditor, makeTimeBlock } from './blocks/time-block-editor'

--- a/packages/ui/src/post-editor/options.ts
+++ b/packages/ui/src/post-editor/options.ts
@@ -1,0 +1,39 @@
+import type { OccasionTag, Visibility } from '@my/app/types/post'
+
+/** Sentinel value for a block that inherits the post's visibility (no override). */
+export const INHERIT_VISIBILITY = ''
+
+export interface Option {
+  value: string
+  label: string
+}
+
+/** Post reach ladder (design §8.4). */
+export const VISIBILITY_OPTIONS: Array<{ value: Visibility; label: string }> = [
+  { value: 'public', label: 'Public' },
+  { value: 'recognized', label: 'Recognized' },
+  { value: 'members', label: 'Members' },
+  { value: 'admins', label: 'Admins' },
+]
+
+/** Per-block visibility override options — with an explicit "inherit" choice. */
+export const BLOCK_VISIBILITY_OPTIONS: Option[] = [
+  { value: INHERIT_VISIBILITY, label: 'Inherit from post' },
+  ...VISIBILITY_OPTIONS,
+]
+
+/** Occasion is DATA (design §8.5) — free-combining tags, no code path per one. */
+export const OCCASION_OPTIONS: Array<{ value: OccasionTag; label: string }> = [
+  { value: 'general', label: 'General' },
+  { value: 'news', label: 'News' },
+  { value: 'announcement', label: 'Announcement' },
+  { value: 'baptism', label: 'Baptism' },
+  { value: 'wedding', label: 'Wedding' },
+  { value: 'shower', label: 'Shower' },
+  { value: 'engagement', label: 'Engagement' },
+  { value: 'funeral', label: 'Funeral' },
+  { value: 'medical', label: 'Medical' },
+  { value: 'study-weekend', label: 'Study weekend' },
+  { value: 'recurring', label: 'Recurring' },
+  { value: 'election-cycle', label: 'Election cycle' },
+]

--- a/packages/ui/src/post-editor/plain-checkbox.tsx
+++ b/packages/ui/src/post-editor/plain-checkbox.tsx
@@ -1,0 +1,38 @@
+import { Checkbox, Label, XStack } from 'tamagui'
+import { Check as CheckIcon } from '@tamagui/lucide-icons'
+import { useId } from 'react'
+
+/**
+ * A small, fully-controlled checkbox row — the post-editor's own primitive
+ * (mirrors the app's checkbox styling but takes plain `checked`/`onCheckedChange`
+ * instead of a react-hook-form `Control`). Cross-platform.
+ */
+export interface PlainCheckboxProps {
+  checked: boolean
+  onCheckedChange: (checked: boolean) => void
+  label: string
+}
+
+export function PlainCheckbox({ checked, onCheckedChange, label }: PlainCheckboxProps) {
+  const id = useId()
+  return (
+    <XStack gap="$3" alignItems="center" paddingVertical="$2">
+      <Checkbox
+        id={id}
+        size="$4"
+        checked={checked}
+        onCheckedChange={(c) => onCheckedChange(c === true)}
+        borderWidth={2}
+        borderColor={checked ? '$primary' : '$textTertiary'}
+        backgroundColor={checked ? '$primary' : 'transparent'}
+      >
+        <Checkbox.Indicator>
+          <CheckIcon color="$primaryForeground" />
+        </Checkbox.Indicator>
+      </Checkbox>
+      <Label htmlFor={id} fontSize="$3" cursor="pointer" onPress={() => onCheckedChange(!checked)}>
+        {label}
+      </Label>
+    </XStack>
+  )
+}

--- a/packages/ui/src/post-editor/plain-select.tsx
+++ b/packages/ui/src/post-editor/plain-select.tsx
@@ -1,0 +1,98 @@
+import { Label, Text, YStack, Select, Adapt, Sheet } from 'tamagui'
+import { CheckCircle, ChevronDown, ChevronUp } from '@tamagui/lucide-icons'
+import type { Option } from './options'
+
+/**
+ * A small, fully-controlled Select — the post-editor's own styling primitive
+ * (the module owns its style, per design §3.1). Mirrors the Tamagui Select
+ * markup used by `event-form-select` but takes plain `value` / `onValueChange`
+ * props instead of a react-hook-form `Control`, so block editors stay pure
+ * controlled components. Cross-platform (Select + Adapt/Sheet handle touch).
+ */
+export interface PlainSelectProps {
+  value: string
+  onValueChange: (value: string) => void
+  options: Option[]
+  label?: string
+  placeholder?: string
+  id?: string
+}
+
+export function PlainSelect({
+  value,
+  onValueChange,
+  options,
+  label,
+  placeholder = 'Select…',
+  id,
+}: PlainSelectProps) {
+  return (
+    <YStack gap="$2">
+      {label ? (
+        <Label htmlFor={id} fontSize="$3" fontWeight="600">
+          {label}
+        </Label>
+      ) : null}
+
+      <Select id={id} value={value} onValueChange={onValueChange}>
+        <Select.Trigger borderColor="$borderColor" iconAfter={ChevronDown}>
+          <Select.Value placeholder={placeholder} />
+        </Select.Trigger>
+
+        <Adapt when="sm" platform="touch">
+          <Sheet modal dismissOnSnapToBottom snapPointsMode="fit">
+            <Sheet.Frame>
+              <Sheet.ScrollView>
+                <Adapt.Contents />
+              </Sheet.ScrollView>
+            </Sheet.Frame>
+            <Sheet.Overlay
+              animation="lazy"
+              enterStyle={{ opacity: 0 }}
+              exitStyle={{ opacity: 0 }}
+            />
+          </Sheet>
+        </Adapt>
+
+        <Select.Content zIndex={200000}>
+          <Select.ScrollUpButton
+            alignItems="center"
+            justifyContent="center"
+            position="relative"
+            width="100%"
+            height="$3"
+          >
+            <YStack zIndex={10}>
+              <ChevronUp size={20} />
+            </YStack>
+          </Select.ScrollUpButton>
+
+          <Select.Viewport minHeight={200}>
+            <Select.Group>
+              {options.map((option, index) => (
+                <Select.Item key={option.value} index={index} value={option.value}>
+                  <Select.ItemText>{option.label}</Select.ItemText>
+                  <Select.ItemIndicator marginLeft="auto">
+                    <CheckCircle size={16} />
+                  </Select.ItemIndicator>
+                </Select.Item>
+              ))}
+            </Select.Group>
+          </Select.Viewport>
+
+          <Select.ScrollDownButton
+            alignItems="center"
+            justifyContent="center"
+            position="relative"
+            width="100%"
+            height="$3"
+          >
+            <YStack zIndex={10}>
+              <ChevronDown size={20} />
+            </YStack>
+          </Select.ScrollDownButton>
+        </Select.Content>
+      </Select>
+    </YStack>
+  )
+}

--- a/packages/ui/src/post-editor/post-editor.tsx
+++ b/packages/ui/src/post-editor/post-editor.tsx
@@ -1,0 +1,240 @@
+import { YStack, XStack, Card, Text, Label, Input, Separator, H3 } from 'tamagui'
+import { Plus, Trash2, ChevronUp, ChevronDown, X } from '@tamagui/lucide-icons'
+import type { OccasionTag, Post, Visibility } from '@my/app/types/post'
+import { Button } from '../Button'
+import { postReducer, validateForPublish, type PostAction } from './post-reducer'
+import { getBlockDef, listBlockDefs } from './registry'
+import { registerDefaultBlocks } from './register-default-blocks'
+import { PlainSelect } from './plain-select'
+import { OCCASION_OPTIONS, VISIBILITY_OPTIONS } from './options'
+
+// Ensure the reference block editors are available the moment the module loads.
+registerDefaultBlocks()
+
+/**
+ * PostEditor — the ARCHITECTURE KEYSTONE of the Consolidated CMS (epic #131).
+ *
+ * ONE editor for CREATE and EDIT. It takes a {@link Post} — a fresh empty draft
+ * (`createEmptyPost`) or a loaded existing one — and edits it. There is no
+ * separate create-form vs edit-view; a Post *is* its ordered `blocks`.
+ *
+ * PURE CONTROLLED COMPONENT. The ONLY contract to the page is `value` /
+ * `onChange` (+ optional `onPublish`); it fetches nothing and holds no post
+ * state. Every action is applied through the pure {@link postReducer}, so the
+ * page (or the /brand showcase, or native) owns persistence and the editor is
+ * a self-contained module (design §3.1). Cross-platform: no next-auth / next/*.
+ */
+export interface PostEditorProps {
+  value: Post
+  onChange: (next: Post) => void
+  onPublish?: (post: Post) => void
+}
+
+export function PostEditor({ value, onChange, onPublish }: PostEditorProps) {
+  const dispatch = (action: PostAction) => onChange(postReducer(value, action))
+
+  const publishErrors = validateForPublish(value)
+  const canPublish = publishErrors.length === 0
+
+  const availableOccasions = OCCASION_OPTIONS.filter((o) => !value.occasion.includes(o.value))
+
+  return (
+    <YStack gap="$4">
+      {/* ---- Post header ---------------------------------------------------- */}
+      <Card bordered padding="$4" gap="$3">
+        <H3>Post</H3>
+
+        <YStack gap="$2">
+          <Label htmlFor="post-title" fontSize="$3" fontWeight="600">
+            Title
+          </Label>
+          <Input
+            id="post-title"
+            value={value.title}
+            onChangeText={(title) => dispatch({ type: 'patch-post', patch: { title } })}
+            placeholder="Post title"
+          />
+        </YStack>
+
+        {/* Occasion tags — occasion is DATA (free-combining tags). */}
+        <YStack gap="$2">
+          <Label fontSize="$3" fontWeight="600">
+            Occasion tags
+          </Label>
+          <XStack gap="$2" flexWrap="wrap">
+            {value.occasion.map((tag) => (
+              <XStack
+                key={tag}
+                alignItems="center"
+                gap="$1"
+                paddingHorizontal="$2"
+                paddingVertical="$1"
+                borderRadius="$3"
+                backgroundColor="$blue4"
+              >
+                <Text fontSize="$2">{tag}</Text>
+                <Button
+                  size="$1"
+                  circular
+                  chromeless
+                  icon={X}
+                  aria-label={`Remove ${tag}`}
+                  onPress={() =>
+                    dispatch({
+                      type: 'patch-post',
+                      patch: { occasion: value.occasion.filter((t) => t !== tag) },
+                    })
+                  }
+                />
+              </XStack>
+            ))}
+          </XStack>
+          {availableOccasions.length > 0 ? (
+            <XStack maxWidth={260}>
+              <PlainSelect
+                value=""
+                placeholder="Add a tag…"
+                options={availableOccasions}
+                onValueChange={(tag) =>
+                  dispatch({
+                    type: 'patch-post',
+                    patch: { occasion: [...value.occasion, tag as OccasionTag] },
+                  })
+                }
+              />
+            </XStack>
+          ) : null}
+        </YStack>
+
+        <XStack gap="$4" flexWrap="wrap">
+          <YStack minWidth={200} flex={1}>
+            <PlainSelect
+              label="Visibility"
+              value={value.visibility}
+              options={VISIBILITY_OPTIONS}
+              onValueChange={(v) =>
+                dispatch({ type: 'patch-post', patch: { visibility: v as Visibility } })
+              }
+            />
+          </YStack>
+
+          <YStack gap="$2" minWidth={200} flex={1}>
+            <Label htmlFor="post-publish-date" fontSize="$3" fontWeight="600">
+              Publish date
+            </Label>
+            <Input
+              id="post-publish-date"
+              value={value.lifecycle.publishDate ?? ''}
+              onChangeText={(publishDate) =>
+                dispatch({
+                  type: 'patch-post',
+                  patch: {
+                    lifecycle: { ...value.lifecycle, publishDate: publishDate || undefined },
+                  },
+                })
+              }
+              placeholder="YYYY-MM-DD"
+              autoCapitalize="none"
+            />
+          </YStack>
+        </XStack>
+      </Card>
+
+      {/* ---- Block canvas --------------------------------------------------- */}
+      <YStack gap="$3">
+        <H3>Blocks</H3>
+        {value.blocks.length === 0 ? (
+          <Text color="$color10">No blocks yet. Add one from the toolbar below.</Text>
+        ) : (
+          value.blocks.map((block, index) => {
+            const def = getBlockDef(block.kind)
+            const Editor = def?.Editor
+            return (
+              <Card key={block.id} bordered padding="$3" gap="$3">
+                <XStack justifyContent="space-between" alignItems="center">
+                  <Text fontSize="$4" fontWeight="600">
+                    {def?.label ?? block.kind}
+                  </Text>
+                  <XStack gap="$2">
+                    <Button
+                      size="$2"
+                      icon={ChevronUp}
+                      disabled={index === 0}
+                      aria-label="Move block up"
+                      onPress={() =>
+                        dispatch({ type: 'move-block', id: block.id, direction: 'up' })
+                      }
+                    />
+                    <Button
+                      size="$2"
+                      icon={ChevronDown}
+                      disabled={index === value.blocks.length - 1}
+                      aria-label="Move block down"
+                      onPress={() =>
+                        dispatch({ type: 'move-block', id: block.id, direction: 'down' })
+                      }
+                    />
+                    <Button
+                      size="$2"
+                      theme="red"
+                      icon={Trash2}
+                      aria-label="Remove block"
+                      onPress={() => dispatch({ type: 'remove-block', id: block.id })}
+                    />
+                  </XStack>
+                </XStack>
+                <Separator />
+                {Editor ? (
+                  <Editor
+                    block={block}
+                    onChange={(next) =>
+                      dispatch({ type: 'patch-block', id: block.id, patch: next })
+                    }
+                    onRemove={() => dispatch({ type: 'remove-block', id: block.id })}
+                  />
+                ) : (
+                  <Text color="$red10">No editor registered for block kind "{block.kind}"</Text>
+                )}
+              </Card>
+            )
+          })
+        )}
+      </YStack>
+
+      {/* ---- Toolbar (add blocks) ------------------------------------------ */}
+      <Card bordered padding="$3" gap="$2" backgroundColor="$backgroundHover">
+        <Text fontSize="$3" fontWeight="600">
+          Add a block
+        </Text>
+        <XStack gap="$2" flexWrap="wrap">
+          {listBlockDefs().map((def) => (
+            <Button
+              key={def.kind}
+              size="$3"
+              icon={def.icon ?? Plus}
+              onPress={() => dispatch({ type: 'add-block', block: def.make() })}
+            >
+              {def.label}
+            </Button>
+          ))}
+        </XStack>
+      </Card>
+
+      {/* ---- Publish (validate-on-publish only) ---------------------------- */}
+      {onPublish ? (
+        <YStack gap="$2">
+          {publishErrors.length > 0 ? (
+            <Text fontSize="$3" color="$red10">
+              {publishErrors.join(' · ')}
+            </Text>
+          ) : null}
+          <XStack>
+            <Button theme="green" disabled={!canPublish} onPress={() => onPublish(value)}>
+              Publish
+            </Button>
+          </XStack>
+        </YStack>
+      ) : null}
+    </YStack>
+  )
+}

--- a/packages/ui/src/post-editor/post-reducer.ts
+++ b/packages/ui/src/post-editor/post-reducer.ts
@@ -1,0 +1,107 @@
+import type { Block, Post } from '@my/app/types/post'
+
+/**
+ * Pure state transitions for the {@link PostEditor}.
+ *
+ * The editor is a fully-controlled component (`value: Post`, `onChange`) — it
+ * holds NO internal state. Every user action is expressed as a {@link PostAction}
+ * and applied by {@link postReducer}, a pure function, so the editor's behaviour
+ * is unit-testable without rendering (add / remove / reorder / patch a block, or
+ * patch the post header). This is the "own store/reducer" the design calls for
+ * (docs/UNIFIED_POST_MODEL_DESIGN.md §3.1) expressed as a reducer instead of a
+ * hidden store, keeping the value/onChange contract the single boundary.
+ *
+ * Cross-platform: pure types + logic, no platform imports.
+ */
+
+export type PostAction =
+  | { type: 'patch-post'; patch: Partial<Post> }
+  /** Append a fully-formed block (created via a registry `make()`). */
+  | { type: 'add-block'; block: Block }
+  | { type: 'remove-block'; id: string }
+  | { type: 'move-block'; id: string; direction: 'up' | 'down' }
+  /** Merge a patch (or a full replacement block) into the block with `id`. */
+  | { type: 'patch-block'; id: string; patch: Partial<Block> }
+
+export function postReducer(post: Post, action: PostAction): Post {
+  switch (action.type) {
+    case 'patch-post':
+      return { ...post, ...action.patch }
+
+    case 'add-block':
+      return { ...post, blocks: [...post.blocks, action.block] }
+
+    case 'remove-block':
+      return { ...post, blocks: post.blocks.filter((b) => b.id !== action.id) }
+
+    case 'move-block': {
+      const i = post.blocks.findIndex((b) => b.id === action.id)
+      if (i < 0) return post
+      const j = action.direction === 'up' ? i - 1 : i + 1
+      if (j < 0 || j >= post.blocks.length) return post
+      const blocks = [...post.blocks]
+      const tmp = blocks[i]
+      blocks[i] = blocks[j]
+      blocks[j] = tmp
+      return { ...post, blocks }
+    }
+
+    case 'patch-block':
+      return {
+        ...post,
+        blocks: post.blocks.map((b) =>
+          b.id === action.id ? ({ ...b, ...action.patch } as Block) : b
+        ),
+      }
+
+    default:
+      return post
+  }
+}
+
+/**
+ * Client-side id generator for blocks (and unsaved drafts). Server-persisted
+ * post ids are uuids assigned by the repository; block ids only need to be
+ * unique within a post, so a compact time+random id is sufficient and avoids a
+ * uuid dependency in shared UI.
+ */
+export function genId(prefix = 'blk'): string {
+  const rand = Math.random().toString(36).slice(2, 10)
+  return `${prefix}_${Date.now().toString(36)}_${rand}`
+}
+
+/**
+ * A new, empty draft Post — the CREATE case of the one-editor principle. The
+ * editor treats this exactly like a loaded existing Post; there is no separate
+ * create form. `id: ''` marks it unsaved (the API assigns the real uuid on the
+ * first save), so the page can branch create-vs-update purely on `id`.
+ */
+export function createEmptyPost(tenant: string, authorId: string): Post {
+  const now = new Date().toISOString()
+  return {
+    id: '',
+    tenant,
+    authorId,
+    title: '',
+    occasion: ['general'],
+    visibility: 'public',
+    sharingScope: 'own',
+    lifecycle: {},
+    blocks: [],
+    createdAt: now,
+    updatedAt: now,
+    status: 'draft',
+  }
+}
+
+/**
+ * Validate-on-PUBLISH only (never blocks typing/editing). A post may be
+ * published once it has a title and at least one block. Returns human-readable
+ * errors ([] = ok) so both the editor and the page can surface them inline.
+ */
+export function validateForPublish(post: Post): string[] {
+  const errors: string[] = []
+  if (!post.title.trim()) errors.push('A title is required')
+  if (post.blocks.length === 0) errors.push('Add at least one block')
+  return errors
+}

--- a/packages/ui/src/post-editor/register-default-blocks.ts
+++ b/packages/ui/src/post-editor/register-default-blocks.ts
@@ -1,0 +1,31 @@
+import { registerBlock } from './registry'
+import { FileText, Clock } from '@tamagui/lucide-icons'
+import { TextBlockEditor, makeTextBlock } from './blocks/text-block-editor'
+import { TimeBlockEditor, makeTimeBlock } from './blocks/time-block-editor'
+
+/**
+ * Register the reference block editors (the two hardest shapes: free-prose Text
+ * and UTC-storing Time). Idempotent so it is safe to call from module scope in
+ * the editor AND from tests. Remaining block editors (Person, Location, Flyer,
+ * Registration, Link) are 2b — they register the same way with no editor changes.
+ */
+let registered = false
+
+export function registerDefaultBlocks(): void {
+  if (registered) return
+  registered = true
+
+  registerBlock('text', {
+    label: 'Text',
+    icon: FileText,
+    make: makeTextBlock,
+    Editor: TextBlockEditor,
+  })
+
+  registerBlock('time', {
+    label: 'Date & time',
+    icon: Clock,
+    make: makeTimeBlock,
+    Editor: TimeBlockEditor,
+  })
+}

--- a/packages/ui/src/post-editor/registry.ts
+++ b/packages/ui/src/post-editor/registry.ts
@@ -1,0 +1,63 @@
+import type { FC } from 'react'
+import type { Block, BlockKind } from '@my/app/types/post'
+
+/**
+ * Block registry — the extensibility seam of the post editor
+ * (docs/UNIFIED_POST_MODEL_DESIGN.md §3.1: "Each Block type is its own
+ * encapsulated editor, registered in a block registry; the toolbar orchestrates
+ * them.").
+ *
+ * A block definition bundles everything the editor needs to offer and render a
+ * block kind: a toolbar `label`/`icon`, a `make()` factory for the toolbar's
+ * "add" action, and the `Editor` component the canvas renders for each instance.
+ * Adding a new block type is one `registerBlock(...)` call — the PostEditor,
+ * toolbar, and canvas need no changes.
+ *
+ * Cross-platform: no platform imports; the registry is a plain module map.
+ */
+
+/** Props every block Editor receives. `onChange` emits the FULL next block. */
+export interface BlockEditorProps<B extends Block = Block> {
+  block: B
+  onChange: (next: B) => void
+  onRemove: () => void
+}
+
+export interface BlockDef<B extends Block = Block> {
+  kind: BlockKind
+  /** Toolbar label (e.g. 'Text', 'Date & time'). */
+  label: string
+  /** Toolbar icon (Tamagui / Lucide icon component — a function component). */
+  icon?: FC<{ size?: number | string; color?: string }>
+  /** Factory for a fresh, empty block of this kind (used by the toolbar). */
+  make: () => B
+  /** The block's encapsulated editor, rendered per-instance on the canvas. */
+  Editor: FC<BlockEditorProps<B>>
+}
+
+const registry = new Map<BlockKind, BlockDef>()
+
+/**
+ * Register (or override) the definition for a block kind. Typed per-block-kind
+ * at the call site; stored type-erased so the editor can iterate uniformly.
+ */
+export function registerBlock<B extends Block>(
+  kind: B['kind'],
+  def: Omit<BlockDef<B>, 'kind'>
+): void {
+  registry.set(kind, { kind, ...def } as unknown as BlockDef)
+}
+
+export function getBlockDef(kind: BlockKind): BlockDef | undefined {
+  return registry.get(kind)
+}
+
+/** All registered block definitions, in registration order (toolbar order). */
+export function listBlockDefs(): BlockDef[] {
+  return Array.from(registry.values())
+}
+
+/** Test/util helper — empties the registry so a test starts from a clean slate. */
+export function clearBlockRegistry(): void {
+  registry.clear()
+}


### PR DESCRIPTION
Phase 2a of #131 — the editor **architecture keystone**. Behind `CONSOLIDATED_CMS` (routes 404 when off; `/brand` showcase owner/admin only). All-new files + a 3-line barrel export — additive, no existing behaviour changed.

## The one editor (Ken's principle)
**Create == Edit == in-context — one component.** `createEmptyPost()` returns a Post with `id:''`; the SAME `<PostEditor>` edits it identically to a loaded Post; the page branches only on `id` (empty → POST mints the uuid → subsequent edits PUT). No separate create-form/edit-view.

## What
- **`packages/ui/src/post-editor/`** (self-contained, cross-platform, no `next-*` imports):
  - `PostEditor` — controlled `{ value, onChange, onPublish }`; post header (title, occasion chips, visibility, publish date) + ordered block canvas (add/remove/reorder) + add-block toolbar + validate-gated Publish. Holds no state — all actions via a pure reducer.
  - `post-reducer.ts` — pure `postReducer` (patch-post/add/remove/move/patch-block), `createEmptyPost`, `validateForPublish`.
  - `registry.ts` — the extensibility seam: `registerBlock(kind, { label, icon, make, Editor })`. **Adding a block type = one call; the editor/toolbar/canvas need no changes** (this is what 2b snaps onto).
  - Reference blocks: **Text** (markdown + per-block visibility + `containsPii`) and **Time** (label + wall-clock → UTC `startsAt`, tz-shown via `timezone.ts`).
- **/brand showcase** — `/admin/ui-ux/brand/post-editor` (in-memory draft + live JSON), the isolated dev surface (§3.1).
- **Save/load** — `/api/admin/posts` (+ `/[id]`) → `postRepository`, gated `auth()` → owner/admin → `CONSOLIDATED_CMS` (else 404). Admin page `admin/posts/[id]` (same for new/existing, debounced autosave, publish→`ready`). Cross-platform client helpers in `get-data.ts`.
- **Validate on publish only** — never blocks typing; publish needs title + ≥1 block.

## Deferred (next slices)
2b: remaining block editors (Person/Location/Flyer/Registration/Link) — parallel, each one `registerBlock`. 2c: draggable toolbar + native date picker + occasion-tag default block sets + posts list page.

## Verify
- **23 tests** (reducer add/remove/reorder/patch + publish-validation; registry; admin-route 401/403/flag-404/success). Typecheck clean. **`next build` compiled the new Tamagui UI** (28s; build only stops on a pre-existing unrelated route needing GOOGLE_SERVICE_ACCOUNT_KEY locally — Vercel has it). Visual editor best eyeballed on the Vercel preview at `/admin/ui-ux/brand/post-editor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)