### PR TITLE
CONSOLIDATED_CMS Phase 2c — occasion defaults, posts list, person stable-id, collapsible toolbar (#131)

### DIFF
--- a/apps/next/app/admin/(admin-plus)/posts/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/posts/page.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { YStack, XStack, Card, Text, Spinner, Heading, Button, Paragraph } from '@my/ui'
+import { Plus } from '@tamagui/lucide-icons'
+import { useAdminAccess } from '@/hooks/use-admin-access'
+import { useHydrated } from '@my/app/hooks/use-hydrated'
+import { listPosts } from '@my/app/provider/get-data'
+import type { Post } from '@my/app/types/post'
+
+/**
+ * /admin/posts — the unified Post list (Consolidated CMS Phase 2c).
+ *
+ * Flag-gated the same way as the editor and its API: the page mirrors the
+ * other /admin/(admin-plus) list pages' admin-access gate, and the underlying
+ * `GET /api/admin/posts` 404s outright when CONSOLIDATED_CMS is off — so an
+ * un-flagged admin sees a load error here, not partial functionality.
+ *
+ * "New post" and each row navigate via route (`/admin/posts/new` |
+ * `/admin/posts/{id}`) into the SAME `<PostEditor>` page (the one-editor
+ * principle) — this page is purely a list + entry point.
+ */
+function formatUpdatedAt(iso: string): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString('en-CA', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+const STATUS_COLOR: Record<Post['status'], string> = {
+  draft: '$yellow4',
+  ready: '$green4',
+  archived: '$gray4',
+}
+
+export default function AdminPostsPage() {
+  const isHydrated = useHydrated()
+  const { hasAccess, isLoading } = useAdminAccess()
+  const router = useRouter()
+
+  const [posts, setPosts] = useState<Post[]>([])
+  const [loading, setLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!hasAccess) return
+    let cancelled = false
+    setLoading(true)
+    listPosts()
+      .then((data) => {
+        if (cancelled) return
+        // Newest-edited first.
+        const sorted = [...data].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+        setPosts(sorted)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setErrorMessage(err instanceof Error ? err.message : 'Failed to load posts')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [hasAccess])
+
+  if (!isHydrated || isLoading || !hasAccess) {
+    return (
+      <YStack flex={1} justifyContent="center" alignItems="center" padding="$4">
+        <Spinner size="large" width={36} height={36} />
+        <Text marginTop="$4">Loading...</Text>
+      </YStack>
+    )
+  }
+
+  return (
+    <YStack padding="$4" gap="$4" maxWidth={900} alignSelf="center" width="100%">
+      <XStack justifyContent="space-between" alignItems="center" gap="$3">
+        <Heading size="$8">Posts</Heading>
+        <Button
+          icon={<Plus size={16} />}
+          backgroundColor="$primary"
+          color="white"
+          hoverStyle={{ backgroundColor: '$primaryHover' }}
+          onPress={() => router.push('/admin/posts/new')}
+        >
+          New post
+        </Button>
+      </XStack>
+
+      {errorMessage ? <Paragraph color="$error">{errorMessage}</Paragraph> : null}
+
+      {loading ? (
+        <YStack alignItems="center" padding="$4">
+          <Spinner size="small" width={20} height={20} />
+        </YStack>
+      ) : posts.length === 0 ? (
+        <Paragraph color="$textSecondary">No posts yet — create the first one.</Paragraph>
+      ) : (
+        <YStack gap="$2">
+          {posts.map((post) => (
+            <Card
+              key={post.id}
+              bordered
+              padding="$3"
+              gap="$2"
+              cursor="pointer"
+              pressStyle={{ opacity: 0.8 }}
+              hoverStyle={{ backgroundColor: '$backgroundHover' }}
+              onPress={() => router.push(`/admin/posts/${post.id}`)}
+            >
+              <XStack justifyContent="space-between" alignItems="center" gap="$3">
+                <Text fontSize="$5" fontWeight="600" flex={1} numberOfLines={1}>
+                  {post.title || 'Untitled post'}
+                </Text>
+                <XStack
+                  paddingHorizontal="$2"
+                  paddingVertical="$1"
+                  borderRadius="$3"
+                  backgroundColor={STATUS_COLOR[post.status] ?? '$gray4'}
+                >
+                  <Text fontSize="$2" fontWeight="600" textTransform="uppercase">
+                    {post.status}
+                  </Text>
+                </XStack>
+              </XStack>
+
+              <XStack justifyContent="space-between" alignItems="center" gap="$3" flexWrap="wrap">
+                <XStack gap="$2" flexWrap="wrap">
+                  {post.occasion.length === 0 ? (
+                    <Text fontSize="$2" color="$color10">
+                      No occasion tags
+                    </Text>
+                  ) : (
+                    post.occasion.map((tag) => (
+                      <XStack
+                        key={tag}
+                        paddingHorizontal="$2"
+                        paddingVertical="$1"
+                        borderRadius="$3"
+                        backgroundColor="$blue4"
+                      >
+                        <Text fontSize="$2">{tag}</Text>
+                      </XStack>
+                    ))
+                  )}
+                </XStack>
+                <Text fontSize="$2" color="$color10">
+                  Updated {formatUpdatedAt(post.updatedAt)}
+                </Text>
+              </XStack>
+            </Card>
+          ))}
+        </YStack>
+      )}
+    </YStack>
+  )
+}

--- a/apps/next/tests/legacy-to-post.test.ts
+++ b/apps/next/tests/legacy-to-post.test.ts
@@ -131,7 +131,11 @@ describe('legacyToPost — baptism', () => {
   it('redacted for anon: candidate first-name only, bio gone', () => {
     const r = redactPost(post, anon)!
     const c = r.blocks.filter((b): b is PersonBlock => b.kind === 'person').find((b) => b.role === 'candidate')!
-    expect(c.people[0]).toEqual({ firstName: 'Joshua' })
+    // id (pii:'none') is carried through redaction — not shown/PII, just a stable key.
+    expect(c.people[0].firstName).toBe('Joshua')
+    expect(c.people[0]).not.toHaveProperty('lastName')
+    expect(c.people[0]).not.toHaveProperty('bio')
+    expect(typeof c.people[0].id).toBe('string')
   })
 })
 

--- a/apps/next/tests/post-editor-occasion-defaults.test.ts
+++ b/apps/next/tests/post-editor-occasion-defaults.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { applyOccasionDefaults } from '@my/ui/src/post-editor/occasion-defaults'
+import { createEmptyPost } from '@my/ui/src/post-editor/post-reducer'
+import type { Block, LocationBlock, PersonBlock, Post, TextBlock, TimeBlock } from '@my/app/types/post'
+
+/**
+ * Occasion → default block set (Consolidated CMS Phase 2c). Pure-module tests
+ * — no rendering, mirrors the reducer/registry test convention. See the file
+ * header of `occasion-defaults.ts` for why this module avoids importing the
+ * icon-bearing `blocks/*-block-editor.tsx` factories.
+ */
+
+function draft(occasion: Post['occasion'], blocks: Block[] = []): Post {
+  return { ...createEmptyPost('tee', 'author@x.com'), occasion, blocks }
+}
+
+function kinds(post: Post): string[] {
+  return post.blocks.map((b) => b.kind)
+}
+
+function personRoles(post: Post): string[] {
+  return post.blocks.filter((b): b is PersonBlock => b.kind === 'person').map((b) => b.role)
+}
+
+describe('applyOccasionDefaults', () => {
+  it('baptism → candidate person + location + time + members-only testimony text', () => {
+    const next = applyOccasionDefaults(draft(['baptism']))
+    expect(personRoles(next)).toEqual(['candidate'])
+    expect(kinds(next).sort()).toEqual(['location', 'person', 'text', 'time'])
+    const text = next.blocks.find((b): b is TextBlock => b.kind === 'text')!
+    expect(text.visibility).toBe('members')
+    expect(text.containsPii).toBe(true)
+  })
+
+  it('funeral → deceased person + location + time (no text default)', () => {
+    const next = applyOccasionDefaults(draft(['funeral']))
+    expect(personRoles(next)).toEqual(['deceased'])
+    expect(kinds(next).sort()).toEqual(['location', 'person', 'time'])
+  })
+
+  it('wedding → bride + groom person blocks + location + time', () => {
+    const next = applyOccasionDefaults(draft(['wedding']))
+    expect(personRoles(next).sort()).toEqual(['bride', 'groom'])
+    expect(kinds(next).sort()).toEqual(['location', 'person', 'person', 'time'])
+  })
+
+  it('news → a single text block', () => {
+    const next = applyOccasionDefaults(draft(['news']))
+    expect(kinds(next)).toEqual(['text'])
+  })
+
+  it('an occasion with no specific mapping falls back to a single text block', () => {
+    const next = applyOccasionDefaults(draft(['general']))
+    expect(kinds(next)).toEqual(['text'])
+  })
+
+  it('a multi-tag post with one mapped tag does NOT also get the generic fallback', () => {
+    // 'shower' has no specific mapping; 'wedding' does — should get ONLY
+    // wedding's defaults, not wedding's defaults plus a generic text block.
+    const next = applyOccasionDefaults(draft(['wedding', 'shower']))
+    expect(kinds(next).sort()).toEqual(['location', 'person', 'person', 'time'])
+  })
+
+  it('is idempotent — applying twice does not duplicate blocks', () => {
+    const once = applyOccasionDefaults(draft(['funeral']))
+    const twice = applyOccasionDefaults(once)
+    expect(twice.blocks).toEqual(once.blocks)
+    expect(twice.blocks).toHaveLength(3)
+  })
+
+  it('ADDITIVE: never removes or edits existing author content — only tops up missing slots', () => {
+    const authoredLocation: LocationBlock = {
+      id: 'loc-authored',
+      kind: 'location',
+      mode: 'plain',
+      venueName: 'Authored Hall', // author-entered content that must survive
+    }
+    const post = draft(['funeral'], [authoredLocation])
+    const next = applyOccasionDefaults(post)
+
+    // The author's location block is untouched (same id, same venueName).
+    const loc = next.blocks.find((b): b is LocationBlock => b.kind === 'location')!
+    expect(loc).toEqual(authoredLocation)
+
+    // The missing slots (deceased person + time) were added; location was NOT duplicated.
+    expect(kinds(next).sort()).toEqual(['location', 'person', 'time'])
+    expect(personRoles(next)).toEqual(['deceased'])
+  })
+
+  it('ADDITIVE: an existing person block in the same role slot blocks that default, but a different role still gets added', () => {
+    const authoredBride: PersonBlock = {
+      id: 'person-authored',
+      kind: 'person',
+      role: 'bride',
+      people: [{ id: 'ppl-1', firstName: 'Custom' }],
+    }
+    const next = applyOccasionDefaults(draft(['wedding'], [authoredBride]))
+
+    const brides = next.blocks.filter((b): b is PersonBlock => b.kind === 'person' && b.role === 'bride')
+    expect(brides).toHaveLength(1)
+    expect(brides[0]).toEqual(authoredBride) // untouched, not overwritten
+
+    const grooms = next.blocks.filter((b): b is PersonBlock => b.kind === 'person' && b.role === 'groom')
+    expect(grooms).toHaveLength(1) // the missing groom default was still added
+  })
+
+  it('a fully author-populated post (all slots already occupied) is untouched — same block array', () => {
+    const authored: Block[] = [
+      { id: 'p1', kind: 'person', role: 'deceased', people: [{ id: 'ppl-1', firstName: 'Tom' }] },
+      { id: 'l1', kind: 'location', mode: 'plain' } as LocationBlock,
+      { id: 't1', kind: 'time' } as TimeBlock,
+    ]
+    const post = draft(['funeral'], authored)
+    const next = applyOccasionDefaults(post)
+    expect(next).toBe(post) // no-op: identical reference, nothing appended
+  })
+
+  it('applying defaults never removes blocks unrelated to the occasion (e.g. a link block)', () => {
+    const link: Block = { id: 'lk1', kind: 'link', url: 'https://example.com' }
+    const next = applyOccasionDefaults(draft(['baptism'], [link]))
+    expect(next.blocks.some((b) => b.id === 'lk1')).toBe(true)
+    expect(next.blocks.length).toBeGreaterThan(1)
+  })
+})

--- a/apps/next/tests/post-editor-reducer.test.ts
+++ b/apps/next/tests/post-editor-reducer.test.ts
@@ -4,7 +4,7 @@ import {
   createEmptyPost,
   validateForPublish,
 } from '@my/ui/src/post-editor/post-reducer'
-import type { Block, Post, TextBlock, TimeBlock } from '@my/app/types/post'
+import type { Block, PersonBlock, Post, TextBlock, TimeBlock } from '@my/app/types/post'
 
 /**
  * Reducer-level tests for the PostEditor's pure state transitions
@@ -107,5 +107,40 @@ describe('postReducer', () => {
     const replacement: TextBlock = { id: 'a', kind: 'text', body: 'replaced', containsPii: false }
     const next = postReducer(p, { type: 'patch-block', id: 'a', patch: replacement })
     expect(next.blocks[0]).toEqual(replacement)
+  })
+
+  it('patch-block on a PersonBlock preserves each person entry\'s stable id (Phase 2c)', () => {
+    const person: PersonBlock = {
+      id: 'pb1',
+      kind: 'person',
+      role: 'candidate',
+      people: [{ id: 'ppl-1', firstName: 'Josh' }],
+    }
+    const p = draft([person])
+    const patched = postReducer(p, {
+      type: 'patch-block',
+      id: 'pb1',
+      patch: { people: [{ id: 'ppl-1', firstName: 'Josh', lastName: 'A' }] } as Partial<Block>,
+    })
+    const result = patched.blocks[0] as PersonBlock
+    expect(result.people[0].id).toBe('ppl-1') // id is stable across an edit
+    expect(result.people[0].lastName).toBe('A')
+
+    // Removing then re-adding a person via a fresh id, as the editor's
+    // add/remove flow does, still round-trips cleanly through the reducer.
+    const withSecondPerson = postReducer(patched, {
+      type: 'patch-block',
+      id: 'pb1',
+      patch: {
+        people: [
+          { id: 'ppl-1', firstName: 'Josh', lastName: 'A' },
+          { id: 'ppl-2', firstName: 'New' },
+        ],
+      } as Partial<Block>,
+    })
+    expect((withSecondPerson.blocks[0] as PersonBlock).people.map((pp) => pp.id)).toEqual([
+      'ppl-1',
+      'ppl-2',
+    ])
   })
 })

--- a/apps/next/tests/redact-post.test.ts
+++ b/apps/next/tests/redact-post.test.ts
@@ -24,12 +24,19 @@ describe('redactBlock — PiiClass name (PersonBlock)', () => {
     id: 'p1',
     kind: 'person',
     role: 'candidate',
-    people: [{ firstName: 'Joshua', lastName: 'Archibald', ecclesia: 'Toronto East', title: 'Brother' }],
+    people: [
+      { id: 'ppl-1', firstName: 'Joshua', lastName: 'Archibald', ecclesia: 'Toronto East', title: 'Brother' },
+    ],
   }
 
-  it('anon / public-web → first name only, no lastName on the object', () => {
+  it('anon / public-web → first name only, no lastName on the object; id (pii:none) carried', () => {
     const r = redactBlock(block, anon) as PersonBlock
-    expect(r.people[0]).toEqual({ firstName: 'Joshua', ecclesia: 'Toronto East', title: 'Brother' })
+    expect(r.people[0]).toEqual({
+      id: 'ppl-1',
+      firstName: 'Joshua',
+      ecclesia: 'Toronto East',
+      title: 'Brother',
+    })
     expect(r.people[0]).not.toHaveProperty('lastName')
   })
 
@@ -50,13 +57,13 @@ describe('redactBlock — PiiClass bio', () => {
     id: 'p2',
     kind: 'person',
     role: 'deceased',
-    people: [{ firstName: 'Tom', lastName: 'Perks', bio: 'A long obituary', age: 84 }],
+    people: [{ id: 'ppl-2', firstName: 'Tom', lastName: 'Perks', bio: 'A long obituary', age: 84 }],
   }
 
   it('anon → bio omitted (name floored)', () => {
     const r = redactBlock(block, anon) as PersonBlock
     expect(r.people[0]).not.toHaveProperty('bio')
-    expect(r.people[0]).toEqual({ firstName: 'Tom', age: 84 })
+    expect(r.people[0]).toEqual({ id: 'ppl-2', firstName: 'Tom', age: 84 })
   })
 
   it('member → bio shown', () => {
@@ -76,7 +83,7 @@ describe('redactBlock — PiiClass contact', () => {
     id: 'p3',
     kind: 'person',
     role: 'contact',
-    people: [{ firstName: 'Sue', lastName: 'Green', contact: '416-555-1212' }],
+    people: [{ id: 'ppl-3', firstName: 'Sue', lastName: 'Green', contact: '416-555-1212' }],
   }
   const reg: RegistrationBlock = {
     id: 'r1',

--- a/apps/next/tests/services/post-service.test.ts
+++ b/apps/next/tests/services/post-service.test.ts
@@ -41,7 +41,12 @@ const nativePost: Post = {
   sharingScope: 'own',
   lifecycle: {},
   blocks: [
-    { id: 'pb', kind: 'person', role: 'bride', people: [{ firstName: 'Mary', lastName: 'Jones' }] },
+    {
+      id: 'pb',
+      kind: 'person',
+      role: 'bride',
+      people: [{ id: 'ppl-mary', firstName: 'Mary', lastName: 'Jones' }],
+    },
   ],
   createdAt: '2026-07-01T00:00:00.000Z',
   updatedAt: '2026-07-01T00:00:00.000Z',
@@ -108,8 +113,8 @@ describe('getPostsForViewer', () => {
   it('redacts PII for an anonymous viewer (first-name floor, bio + members-only text dropped)', async () => {
     const posts = await getPostsForViewer(ANONYMOUS_VIEWER)
 
-    // native person: first name only, no surname.
-    expect(person(byId(posts, 'native-1'))).toEqual({ firstName: 'Mary' })
+    // native person: first name only, no surname. id (pii:'none') is carried through.
+    expect(person(byId(posts, 'native-1'))).toEqual({ id: 'ppl-mary', firstName: 'Mary' })
 
     // legacy baptism candidate: first name only, obituary/testimony bio dropped.
     const candidate = person(byId(posts, 'ev-1'))

--- a/packages/app/types/post.ts
+++ b/packages/app/types/post.ts
@@ -86,6 +86,7 @@ export interface TextBlock extends BlockBase {
 
 /** A person's field-classes: firstName always shown; lastName/bio/contact gated. */
 export interface BlockPerson {
+  id: string // pii:'none' — stable per-entry id (React keying; NOT shown/PII)
   firstName: string // pii:'name' — ALWAYS shown (first-name floor)
   lastName?: string // pii:'name' — dropped below reveal tier
   bio?: string // pii:'bio' — obituary / testimony / about — hidden below member

--- a/packages/app/utils/legacy-to-post.ts
+++ b/packages/app/utils/legacy-to-post.ts
@@ -197,6 +197,7 @@ function eventToPost(event: Event): Post {
   // ── People (name / bio class) ──
   if (event.candidate) {
     const person: PersonBlock['people'][number] = {
+      id: bid('ppl'),
       firstName: event.candidate.firstName,
       lastName: event.candidate.lastName,
     }
@@ -210,6 +211,7 @@ function eventToPost(event: Event): Post {
   }
   if (event.deceased) {
     const person: PersonBlock['people'][number] = {
+      id: bid('ppl'),
       firstName: event.deceased.firstName,
       lastName: event.deceased.lastName,
     }
@@ -224,13 +226,25 @@ function eventToPost(event: Event): Post {
       id: bid('person'),
       kind: 'person',
       role: 'bride',
-      people: [{ firstName: event.couple.bride.firstName, lastName: event.couple.bride.lastName }],
+      people: [
+        {
+          id: bid('ppl'),
+          firstName: event.couple.bride.firstName,
+          lastName: event.couple.bride.lastName,
+        },
+      ],
     })
     blocks.push({
       id: bid('person'),
       kind: 'person',
       role: 'groom',
-      people: [{ firstName: event.couple.groom.firstName, lastName: event.couple.groom.lastName }],
+      people: [
+        {
+          id: bid('ppl'),
+          firstName: event.couple.groom.firstName,
+          lastName: event.couple.groom.lastName,
+        },
+      ],
     })
   }
   if (event.sponsors?.length) {
@@ -239,6 +253,7 @@ function eventToPost(event: Event): Post {
       kind: 'person',
       role: 'sponsor',
       people: event.sponsors.map((s) => ({
+        id: bid('ppl'),
         firstName: s.firstName,
         lastName: s.lastName,
         ...(s.role ? { label: s.role } : {}),
@@ -251,6 +266,7 @@ function eventToPost(event: Event): Post {
       kind: 'person',
       role: 'speaker',
       people: event.speakers.map((s) => ({
+        id: bid('ppl'),
         firstName: s.firstName,
         lastName: s.lastName,
         ...(s.title ? { title: s.title } : {}),
@@ -264,6 +280,7 @@ function eventToPost(event: Event): Post {
       kind: 'person',
       role: 'other',
       people: event.weddingParty.map((m) => ({
+        id: bid('ppl'),
         firstName: m.firstName,
         lastName: m.lastName,
         ...(m.role ? { label: m.role } : {}),

--- a/packages/app/utils/redact-post.ts
+++ b/packages/app/utils/redact-post.ts
@@ -82,6 +82,7 @@ function redactPerson(block: PersonBlock, viewer: Viewer, channel: Channel): Per
       // shapePersonName drops lastName below reveal tier — no View-Source leak.
       const named = shapePersonName(p, viewer, channel)
       const out: PersonBlock['people'][number] = {
+        id: p.id, // pii:'none' — always carried (keying, not shown)
         firstName: named.firstName,
       }
       if (named.lastName) out.lastName = named.lastName

--- a/packages/ui/src/post-editor/blocks/person-block-editor.tsx
+++ b/packages/ui/src/post-editor/blocks/person-block-editor.tsx
@@ -9,10 +9,13 @@ import { Button } from '../../Button'
 /**
  * PersonBlock editor — a `role` (design vocabulary for the block's people —
  * speaker/candidate/deceased/etc) plus a repeatable list of
- * {@link BlockPerson}. `firstName` is the only required field (the PII
- * "first-name floor" — always shown even to anon; design §8.2); the rest are
- * `pii:'name'|'bio'|'contact'` and gated by the redactor at read time, not
- * here — the editor just captures them.
+ * {@link BlockPerson}. `firstName` is the only author-facing required field
+ * (the PII "first-name floor" — always shown even to anon; design §8.2); the
+ * rest are `pii:'name'|'bio'|'contact'` and gated by the redactor at read
+ * time, not here — the editor just captures them. `id` is minted here (not
+ * author-facing) — a stable per-entry id so the list can be keyed by identity
+ * instead of array index (fixes focus jumping to the wrong input when a
+ * middle entry is removed).
  *
  * Fully controlled: `onChange` emits the full next PersonBlock.
  */
@@ -32,7 +35,7 @@ const ROLE_OPTIONS: Array<{ value: PersonBlock['role']; label: string }> = [
 ]
 
 function emptyPerson(): BlockPerson {
-  return { firstName: '' }
+  return { id: genId('ppl'), firstName: '' }
 }
 
 export function PersonBlockEditor({ block, onChange }: BlockEditorProps<PersonBlock>) {
@@ -63,7 +66,7 @@ export function PersonBlockEditor({ block, onChange }: BlockEditorProps<PersonBl
 
       <YStack gap="$3">
         {block.people.map((person, index) => (
-          <Card key={index} bordered padding="$3" gap="$3" backgroundColor="$backgroundHover">
+          <Card key={person.id} bordered padding="$3" gap="$3" backgroundColor="$backgroundHover">
             <XStack justifyContent="space-between" alignItems="center">
               <Text fontSize="$3" fontWeight="600">
                 Person {index + 1}

--- a/packages/ui/src/post-editor/index.ts
+++ b/packages/ui/src/post-editor/index.ts
@@ -27,6 +27,9 @@ export {
 } from './registry'
 export { registerDefaultBlocks } from './register-default-blocks'
 
+// Occasion-tag default block sets (Phase 2c) — pure, unit-testable in isolation.
+export { applyOccasionDefaults } from './occasion-defaults'
+
 // Block editors + factories (for direct reuse / registration).
 export { TextBlockEditor, makeTextBlock } from './blocks/text-block-editor'
 export { TimeBlockEditor, makeTimeBlock } from './blocks/time-block-editor'

--- a/packages/ui/src/post-editor/occasion-defaults.ts
+++ b/packages/ui/src/post-editor/occasion-defaults.ts
@@ -1,0 +1,133 @@
+import type { Block, LocationBlock, OccasionTag, PersonBlock, Post, TextBlock, TimeBlock } from '@my/app/types/post'
+import { DEFAULT_TIMEZONE } from '@my/app/utils/timezone'
+import { genId } from './post-reducer'
+
+/**
+ * Occasion → default block set (Consolidated CMS Phase 2c; design doc "Phase
+ * 2 — Toolbar authoring UI": *"`occasion` tags seed default block sets (a
+ * baptism occasion pre-adds Candidate + Location + Time + a members-only
+ * Testimony text block)"*).
+ *
+ * Pure, data-only map — no code path per occasion (occasion is DATA, design
+ * §8.5). Setting an occasion tag pre-adds a small starting set of EMPTY
+ * blocks so the author isn't staring at a blank canvas; every added block is
+ * just a normal block afterwards — freely edited or deleted like any other.
+ *
+ * ADDITIVE / SAFE-BY-DEFAULT (see {@link applyOccasionDefaults}): a default is
+ * only added for a "slot" the post doesn't already occupy — existing author
+ * content is NEVER removed, replaced, or edited. This covers both "no blocks
+ * yet" and "some blocks already, top up the missing defaults" with the same
+ * rule, so there's no special-casing between create and edit.
+ *
+ * Cross-platform: pure types + logic, no platform imports. Deliberately does
+ * NOT import the `blocks/*-block-editor.tsx` `make*Block()` factories — several
+ * of those pull in `@tamagui/lucide-icons` (via `PlainSelect`/`PlainCheckbox`),
+ * which the plain-Node Vitest environment can't parse (see
+ * `post-editor-blocks-2b.test.ts`'s file header for the full story). Blocks are
+ * constructed directly here from the typed shape instead, so this module —
+ * and its tests — stay lightweight and hang-free.
+ */
+
+interface OccasionDefaultBlock {
+  /**
+   * The "slot" this default occupies, for the already-present check. Block
+   * kind for most blocks; Person blocks use `kind:role` so e.g. a wedding's
+   * bride and groom defaults are independently addable (two `person` blocks,
+   * two different slots).
+   */
+  slot: string
+  make: () => Block
+}
+
+function personDefault(role: PersonBlock['role']): OccasionDefaultBlock {
+  return {
+    slot: `person:${role}`,
+    make: (): PersonBlock => ({ id: genId('blk'), kind: 'person', role, people: [] }),
+  }
+}
+
+const LOCATION_DEFAULT: OccasionDefaultBlock = {
+  slot: 'location',
+  make: (): LocationBlock => ({ id: genId('blk'), kind: 'location', mode: 'plain' }),
+}
+
+const TIME_DEFAULT: OccasionDefaultBlock = {
+  slot: 'time',
+  make: (): TimeBlock => ({ id: genId('blk'), kind: 'time', timezone: DEFAULT_TIMEZONE }),
+}
+
+/** A members-only text block seeded for the baptism candidate's testimony. */
+const TESTIMONY_TEXT_DEFAULT: OccasionDefaultBlock = {
+  slot: 'text',
+  make: (): TextBlock => ({
+    id: genId('blk'),
+    kind: 'text',
+    body: '## Testimony\n\n',
+    containsPii: true,
+    visibility: 'members',
+  }),
+}
+
+/** A single, plain text block — the news/default shape. */
+const TEXT_DEFAULT: OccasionDefaultBlock = {
+  slot: 'text',
+  make: (): TextBlock => ({ id: genId('blk'), kind: 'text', body: '', containsPii: false }),
+}
+
+/**
+ * occasion → default block set (design doc examples): baptism gets a
+ * candidate + location + time + a members-only testimony text block; funeral
+ * gets a deceased + location + time; wedding gets a bride + groom + location +
+ * time; news gets a single text block. Occasions with no entry here fall back
+ * to {@link FALLBACK_DEFAULTS} (also a single text block) via
+ * {@link defaultBlockSetFor}.
+ */
+const OCCASION_DEFAULTS: Partial<Record<OccasionTag, OccasionDefaultBlock[]>> = {
+  baptism: [personDefault('candidate'), LOCATION_DEFAULT, TIME_DEFAULT, TESTIMONY_TEXT_DEFAULT],
+  funeral: [personDefault('deceased'), LOCATION_DEFAULT, TIME_DEFAULT],
+  wedding: [personDefault('bride'), personDefault('groom'), LOCATION_DEFAULT, TIME_DEFAULT],
+  news: [TEXT_DEFAULT],
+}
+
+/** Fallback for occasions with no specific mapping (e.g. 'general', 'announcement'). */
+const FALLBACK_DEFAULTS: OccasionDefaultBlock[] = [TEXT_DEFAULT]
+
+/**
+ * The union of default blocks for a post's occasion tags, de-duplicated by
+ * slot (a post can carry multiple free-combining occasion tags, design §8.5).
+ * The generic fallback only applies when NONE of the post's tags has a
+ * specific mapping — e.g. `['wedding','shower']` gets wedding's defaults, not
+ * wedding's defaults PLUS a generic text block for 'shower'.
+ */
+function defaultBlockSetFor(occasion: OccasionTag[]): OccasionDefaultBlock[] {
+  const bySlot = new Map<string, OccasionDefaultBlock>()
+  for (const tag of occasion) {
+    for (const def of OCCASION_DEFAULTS[tag] ?? []) {
+      if (!bySlot.has(def.slot)) bySlot.set(def.slot, def)
+    }
+  }
+  if (bySlot.size === 0) {
+    for (const def of FALLBACK_DEFAULTS) bySlot.set(def.slot, def)
+  }
+  return Array.from(bySlot.values())
+}
+
+/** The slot an EXISTING block occupies, using the same discriminator as the defaults above. */
+function slotOf(block: Block): string {
+  return block.kind === 'person' ? `person:${block.role}` : block.kind
+}
+
+/**
+ * Pre-add the occasion's default blocks — ADDITIVE ONLY. For each default
+ * "slot" the post doesn't already have a block in, append a fresh instance;
+ * slots the post already occupies (author content OR a previously-applied
+ * default) are left completely untouched. Never removes, replaces, or edits
+ * an existing block — call this as often as you like, it only ever adds.
+ */
+export function applyOccasionDefaults(post: Post): Post {
+  const defaults = defaultBlockSetFor(post.occasion)
+  const existingSlots = new Set(post.blocks.map(slotOf))
+  const toAdd = defaults.filter((d) => !existingSlots.has(d.slot)).map((d) => d.make())
+  if (toAdd.length === 0) return post
+  return { ...post, blocks: [...post.blocks, ...toAdd] }
+}

--- a/packages/ui/src/post-editor/post-editor.tsx
+++ b/packages/ui/src/post-editor/post-editor.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react'
 import { YStack, XStack, Card, Text, Label, Input, Separator, H3 } from 'tamagui'
-import { Plus, Trash2, ChevronUp, ChevronDown, X } from '@tamagui/lucide-icons'
+import { Plus, Trash2, ChevronUp, ChevronDown, ChevronRight, X } from '@tamagui/lucide-icons'
 import type { OccasionTag, Post, Visibility } from '@my/app/types/post'
 import { Button } from '../Button'
 import { postReducer, validateForPublish, type PostAction } from './post-reducer'
@@ -7,6 +8,7 @@ import { getBlockDef, listBlockDefs } from './registry'
 import { registerDefaultBlocks } from './register-default-blocks'
 import { PlainSelect } from './plain-select'
 import { OCCASION_OPTIONS, VISIBILITY_OPTIONS } from './options'
+import { applyOccasionDefaults } from './occasion-defaults'
 
 // Ensure the reference block editors are available the moment the module loads.
 registerDefaultBlocks()
@@ -32,11 +34,27 @@ export interface PostEditorProps {
 
 export function PostEditor({ value, onChange, onPublish }: PostEditorProps) {
   const dispatch = (action: PostAction) => onChange(postReducer(value, action))
+  const [toolbarExpanded, setToolbarExpanded] = useState(true)
 
   const publishErrors = validateForPublish(value)
   const canPublish = publishErrors.length === 0
 
   const availableOccasions = OCCASION_OPTIONS.filter((o) => !value.occasion.includes(o.value))
+
+  /**
+   * Adding an occasion tag pre-adds that occasion's default block set
+   * (Phase 2c) — additive only, never touches existing blocks (see
+   * `occasion-defaults.ts`). Composed as two pure reducer steps applied to
+   * the SAME base `value` so the editor stays a single onChange per action,
+   * same as every other toolbar action here.
+   */
+  const addOccasionTag = (tag: OccasionTag) => {
+    const withTag = postReducer(value, {
+      type: 'patch-post',
+      patch: { occasion: [...value.occasion, tag] },
+    })
+    onChange(applyOccasionDefaults(withTag))
+  }
 
   return (
     <YStack gap="$4">
@@ -95,12 +113,7 @@ export function PostEditor({ value, onChange, onPublish }: PostEditorProps) {
                 value=""
                 placeholder="Add a tag…"
                 options={availableOccasions}
-                onValueChange={(tag) =>
-                  dispatch({
-                    type: 'patch-post',
-                    patch: { occasion: [...value.occasion, tag as OccasionTag] },
-                  })
-                }
+                onValueChange={(tag) => addOccasionTag(tag as OccasionTag)}
               />
             </XStack>
           ) : null}
@@ -201,23 +214,41 @@ export function PostEditor({ value, onChange, onPublish }: PostEditorProps) {
         )}
       </YStack>
 
-      {/* ---- Toolbar (add blocks) ------------------------------------------ */}
+      {/* ---- Toolbar (add blocks) — collapsible; free-drag positioning and
+          block drag-reorder are a later slice (up/down reorder stays above). */}
       <Card bordered padding="$3" gap="$2" backgroundColor="$backgroundHover">
-        <Text fontSize="$3" fontWeight="600">
-          Add a block
-        </Text>
-        <XStack gap="$2" flexWrap="wrap">
-          {listBlockDefs().map((def) => (
-            <Button
-              key={def.kind}
-              size="$3"
-              icon={def.icon ?? Plus}
-              onPress={() => dispatch({ type: 'add-block', block: def.make() })}
-            >
-              {def.label}
-            </Button>
-          ))}
+        <XStack
+          alignItems="center"
+          justifyContent="space-between"
+          cursor="pointer"
+          pressStyle={{ opacity: 0.8 }}
+          aria-label={toolbarExpanded ? 'Collapse block toolbar' : 'Expand block toolbar'}
+          onPress={() => setToolbarExpanded((prev) => !prev)}
+        >
+          <XStack alignItems="center" gap="$2">
+            {toolbarExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+            <Text fontSize="$3" fontWeight="600">
+              Add a block
+            </Text>
+          </XStack>
+          <Text fontSize="$2" color="$color10">
+            {toolbarExpanded ? 'Hide' : 'Show'}
+          </Text>
         </XStack>
+        {toolbarExpanded ? (
+          <XStack gap="$2" flexWrap="wrap">
+            {listBlockDefs().map((def) => (
+              <Button
+                key={def.kind}
+                size="$3"
+                icon={def.icon ?? Plus}
+                onPress={() => dispatch({ type: 'add-block', block: def.make() })}
+              >
+                {def.label}
+              </Button>
+            ))}
+          </XStack>
+        ) : null}
       </Card>
 
       {/* ---- Publish (validate-on-publish only) ---------------------------- */}


### PR DESCRIPTION
Phase 2c of #131 — editor completeness. Additive, behind `CONSOLIDATED_CMS`.

## What
- **Occasion-tag default block sets** (`post-editor/occasion-defaults.ts`) — setting an occasion pre-adds its default blocks: `baptism`→Candidate+Location+Time+members-Testimony; `funeral`→Deceased+Location+Time; `wedding`→Bride+Groom+Location+Time; `news`/fallback→Text. **Additive & idempotent** — slot-based (kind, or kind:role for Person), only fills unoccupied slots, never edits/removes author content, calling twice is a no-op.
- **Posts list page** `/admin/posts` — title/occasion/status/updatedAt via `listPosts`; 'New post'→`/admin/posts/new`; rows→`/admin/posts/{id}`.
- **Person stable id** — `BlockPerson.id` (`pii:'none'`) minted at every construction site (editor + all 6 legacy-adapter people), carried through `redactPerson` (keying only, not shown), keys the people list → fixes focus-jump on middle-remove.
- **Collapsible toolbar** — the add-block palette collapses (matches the `sections-editor` accordion idiom, cross-platform). Up/down reorder unchanged; free-drag deferred to 2d.

## Verify
- Post-model suite **78/78** (occasion-defaults 11 cases incl. additive-preservation/idempotency/multi-tag non-dilution; person-id stability + redactor carry; registry/reducer green). Typecheck clean; `next build` compiles (pre-existing GOOGLE-key route aside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)