### PR TITLE
CONSOLIDATED_CMS Phase 3 — PostView renderer + viewable public post (#131)

### DIFF
--- a/apps/next/app/(public)/posts/[id]/page.tsx
+++ b/apps/next/app/(public)/posts/[id]/page.tsx
@@ -1,0 +1,31 @@
+import { notFound } from 'next/navigation'
+import { getPublicPost } from '../../../../utils/get-public-post'
+import { PostViewScreen } from './post-view-screen'
+
+/**
+ * Public Post view page (Consolidated CMS epic #131, Phase 3).
+ *
+ * A SERVER component: it does the read + redaction on the server via
+ * `getPublicPost` (flag gate → load → status gate → `redactPost` at the
+ * `public-web` tier) and passes the already-redacted post to the client
+ * `PostViewScreen`. When the post is hidden — flag OFF, missing, not `ready`, or
+ * unreachable for the viewer — `getPublicPost` returns `null` and we `notFound()`
+ * so the whole feature stays invisible while the flag is OFF.
+ *
+ * This is a NEW, additive surface. It does not touch the legacy events/news
+ * pages, `/api/events/public`, or the newsletter render path.
+ */
+
+// Session/viewer-dependent redaction ⇒ never statically cache this page.
+export const dynamic = 'force-dynamic'
+
+export default async function PublicPostPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const post = await getPublicPost(id)
+  if (!post) notFound()
+  return <PostViewScreen post={post} />
+}

--- a/apps/next/app/(public)/posts/[id]/post-view-screen.tsx
+++ b/apps/next/app/(public)/posts/[id]/post-view-screen.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { YStack } from 'tamagui'
+import { PostView } from '@my/ui'
+import type { Post } from '@my/app/types/post'
+
+/**
+ * Thin client wrapper that provides the page layout around {@link PostView}.
+ * The server page does the read + redaction and passes an already-REDACTED post;
+ * this only supplies the centered content column (Tamagui components must render
+ * in a client boundary).
+ */
+export function PostViewScreen({ post }: { post: Post }) {
+  return (
+    <YStack flex={1} padding="$4" alignItems="center">
+      <PostView post={post} />
+    </YStack>
+  )
+}

--- a/apps/next/app/admin/(admin-plus)/ui-ux/brand/post-view/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/ui-ux/brand/post-view/page.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { PostViewShowcase } from '@my/ui/src/branding'
+import { useAdminAccess } from '@/hooks/use-admin-access'
+import { YStack, Text, Spinner } from '@my/ui'
+import { useHydrated } from '@my/app/hooks/use-hydrated'
+
+export default function BrandPostViewPage() {
+  const isHydrated = useHydrated()
+  const { hasAccess, isLoading } = useAdminAccess()
+
+  if (!isHydrated || isLoading || !hasAccess) {
+    return (
+      <YStack flex={1} justifyContent="center" alignItems="center" padding="$4">
+        <Spinner size="large" width={36} height={36} />
+        <Text marginTop="$4">Loading...</Text>
+      </YStack>
+    )
+  }
+
+  return <PostViewShowcase />
+}

--- a/apps/next/app/api/posts/[id]/route.ts
+++ b/apps/next/app/api/posts/[id]/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { getPublicPost } from '../../../../utils/get-public-post'
+
+/**
+ * Public Post read API (Consolidated CMS epic #131, Phase 3).
+ *
+ * The PUBLIC counterpart to `/api/admin/posts/[id]` — but where the admin route
+ * returns the RAW post to an owner/admin, this route returns the post ONLY after
+ * `getPublicPost` has flag-gated it and run it through `redactPost` at the
+ * `public-web` tier. It never exposes un-redacted PII, so it is safe for
+ * anonymous callers. A hidden post (flag OFF, missing, not `ready`, or
+ * unreachable for the viewer) is a 404 — the feature stays invisible.
+ *
+ * Distinct from the admin route by design: DO NOT point public clients at the
+ * admin endpoint (it neither redacts nor is reachable without owner/admin).
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const post = await getPublicPost(id)
+    if (!post) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
+    return NextResponse.json(post)
+  } catch (error) {
+    console.error('Error loading public post:', error)
+    return NextResponse.json({ error: 'Failed to load post' }, { status: 500 })
+  }
+}

--- a/apps/next/tests/post-view-format.test.ts
+++ b/apps/next/tests/post-view-format.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect } from 'vitest'
+import {
+  personRoleLabel,
+  formatPersonName,
+  personMetaLine,
+  locationAddressLines,
+  locationMapsHref,
+  formatTimeBlock,
+  formatDateFacet,
+  looksLikeImage,
+  formatOccasions,
+} from '@my/ui/src/post-view/post-view-format'
+import type {
+  FlyerBlock,
+  LinkBlock,
+  LocationBlock,
+  PersonBlock,
+  Post,
+  RegistrationBlock,
+  TextBlock,
+  TimeBlock,
+} from '@my/app/types/post'
+
+/**
+ * PostView display-string coverage (Consolidated CMS Phase 3).
+ *
+ * These test the PURE formatting helpers that decide WHAT PostView renders,
+ * NOT the rendered React tree. Rendering `PostView` in this plain-Node Vitest
+ * env hangs because it (and its Tamagui deps) pull in `@tamagui/lucide-icons`,
+ * whose CJS build loads React Native's Flow-typed source that this config can't
+ * transform — the same wall the Phase 2b block tests document. So we assert the
+ * display layer at the string boundary instead, across all seven block kinds.
+ */
+
+describe('personRoleLabel', () => {
+  it('maps design roles to display labels', () => {
+    expect(personRoleLabel('speaker')).toBe('Speaker')
+    expect(personRoleLabel('deceased')).toBe('In memory of')
+    expect(personRoleLabel('candidate')).toBe('Candidate')
+    expect(personRoleLabel('other')).toBe('People')
+  })
+})
+
+describe('formatPersonName', () => {
+  it('joins first + last when present (redactor already decided)', () => {
+    expect(formatPersonName({ id: 'p', firstName: 'Sarah', lastName: 'Thompson' })).toBe(
+      'Sarah Thompson'
+    )
+  })
+  it('is first-name only when the surname was redacted away', () => {
+    expect(formatPersonName({ id: 'p', firstName: 'Sarah' })).toBe('Sarah')
+  })
+  it('prefixes an honorific title when present', () => {
+    expect(
+      formatPersonName({ id: 'p', firstName: 'John', lastName: 'Carter', title: 'Brother' })
+    ).toBe('Brother John Carter')
+  })
+})
+
+describe('personMetaLine', () => {
+  it('joins label, ecclesia, age with middots', () => {
+    expect(
+      personMetaLine({ id: 'p', firstName: 'John', label: 'speaker', ecclesia: 'Hamilton', age: 42 })
+    ).toBe('speaker · Hamilton · age 42')
+  })
+  it('is empty when there is nothing to show', () => {
+    expect(personMetaLine({ id: 'p', firstName: 'John' })).toBe('')
+  })
+})
+
+describe('locationAddressLines', () => {
+  const base: LocationBlock = {
+    id: 'l',
+    kind: 'location',
+    mode: 'geo',
+    venueName: 'Toronto East Hall',
+    address: '960 Pape Avenue',
+    city: 'Toronto',
+    province: 'ON',
+    postalCode: 'M4K 3V1',
+    country: 'Canada',
+  }
+  it('produces venue, address, city line, country in reading order', () => {
+    expect(locationAddressLines(base)).toEqual([
+      'Toronto East Hall',
+      '960 Pape Avenue',
+      'Toronto, ON, M4K 3V1',
+      'Canada',
+    ])
+  })
+  it('collapses to the safe floor when precise fields were redacted', () => {
+    // Mirrors a redacted anon block: venue + city only.
+    expect(
+      locationAddressLines({ id: 'l', kind: 'location', mode: 'geo', venueName: 'Toronto East Hall', city: 'Toronto' })
+    ).toEqual(['Toronto East Hall', 'Toronto'])
+  })
+})
+
+describe('locationMapsHref', () => {
+  it('prefers an explicit mapsUrl', () => {
+    expect(
+      locationMapsHref({ id: 'l', kind: 'location', mode: 'geo', mapsUrl: 'https://maps.example/x', city: 'Toronto' })
+    ).toBe('https://maps.example/x')
+  })
+  it('derives a maps search url from address parts', () => {
+    const href = locationMapsHref({
+      id: 'l',
+      kind: 'location',
+      mode: 'geo',
+      venueName: 'Toronto East Hall',
+      city: 'Toronto',
+    })
+    expect(href).toContain('https://www.google.com/maps/search/')
+    expect(href).toContain(encodeURIComponent('Toronto East Hall, Toronto'))
+  })
+  it('returns undefined when there is nothing to link', () => {
+    expect(locationMapsHref({ id: 'l', kind: 'location', mode: 'ecclesia' })).toBeUndefined()
+  })
+})
+
+describe('formatTimeBlock', () => {
+  it('formats an ISO instant in its timezone', () => {
+    const block: TimeBlock = {
+      id: 't',
+      kind: 'time',
+      label: 'Baptism service',
+      startsAt: '2026-09-12T14:00:00.000Z',
+      timezone: 'America/Toronto',
+    }
+    const out = formatTimeBlock(block)
+    expect(out.label).toBe('Baptism service')
+    expect(out.dateLine).toContain('2026')
+    expect(out.dateLine).toContain('September')
+    expect(out.timeLine).toContain('10:00am') // 14:00 UTC = 10:00 EDT
+  })
+  it('appends an end time as a range', () => {
+    const out = formatTimeBlock({
+      id: 't',
+      kind: 'time',
+      startsAt: '2026-09-12T14:00:00.000Z',
+      endsAt: '2026-09-12T16:00:00.000Z',
+      timezone: 'America/Toronto',
+    })
+    expect(out.timeLine).toContain('–')
+    expect(out.timeLine).toContain('12:00pm')
+  })
+  it('falls back to free-text display when there is no ISO instant', () => {
+    const out = formatTimeBlock({ id: 't', kind: 'time', label: 'Reception', display: '7:30pm' })
+    expect(out.dateLine).toBe('')
+    expect(out.timeLine).toBe('7:30pm')
+  })
+})
+
+describe('formatDateFacet', () => {
+  const base: Post = {
+    id: 'x',
+    tenant: 't',
+    authorId: 'a',
+    title: 'T',
+    occasion: ['general'],
+    visibility: 'public',
+    sharingScope: 'own',
+    lifecycle: {},
+    blocks: [],
+    createdAt: '',
+    updatedAt: '',
+    status: 'ready',
+  }
+  it('uses a future startsAt for event-shaped posts', () => {
+    const facet = formatDateFacet({ ...base, lifecycle: { startsAt: '2026-09-12T14:00:00.000Z' } })
+    expect(facet).toContain('September')
+  })
+  it('falls back to publishDate for news-shaped posts', () => {
+    const facet = formatDateFacet({ ...base, lifecycle: { publishDate: '2026-08-01' } })
+    expect(facet).toContain('August')
+  })
+  it('is undefined when no date is known', () => {
+    expect(formatDateFacet(base)).toBeUndefined()
+  })
+})
+
+describe('looksLikeImage', () => {
+  it('detects by mime type', () => {
+    expect(looksLikeImage('https://x/y', 'image/png')).toBe(true)
+  })
+  it('detects by extension', () => {
+    expect(looksLikeImage('https://x/y.jpg')).toBe(true)
+    expect(looksLikeImage('https://x/y.webp')).toBe(true)
+  })
+  it('is false for a pdf', () => {
+    expect(looksLikeImage('https://x/y.pdf', 'application/pdf')).toBe(false)
+  })
+})
+
+describe('formatOccasions', () => {
+  it('title-cases and middot-joins tags', () => {
+    expect(formatOccasions(['baptism', 'study-weekend'])).toBe('Baptism · Study weekend')
+  })
+})
+
+/**
+ * A single sample post exercising ALL SEVEN block kinds — proves the display
+ * layer has a formatting story for each kind PostView renders (text/person/
+ * location/time/flyer/registration/link), keeping display coverage in lockstep
+ * with the editor's 7-kind registry.
+ */
+describe('all-seven-kinds display coverage', () => {
+  const text: TextBlock = { id: 'b1', kind: 'text', body: '# Hi', containsPii: false }
+  const person: PersonBlock = {
+    id: 'b2',
+    kind: 'person',
+    role: 'candidate',
+    people: [{ id: 'p', firstName: 'Sarah', lastName: 'Thompson' }],
+  }
+  const location: LocationBlock = {
+    id: 'b3',
+    kind: 'location',
+    mode: 'geo',
+    venueName: 'Hall',
+    city: 'Toronto',
+  }
+  const time: TimeBlock = {
+    id: 'b4',
+    kind: 'time',
+    startsAt: '2026-09-12T14:00:00.000Z',
+    timezone: 'America/Toronto',
+  }
+  const flyer: FlyerBlock = {
+    id: 'b5',
+    kind: 'flyer',
+    document: {
+      id: 'd',
+      documentType: 'upload',
+      fileName: 'f.png',
+      originalName: 'Flyer',
+      fileUrl: 'https://x/f.png',
+      fileSize: 1,
+      mimeType: 'image/png',
+      uploadedAt: new Date(),
+      uploadedBy: 'a',
+    },
+  }
+  const registration: RegistrationBlock = { id: 'b6', kind: 'registration', required: true }
+  const link: LinkBlock = { id: 'b7', kind: 'link', url: 'https://x/y', label: 'More' }
+
+  it('has a display projection for each kind', () => {
+    expect(personRoleLabel(person.role)).toBe('Candidate')
+    expect(formatPersonName(person.people[0])).toBe('Sarah Thompson')
+    expect(locationAddressLines(location)).toEqual(['Hall', 'Toronto'])
+    expect(formatTimeBlock(time).dateLine).toContain('September')
+    expect(looksLikeImage(flyer.document.fileUrl, flyer.document.mimeType)).toBe(true)
+    expect(registration.required).toBe(true)
+    expect(link.label).toBe('More')
+    // text body renders via MarkdownLiteText at the component layer.
+    expect(text.body.startsWith('#')).toBe(true)
+  })
+})

--- a/apps/next/tests/public-post-route.test.ts
+++ b/apps/next/tests/public-post-route.test.ts
@@ -1,0 +1,137 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { ANONYMOUS_VIEWER, type Viewer } from '@my/app/utils/viewer-pii'
+import type { Post } from '@my/app/types/post'
+
+/**
+ * Public Post read route guard + redaction (Consolidated CMS Phase 3).
+ *
+ * The safety-critical bits: the feature is HIDDEN while the CONSOLIDATED_CMS
+ * flag is OFF (404, repo never touched), drafts never leak, and — crucially —
+ * the response is passed through the REAL `redactPost` at the `public-web` tier
+ * so an anonymous caller never receives un-redacted PII (surnames, members-only
+ * blocks). Only `redactPost` is left un-mocked; everything else is stubbed in
+ * the style of `posts-route.test.ts`.
+ */
+
+const h = vi.hoisted(() => ({
+  auth: vi.fn(),
+  checkFlag: vi.fn(),
+  getPost: vi.fn(),
+  resolveViewer: vi.fn(),
+}))
+
+vi.mock('../utils/auth', () => ({ auth: h.auth }))
+vi.mock('../utils/resolve-viewer', () => ({ resolveViewer: h.resolveViewer }))
+vi.mock('@my/app/features/feature-flags/use-feature-flag-wrapper', () => ({
+  checkFeatureFlagFromDB: h.checkFlag,
+}))
+vi.mock('@my/app/provider/dynamodb/repositories/post-repository', () => ({
+  postRepository: { getPost: h.getPost },
+}))
+
+import { GET } from '../app/api/posts/[id]/route'
+
+function req() {
+  return {} as any
+}
+function ctx(id: string) {
+  return { params: Promise.resolve({ id }) }
+}
+
+/** A ready, public post carrying PII the redactor must scrub for anon. */
+function samplePost(): Post {
+  const now = new Date().toISOString()
+  return {
+    id: 'p1',
+    tenant: 'demo',
+    authorId: 'a',
+    title: 'Baptism',
+    occasion: ['baptism'],
+    visibility: 'public',
+    sharingScope: 'own',
+    lifecycle: { publishDate: '2026-08-01' },
+    status: 'ready',
+    createdAt: now,
+    updatedAt: now,
+    blocks: [
+      {
+        id: 'b-person',
+        kind: 'person',
+        role: 'candidate',
+        people: [{ id: 'pp', firstName: 'Sarah', lastName: 'Thompson' }],
+      },
+      // Members-only text block — must be dropped for an anonymous viewer.
+      { id: 'b-secret', kind: 'text', body: 'private note', containsPii: true, visibility: 'members' },
+    ],
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.auth.mockResolvedValue(null)
+  h.checkFlag.mockResolvedValue(true)
+  h.resolveViewer.mockResolvedValue(ANONYMOUS_VIEWER)
+  h.getPost.mockResolvedValue(samplePost())
+})
+
+describe('GET /api/posts/[id] — gate', () => {
+  it('404 when the CONSOLIDATED_CMS flag is OFF (feature hidden), repo untouched', async () => {
+    h.checkFlag.mockResolvedValue(false)
+    const res = await GET(req(), ctx('p1'))
+    expect(res.status).toBe(404)
+    expect(h.getPost).not.toHaveBeenCalled()
+  })
+
+  it('404 when the post does not exist', async () => {
+    h.getPost.mockResolvedValue(null)
+    const res = await GET(req(), ctx('missing'))
+    expect(res.status).toBe(404)
+  })
+
+  it('404 for a draft post (never leak an unpublished draft)', async () => {
+    h.getPost.mockResolvedValue({ ...samplePost(), status: 'draft' })
+    const res = await GET(req(), ctx('p1'))
+    expect(res.status).toBe(404)
+  })
+
+  it('404 when the viewer cannot reach the post visibility', async () => {
+    h.getPost.mockResolvedValue({ ...samplePost(), visibility: 'members' })
+    const res = await GET(req(), ctx('p1'))
+    expect(res.status).toBe(404) // redactPost → null for anonymous
+  })
+})
+
+describe('GET /api/posts/[id] — redaction applied', () => {
+  it('200 returns the post with PII scrubbed for an anonymous viewer', async () => {
+    const res = await GET(req(), ctx('p1'))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Post
+
+    // Reach check happened at the public-web tier.
+    expect(h.resolveViewer).toHaveBeenCalledTimes(1)
+
+    // Surname was stripped (first-name floor kept).
+    const person = body.blocks.find((b) => b.kind === 'person') as any
+    expect(person.people[0].firstName).toBe('Sarah')
+    expect(person.people[0].lastName).toBeUndefined()
+
+    // Members-only block dropped entirely for anon.
+    expect(body.blocks.find((b) => b.id === 'b-secret')).toBeUndefined()
+  })
+
+  it('reveals full names for a verified member viewer', async () => {
+    const member: Viewer = {
+      assurance: 'authenticated',
+      role: 'member',
+      tenant: 'demo',
+      email: 'm@demo.test',
+    }
+    h.resolveViewer.mockResolvedValue(member)
+    const res = await GET(req(), ctx('p1'))
+    const body = (await res.json()) as Post
+    const person = body.blocks.find((b) => b.kind === 'person') as any
+    expect(person.people[0].lastName).toBe('Thompson')
+    // Members-only block is now visible.
+    expect(body.blocks.find((b) => b.id === 'b-secret')).toBeDefined()
+  })
+})

--- a/apps/next/utils/get-public-post.ts
+++ b/apps/next/utils/get-public-post.ts
@@ -1,0 +1,47 @@
+import { auth } from './auth'
+import { resolveViewer } from './resolve-viewer'
+import { postRepository } from '@my/app/provider/dynamodb/repositories/post-repository'
+import { checkFeatureFlagFromDB } from '@my/app/features/feature-flags/use-feature-flag-wrapper'
+import { FEATURE_FLAGS } from '@my/app/features/feature-flags/feature-flags'
+import { redactPost } from '@my/app/utils/redact-post'
+import type { Post } from '@my/app/types/post'
+
+/**
+ * THE public read for a single unified Post (Consolidated CMS epic #131, Phase 3).
+ *
+ * The one server boundary that both the public page (`/(public)/posts/[id]`) and
+ * the public read API (`/api/posts/[id]`) call — so redaction + flag-gating live
+ * in ONE place and can't drift. Returns the REDACTED post (safe to serialize to
+ * any viewer), or `null` when the post must be hidden:
+ *
+ *   1. FLAG OFF → `null`. `CONSOLIDATED_CMS` gates the whole feature; while it's
+ *      OFF the public route 404s and nothing about the unified model is exposed
+ *      (fails closed on any flag-store error — see `checkFeatureFlagFromDB`).
+ *   2. MISSING post → `null`.
+ *   3. NOT publicly viewable → `null`. Only `status: 'ready'` posts are served;
+ *      drafts and archived posts never leak through the public door.
+ *   4. VIEWER CANNOT REACH → `null`. `redactPost` reach-gates by visibility and,
+ *      crucially, PII-scrubs every surviving block for the resolved viewer at the
+ *      hard `public-web` tier BEFORE serialization — a surname / precise address /
+ *      bio is present in the result ONLY if this viewer is allowed to see it.
+ *
+ * This deliberately does NOT touch the legacy events/news read paths — it is a
+ * new, additive, flag-gated surface (the lossy legacy swap is a later phase).
+ */
+export async function getPublicPost(id: string): Promise<Post | null> {
+  // Flag gate first — feature hidden entirely while OFF.
+  const session = await auth()
+  const flagOn = await checkFeatureFlagFromDB(FEATURE_FLAGS.CONSOLIDATED_CMS, session as any)
+  if (!flagOn) return null
+
+  const post = await postRepository.getPost(id)
+  if (!post) return null
+
+  // Only published/ready posts are publicly viewable — never leak a draft.
+  if (post.status !== 'ready') return null
+
+  // Redact for the resolved viewer at the hard public-web tier. Returns null when
+  // the viewer cannot reach the post's visibility at all.
+  const viewer = await resolveViewer()
+  return redactPost(post, viewer, { channel: 'public-web' })
+}

--- a/packages/ui/src/branding/index.ts
+++ b/packages/ui/src/branding/index.ts
@@ -8,6 +8,7 @@ export * from './brand-typography'
 export * from './component-showcase'
 export * from './components-showcase'
 export * from './post-editor-showcase'
+export * from './post-view-showcase'
 export * from './navigation-testing'
 // feature-playground removed — replaced by packages/ui/src/admin/feature-flag-manager.tsx
 export * from '../navigation/navigation-showcase'

--- a/packages/ui/src/branding/post-editor-showcase.tsx
+++ b/packages/ui/src/branding/post-editor-showcase.tsx
@@ -3,7 +3,20 @@
 import { useState } from 'react'
 import { YStack, XStack, H2, Paragraph, Separator, Button, Text } from '@my/ui'
 import { PostEditor, createEmptyPost } from '../post-editor'
+import { PostView } from '../post-view'
+import { redactPost } from '@my/app/utils/redact-post'
+import type { Viewer } from '@my/app/utils/viewer-pii'
 import type { Post } from '@my/app/types/post'
+
+// Author-tier viewer: the editing author sees their own full content while
+// previewing (member tier reveals all PII), so the preview mirrors what a
+// member reader would see rather than the redacted public view.
+const AUTHOR_VIEWER: Viewer = {
+  assurance: 'authenticated',
+  role: 'member',
+  tenant: 'demo-ecclesia',
+  email: 'showcase@tee-admin.com',
+}
 
 /**
  * /brand showcase for the PostEditor (Consolidated CMS Phase 2a).
@@ -18,6 +31,13 @@ export function PostEditorShowcase() {
   const [post, setPost] = useState<Post>(() =>
     createEmptyPost('demo-ecclesia', 'showcase@tee-admin.com')
   )
+  const [showPreview, setShowPreview] = useState(false)
+
+  // Preview the current draft through the SAME redaction boundary the public
+  // page uses, at author (member) tier so the author sees their full content.
+  const previewPost = showPreview
+    ? redactPost(post, AUTHOR_VIEWER, { channel: 'public-web' })
+    : null
 
   return (
     <YStack padding="$4" gap="$4" maxWidth={860} width="100%" alignSelf="center">
@@ -28,7 +48,7 @@ export function PostEditorShowcase() {
           exact same component that edits a loaded post. Controlled via value/onChange
           only; nothing is persisted here.
         </Paragraph>
-        <XStack>
+        <XStack gap="$2">
           <Button
             size="$3"
             variant="outlined"
@@ -36,8 +56,37 @@ export function PostEditorShowcase() {
           >
             Reset draft
           </Button>
+          <Button
+            size="$3"
+            theme={showPreview ? 'blue' : undefined}
+            onPress={() => setShowPreview((prev) => !prev)}
+          >
+            {showPreview ? 'Hide preview' : 'Preview'}
+          </Button>
         </XStack>
       </YStack>
+
+      {showPreview ? (
+        <YStack gap="$2">
+          <Text fontSize="$3" fontWeight="600" color="$color10">
+            Live preview (read-only, redacted at member tier)
+          </Text>
+          <YStack
+            backgroundColor="$color1"
+            borderColor="$borderColor"
+            borderWidth={1}
+            borderRadius="$3"
+            padding="$4"
+          >
+            {previewPost ? (
+              <PostView post={previewPost} />
+            ) : (
+              <Text color="$color10">Nothing to preview yet.</Text>
+            )}
+          </YStack>
+          <Separator />
+        </YStack>
+      ) : null}
 
       <PostEditor
         value={post}

--- a/packages/ui/src/branding/post-view-showcase.tsx
+++ b/packages/ui/src/branding/post-view-showcase.tsx
@@ -1,0 +1,205 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { YStack, XStack, H2, Paragraph, Separator, Button, Text } from '@my/ui'
+import { PostView } from '../post-view'
+import { redactPost } from '@my/app/utils/redact-post'
+import { ANONYMOUS_VIEWER, type Viewer } from '@my/app/utils/viewer-pii'
+import type { Post } from '@my/app/types/post'
+
+/**
+ * /brand showcase for {@link PostView} (Consolidated CMS Phase 3).
+ *
+ * The primary dev surface for the read-only renderer, mirroring the
+ * PostEditorShowcase. Mounts a rich in-memory sample Post exercising ALL SEVEN
+ * block kinds, then renders it through the SAME redaction boundary the real
+ * public page uses (`redactPost(sample, viewer, {channel:'public-web'})`) so the
+ * showcase proves the display is a pure function of a redacted post. A tier
+ * toggle flips the viewer between anonymous and verified-member so you can see
+ * PII (surnames, precise address, bios, contacts) appear/disappear WITHOUT
+ * PostView knowing anything about privacy — the redactor does all the work.
+ */
+
+const MEMBER_VIEWER: Viewer = {
+  assurance: 'authenticated',
+  role: 'member',
+  tenant: 'demo-ecclesia',
+  email: 'member@demo.test',
+}
+
+function makeSamplePost(): Post {
+  const now = new Date().toISOString()
+  return {
+    id: 'sample-post',
+    tenant: 'demo-ecclesia',
+    authorId: 'showcase@tee-admin.com',
+    title: 'Baptism & Fraternal Weekend',
+    occasion: ['baptism', 'study-weekend'],
+    summary: 'Join us to witness a baptism and for a weekend of study and fellowship.',
+    visibility: 'public',
+    sharingScope: 'own',
+    lifecycle: {
+      publishDate: '2026-08-01',
+      startsAt: '2026-09-12T14:00:00.000Z',
+    },
+    status: 'ready',
+    createdAt: now,
+    updatedAt: now,
+    blocks: [
+      {
+        id: 'b-text',
+        kind: 'text',
+        containsPii: false,
+        body:
+          '# You are warmly invited\n\nWe rejoice to announce a **baptism** followed by a study weekend.\n\n- Talks across the weekend\n- Shared meals\n- Visit https://www.example.org for the full programme',
+      },
+      {
+        id: 'b-person',
+        kind: 'person',
+        role: 'candidate',
+        people: [
+          {
+            id: 'p1',
+            firstName: 'Sarah',
+            lastName: 'Thompson',
+            title: 'Sister',
+            ecclesia: 'Toronto East',
+            bio: 'Sarah has been attending for two years and gives her testimony of coming to the Truth.',
+          },
+        ],
+      },
+      {
+        id: 'b-person2',
+        kind: 'person',
+        role: 'speaker',
+        people: [
+          {
+            id: 'p2',
+            firstName: 'John',
+            lastName: 'Carter',
+            title: 'Brother',
+            ecclesia: 'Hamilton',
+            label: 'weekend speaker',
+            contact: 'john.carter@example.org',
+          },
+        ],
+      },
+      {
+        id: 'b-location',
+        kind: 'location',
+        mode: 'geo',
+        label: 'Service & Weekend',
+        venueName: 'Toronto East Hall',
+        address: '960 Pape Avenue',
+        city: 'Toronto',
+        province: 'ON',
+        postalCode: 'M4K 3V1',
+        country: 'Canada',
+        lat: 43.68,
+        lng: -79.35,
+        directions: 'Enter from the north parking lot.',
+        parkingInfo: 'Free parking on site and on adjacent streets.',
+        onlineMeeting: {
+          link: 'https://zoom.us/j/123456789',
+          platform: 'zoom',
+          meetingId: '123 456 789',
+          password: 'ecclesia',
+          dialInNumber: '+1 647 555 0100',
+        },
+      },
+      {
+        id: 'b-time',
+        kind: 'time',
+        label: 'Baptism service',
+        startsAt: '2026-09-12T14:00:00.000Z',
+        endsAt: '2026-09-12T16:00:00.000Z',
+        timezone: 'America/Toronto',
+      },
+      {
+        id: 'b-flyer',
+        kind: 'flyer',
+        document: {
+          id: 'doc1',
+          documentType: 'upload',
+          fileName: 'weekend.png',
+          originalName: 'Weekend Programme',
+          fileUrl: 'https://placehold.co/600x800/png?text=Weekend+Programme',
+          fileSize: 12345,
+          mimeType: 'image/png',
+          uploadedAt: new Date(),
+          uploadedBy: 'showcase@tee-admin.com',
+          description: 'The full weekend programme and talk schedule.',
+        },
+      },
+      {
+        id: 'b-registration',
+        kind: 'registration',
+        required: true,
+        deadline: '2026-09-05',
+        registrationUrl: 'https://www.example.org/register',
+        contactEmail: 'welcome@example.org',
+        contactPhone: '+1 647 555 0199',
+        hasFee: true,
+        fee: 25,
+        paymentInstructions: 'Payment collected at the door or via e-transfer.',
+        notes: 'Lunch provided for those who register.',
+      },
+      {
+        id: 'b-link',
+        kind: 'link',
+        url: 'https://www.example.org/weekend',
+        label: 'Full weekend details',
+      },
+    ],
+  }
+}
+
+export function PostViewShowcase() {
+  const sample = useMemo(makeSamplePost, [])
+  const [asMember, setAsMember] = useState(false)
+
+  const viewer = asMember ? MEMBER_VIEWER : ANONYMOUS_VIEWER
+  const redacted = redactPost(sample, viewer, { channel: 'public-web' })
+
+  return (
+    <YStack padding="$4" gap="$4" maxWidth={860} width="100%" alignSelf="center">
+      <YStack gap="$2">
+        <H2>Post View</H2>
+        <Paragraph color="$color10">
+          The read-only display twin of the editor. This mounts a rich in-memory
+          sample post (all seven block kinds) rendered through the SAME
+          `redactPost(...)` boundary the public page uses. Toggle the viewer tier to
+          watch surnames, precise address, bios and contacts appear/disappear —
+          PostView itself does no gating.
+        </Paragraph>
+        <XStack gap="$2" alignItems="center">
+          <Button
+            size="$3"
+            theme={asMember ? undefined : 'blue'}
+            onPress={() => setAsMember(false)}
+          >
+            Anonymous (public)
+          </Button>
+          <Button
+            size="$3"
+            theme={asMember ? 'blue' : undefined}
+            onPress={() => setAsMember(true)}
+          >
+            Verified member
+          </Button>
+          <Text fontSize="$2" color="$color10">
+            Channel: public-web
+          </Text>
+        </XStack>
+      </YStack>
+
+      <Separator />
+
+      {redacted ? (
+        <PostView post={redacted} />
+      ) : (
+        <Text color="$color10">This viewer cannot reach the sample post.</Text>
+      )}
+    </YStack>
+  )
+}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -45,3 +45,6 @@ export * from './roster'
 
 // Unified Post editor (Consolidated CMS epic #131, Phase 2a)
 export * from './post-editor'
+
+// Unified Post view — read-only display twin of the editor (epic #131, Phase 3)
+export * from './post-view'

--- a/packages/ui/src/post-view/index.ts
+++ b/packages/ui/src/post-view/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Post view — the read-only display twin of the post editor (Consolidated CMS
+ * epic #131, Phase 3). Renders an ALREADY-REDACTED {@link Post} read-only.
+ */
+export { PostView, type PostViewProps } from './post-view'
+
+// Pure display-string helpers (platform-free, unit-testable in isolation —
+// PostView itself pulls in Tamagui + Lucide which the plain-Node test env
+// can't load).
+export {
+  personRoleLabel,
+  formatPersonName,
+  personMetaLine,
+  locationAddressLines,
+  locationMapsHref,
+  formatTimeBlock,
+  formatDateFacet,
+  looksLikeImage,
+  formatOccasions,
+  type FormattedTime,
+} from './post-view-format'

--- a/packages/ui/src/post-view/post-view-format.ts
+++ b/packages/ui/src/post-view/post-view-format.ts
@@ -1,0 +1,180 @@
+/**
+ * Pure formatting helpers for {@link PostView} (Consolidated CMS epic #131,
+ * Phase 3 — the read-only display twin of the editor).
+ *
+ * Kept in a SEPARATE, platform-free module (no `tamagui`, no
+ * `@tamagui/lucide-icons`) so the display logic is unit-testable in the
+ * project's plain-Node Vitest environment — importing the full `PostView`
+ * (which pulls in Tamagui + Lucide) hangs there, the same test-infra wall the
+ * Phase 2b block tests document. PostView renders; THIS decides what strings it
+ * renders.
+ *
+ * Cross-platform: pure functions + the pure `timezone` utils only.
+ */
+
+import type {
+  BlockPerson,
+  LocationBlock,
+  PersonBlock,
+  Post,
+  TimeBlock,
+} from '@my/app/types/post'
+import { formatScheduleDateTime, DEFAULT_TIMEZONE } from '@my/app/utils/timezone'
+
+/** Human-readable label for a PersonBlock role (design vocabulary → display). */
+const ROLE_LABELS: Record<PersonBlock['role'], string> = {
+  speaker: 'Speaker',
+  candidate: 'Candidate',
+  deceased: 'In memory of',
+  bride: 'Bride',
+  groom: 'Groom',
+  sponsor: 'Sponsor',
+  contact: 'Contact',
+  other: 'People',
+}
+
+export function personRoleLabel(role: PersonBlock['role']): string {
+  return ROLE_LABELS[role] ?? 'People'
+}
+
+/**
+ * The display name for an already-REDACTED person. `firstName` is the floor
+ * (always present); `lastName` is present only when the redactor revealed it.
+ * An optional honorific `title` (Brother/Sister/…) prefixes the name.
+ */
+export function formatPersonName(person: BlockPerson): string {
+  const name = [person.firstName, person.lastName].filter(Boolean).join(' ')
+  return person.title ? `${person.title} ${name}`.trim() : name
+}
+
+/**
+ * A secondary "meta" line for a person — sub-role label, ecclesia, age — joined
+ * with middots. Empty string when there's nothing to show. `contact`/`bio` are
+ * rendered separately (they may be long / need their own affordance).
+ */
+export function personMetaLine(person: BlockPerson): string {
+  const parts: string[] = []
+  if (person.label) parts.push(person.label)
+  if (person.ecclesia) parts.push(person.ecclesia)
+  if (typeof person.age === 'number') parts.push(`age ${person.age}`)
+  return parts.join(' · ')
+}
+
+/**
+ * Address lines for a location block, in reading order. Only the fields present
+ * on the (already-redacted) block are included — for an anon viewer the
+ * redactor has already stripped `address`/`postalCode`, so this naturally
+ * collapses to the venue + city floor.
+ */
+export function locationAddressLines(block: LocationBlock): string[] {
+  const lines: string[] = []
+  if (block.venueName) lines.push(block.venueName)
+  if (block.address) lines.push(block.address)
+  const cityLine = [block.city, block.province, block.postalCode]
+    .filter(Boolean)
+    .join(', ')
+  if (cityLine) lines.push(cityLine)
+  if (block.country) lines.push(block.country)
+  return lines
+}
+
+/**
+ * A "get directions" href for a location. Prefers an explicit `mapsUrl`; else,
+ * when there's enough address to search, builds a Google Maps search URL from
+ * the safe address parts. Returns undefined when there's nothing to link.
+ */
+export function locationMapsHref(block: LocationBlock): string | undefined {
+  if (block.mapsUrl) return block.mapsUrl
+  const query = [
+    block.venueName,
+    block.address,
+    block.city,
+    block.province,
+    block.postalCode,
+    block.country,
+  ]
+    .filter(Boolean)
+    .join(', ')
+  if (!query) return undefined
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`
+}
+
+export interface FormattedTime {
+  /** Optional author label (e.g. 'Service', 'Reception'). */
+  label?: string
+  /** e.g. 'Sunday, February 1, 2026' — empty when no date is known. */
+  dateLine: string
+  /** e.g. '7:00pm (Toronto time)' — empty for date-only or free-text. */
+  timeLine: string
+}
+
+/**
+ * Format a TimeBlock for display. Uses the shared `formatScheduleDateTime` (the
+ * codebase's one date/time formatter) when there's an ISO `startsAt`, falling
+ * back to the free-text `display` field. End time, when present, is appended.
+ */
+export function formatTimeBlock(block: TimeBlock): FormattedTime {
+  const timezone = block.timezone || DEFAULT_TIMEZONE
+
+  if (block.startsAt) {
+    const start = formatScheduleDateTime({
+      dateTime: block.startsAt,
+      eventTimezone: timezone,
+      userTimezone: timezone,
+    })
+    let timeLine = start.timeDisplay
+    if (block.endsAt) {
+      const end = formatScheduleDateTime({
+        dateTime: block.endsAt,
+        eventTimezone: timezone,
+        userTimezone: timezone,
+      })
+      if (end.timeDisplay) timeLine = `${timeLine} – ${end.timeDisplay}`
+    }
+    return { label: block.label || undefined, dateLine: start.dateDisplay, timeLine }
+  }
+
+  // No ISO instant — fall back to free-text time.
+  return {
+    label: block.label || undefined,
+    dateLine: '',
+    timeLine: block.display ?? '',
+  }
+}
+
+/**
+ * The header "date facet" — the single most salient date for the post. A future
+ * `lifecycle.startsAt` makes a post event-shaped (show the event date); else the
+ * publish date is the news-shaped facet. Returns undefined when neither exists.
+ */
+export function formatDateFacet(post: Post): string | undefined {
+  const iso = post.lifecycle.startsAt
+  if (iso) {
+    return formatScheduleDateTime({
+      dateTime: iso,
+      eventTimezone: DEFAULT_TIMEZONE,
+      userTimezone: DEFAULT_TIMEZONE,
+    }).fullDisplay
+  }
+  const publish = post.lifecycle.publishDate
+  if (publish) {
+    return formatScheduleDateTime({ date: publish }).dateDisplay
+  }
+  return undefined
+}
+
+const IMAGE_EXTENSION = /\.(jpe?g|png|gif|webp|svg|avif)$/i
+
+/** True when a flyer document should render as an inline image (vs a file link). */
+export function looksLikeImage(url: string, mimeType?: string): boolean {
+  if (mimeType && mimeType.startsWith('image/')) return true
+  return IMAGE_EXTENSION.test(url)
+}
+
+/** Occasion tags rendered as a title-cased, middot-joined string for the header. */
+export function formatOccasions(occasion: Post['occasion']): string {
+  return occasion
+    .map((tag) => tag.replace(/-/g, ' '))
+    .map((tag) => tag.charAt(0).toUpperCase() + tag.slice(1))
+    .join(' · ')
+}

--- a/packages/ui/src/post-view/post-view.tsx
+++ b/packages/ui/src/post-view/post-view.tsx
@@ -1,0 +1,404 @@
+'use client'
+
+import {
+  YStack,
+  XStack,
+  Card,
+  Text,
+  H2,
+  Separator,
+  Image,
+  Paragraph,
+} from 'tamagui'
+import {
+  Calendar,
+  Clock,
+  MapPin,
+  Users,
+  FileImage,
+  ClipboardCheck,
+  Video,
+} from '@tamagui/lucide-icons'
+import type {
+  Block,
+  FlyerBlock,
+  LinkBlock,
+  LocationBlock,
+  PersonBlock,
+  Post,
+  RegistrationBlock,
+  TextBlock,
+  TimeBlock,
+} from '@my/app/types/post'
+import { getPlatformDisplayName } from '@my/app/types/events'
+import { MarkdownLiteText } from '../markdown-lite-text'
+import { ExtLink } from '../ext-link'
+import {
+  formatDateFacet,
+  formatOccasions,
+  formatPersonName,
+  formatTimeBlock,
+  locationAddressLines,
+  locationMapsHref,
+  looksLikeImage,
+  personMetaLine,
+  personRoleLabel,
+} from './post-view-format'
+
+/**
+ * PostView — the READ-ONLY display twin of {@link PostEditor} (Consolidated CMS
+ * epic #131, Phase 3). Given an ALREADY-REDACTED {@link Post} it renders the
+ * header (title, occasion, date facet) and each block read-only, one renderer
+ * per block kind — mirroring the editor's 7-kind coverage so the two stay in
+ * lock-step.
+ *
+ * CONTRACT: `post` MUST be the output of `redactPost(post, viewer, {channel})`.
+ * PostView does NO gating and NO PII scrubbing — a surname / precise address /
+ * bio is present here ONLY because the redactor chose to reveal it. This keeps
+ * the display dumb and the single redaction boundary authoritative (no
+ * ship-then-hide leak: what isn't in the object can't render).
+ *
+ * Cross-platform: only Tamagui + Lucide + the shared `MarkdownLiteText` /
+ * `ExtLink` primitives; no `next-*` imports; ternary JSX only (RN-safe).
+ */
+export interface PostViewProps {
+  post: Post
+}
+
+// ---- Per-kind block renderers -----------------------------------------------
+
+function BlockHeader({
+  icon: Icon,
+  label,
+}: {
+  icon: React.FC<{ size?: number | string; color?: string }>
+  label: string
+}) {
+  return (
+    <XStack alignItems="center" gap="$2">
+      <Icon size={16} color="$color10" />
+      <Text fontSize="$3" fontWeight="600" color="$color10">
+        {label}
+      </Text>
+    </XStack>
+  )
+}
+
+function TextBlockView({ block }: { block: TextBlock }) {
+  if (!block.body.trim()) return null
+  return <MarkdownLiteText text={block.body} fontSize="$4" color="$color12" />
+}
+
+function PersonBlockView({ block }: { block: PersonBlock }) {
+  if (block.people.length === 0) return null
+  return (
+    <YStack gap="$2">
+      <BlockHeader icon={Users} label={personRoleLabel(block.role)} />
+      <YStack gap="$3">
+        {block.people.map((person) => {
+          const meta = personMetaLine(person)
+          return (
+            <YStack key={person.id} gap="$1">
+              <Text fontSize="$4" fontWeight="600" color="$color12">
+                {formatPersonName(person)}
+              </Text>
+              {meta ? (
+                <Text fontSize="$2" color="$color10">
+                  {meta}
+                </Text>
+              ) : null}
+              {person.contact ? (
+                <Text fontSize="$3" color="$color11">
+                  {person.contact}
+                </Text>
+              ) : null}
+              {person.bio ? (
+                <Paragraph fontSize="$3" color="$color11" whiteSpace="pre-wrap">
+                  {person.bio}
+                </Paragraph>
+              ) : null}
+            </YStack>
+          )
+        })}
+      </YStack>
+    </YStack>
+  )
+}
+
+function LocationBlockView({ block }: { block: LocationBlock }) {
+  const lines = locationAddressLines(block)
+  const mapsHref = locationMapsHref(block)
+  const online = block.onlineMeeting
+
+  // An 'ecclesia'-mode block with no captured fields is a read-time inherit
+  // placeholder — nothing to show until inheritance is resolved.
+  if (lines.length === 0 && !online && block.mode === 'ecclesia') {
+    return null
+  }
+
+  return (
+    <YStack gap="$2">
+      <BlockHeader icon={MapPin} label={block.label || 'Location'} />
+      {lines.length > 0 ? (
+        <YStack gap="$0.5">
+          {lines.map((line, i) => (
+            <Text
+              key={i}
+              fontSize={i === 0 ? '$4' : '$3'}
+              fontWeight={i === 0 ? '600' : '400'}
+              color={i === 0 ? '$color12' : '$color11'}
+            >
+              {line}
+            </Text>
+          ))}
+        </YStack>
+      ) : null}
+      {mapsHref ? (
+        <ExtLink href={mapsHref}>Get directions</ExtLink>
+      ) : null}
+      {block.directions ? (
+        <Text fontSize="$3" color="$color11">
+          {block.directions}
+        </Text>
+      ) : null}
+      {block.parkingInfo ? (
+        <Text fontSize="$3" color="$color11">
+          Parking: {block.parkingInfo}
+        </Text>
+      ) : null}
+
+      {online ? (
+        <YStack
+          gap="$1"
+          marginTop="$2"
+          padding="$2"
+          borderRadius="$3"
+          backgroundColor="$backgroundHover"
+        >
+          <XStack alignItems="center" gap="$2">
+            <Video size={16} color="$color10" />
+            <Text fontSize="$3" fontWeight="600" color="$color11">
+              {online.platform ? getPlatformDisplayName(online.platform) : 'Online meeting'}
+            </Text>
+          </XStack>
+          {online.link ? <ExtLink href={online.link}>Join online</ExtLink> : null}
+          {online.meetingId ? (
+            <Text fontSize="$3" color="$color11">
+              Meeting ID: {online.meetingId}
+            </Text>
+          ) : null}
+          {online.password ? (
+            <Text fontSize="$3" color="$color11">
+              Password: {online.password}
+            </Text>
+          ) : null}
+          {online.dialInNumber ? (
+            <Text fontSize="$3" color="$color11">
+              Dial-in: {online.dialInNumber}
+            </Text>
+          ) : null}
+          {online.additionalInfo ? (
+            <Text fontSize="$3" color="$color11">
+              {online.additionalInfo}
+            </Text>
+          ) : null}
+        </YStack>
+      ) : null}
+    </YStack>
+  )
+}
+
+function TimeBlockView({ block }: { block: TimeBlock }) {
+  const { label, dateLine, timeLine } = formatTimeBlock(block)
+  if (!dateLine && !timeLine && !label) return null
+  return (
+    <YStack gap="$1">
+      <BlockHeader icon={Clock} label={label || 'Date & time'} />
+      {dateLine ? (
+        <Text fontSize="$4" fontWeight="600" color="$color12">
+          {dateLine}
+        </Text>
+      ) : null}
+      {timeLine ? (
+        <Text fontSize="$3" color="$color11">
+          {timeLine}
+        </Text>
+      ) : null}
+    </YStack>
+  )
+}
+
+function FlyerBlockView({ block }: { block: FlyerBlock }) {
+  const { document } = block
+  const url = document.fileUrl?.trim()
+  if (!url) return null
+
+  const title = document.originalName || 'Attachment'
+  const isImage = looksLikeImage(url, document.mimeType)
+
+  return (
+    <YStack gap="$2">
+      <BlockHeader icon={FileImage} label="Flyer" />
+      {isImage ? (
+        <Image
+          source={{ uri: url }}
+          width="100%"
+          height={320}
+          maxWidth={480}
+          objectFit="contain"
+          borderRadius="$3"
+          borderWidth={1}
+          borderColor="$borderColor"
+        />
+      ) : document.thumbnailUrl ? (
+        <Image
+          source={{ uri: document.thumbnailUrl }}
+          width="100%"
+          height={320}
+          maxWidth={480}
+          objectFit="contain"
+          borderRadius="$3"
+          borderWidth={1}
+          borderColor="$borderColor"
+        />
+      ) : null}
+      {document.description ? (
+        <Text fontSize="$3" color="$color11">
+          {document.description}
+        </Text>
+      ) : null}
+      <ExtLink href={url}>{isImage ? `View ${title}` : `Open ${title}`}</ExtLink>
+    </YStack>
+  )
+}
+
+function RegistrationBlockView({ block }: { block: RegistrationBlock }) {
+  const hasAnything =
+    block.required ||
+    block.deadline ||
+    block.registrationUrl ||
+    block.contactEmail ||
+    block.contactPhone ||
+    block.hasFee ||
+    block.notes
+  if (!hasAnything) return null
+
+  return (
+    <YStack gap="$1">
+      <BlockHeader icon={ClipboardCheck} label="Registration" />
+      {block.required ? (
+        <Text fontSize="$3" fontWeight="600" color="$color12">
+          Registration required
+        </Text>
+      ) : null}
+      {block.deadline ? (
+        <Text fontSize="$3" color="$color11">
+          Deadline: {block.deadline}
+        </Text>
+      ) : null}
+      {block.hasFee ? (
+        <Text fontSize="$3" color="$color11">
+          Fee: {typeof block.fee === 'number' ? `$${block.fee}` : 'see details'}
+        </Text>
+      ) : null}
+      {block.paymentInstructions ? (
+        <Text fontSize="$3" color="$color11">
+          {block.paymentInstructions}
+        </Text>
+      ) : null}
+      {block.contactEmail ? (
+        <ExtLink href={`mailto:${block.contactEmail}`}>{block.contactEmail}</ExtLink>
+      ) : null}
+      {block.contactPhone ? (
+        <Text fontSize="$3" color="$color11">
+          {block.contactPhone}
+        </Text>
+      ) : null}
+      {block.notes ? (
+        <Text fontSize="$3" color="$color11">
+          {block.notes}
+        </Text>
+      ) : null}
+      {block.registrationUrl ? (
+        <ExtLink href={block.registrationUrl}>Register</ExtLink>
+      ) : null}
+    </YStack>
+  )
+}
+
+function LinkBlockView({ block }: { block: LinkBlock }) {
+  const url = block.url?.trim()
+  if (!url) return null
+  return <ExtLink href={url}>{block.label || url}</ExtLink>
+}
+
+/** Render a single block by kind — mirrors the editor's 7-kind coverage. */
+function BlockView({ block }: { block: Block }) {
+  switch (block.kind) {
+    case 'text':
+      return <TextBlockView block={block} />
+    case 'person':
+      return <PersonBlockView block={block} />
+    case 'location':
+      return <LocationBlockView block={block} />
+    case 'time':
+      return <TimeBlockView block={block} />
+    case 'flyer':
+      return <FlyerBlockView block={block} />
+    case 'registration':
+      return <RegistrationBlockView block={block} />
+    case 'link':
+      return <LinkBlockView block={block} />
+    default:
+      return null
+  }
+}
+
+// ---- The post shell ---------------------------------------------------------
+
+export function PostView({ post }: PostViewProps) {
+  const dateFacet = formatDateFacet(post)
+  const occasions = formatOccasions(post.occasion)
+
+  return (
+    <YStack gap="$4" maxWidth={720} width="100%">
+      {/* ---- Header ---- */}
+      <YStack gap="$2">
+        {occasions ? (
+          <Text fontSize="$2" fontWeight="600" color="$color10" textTransform="uppercase">
+            {occasions}
+          </Text>
+        ) : null}
+        <H2 color="$color12">{post.title || 'Untitled'}</H2>
+        {dateFacet ? (
+          <XStack alignItems="center" gap="$2">
+            <Calendar size={16} color="$color10" />
+            <Text fontSize="$3" color="$color11">
+              {dateFacet}
+            </Text>
+          </XStack>
+        ) : null}
+        {post.summary ? (
+          <Paragraph fontSize="$4" color="$color11">
+            {post.summary}
+          </Paragraph>
+        ) : null}
+      </YStack>
+
+      <Separator />
+
+      {/* ---- Blocks ---- */}
+      {post.blocks.length === 0 ? (
+        <Text color="$color10">This post has no content to display.</Text>
+      ) : (
+        <YStack gap="$4">
+          {post.blocks.map((block) => (
+            <Card key={block.id} bordered padding="$4">
+              <BlockView block={block} />
+            </Card>
+          ))}
+        </YStack>
+      )}
+    </YStack>
+  )
+}


### PR DESCRIPTION
Phase 3 of #131 — a created Post is now **viewable** end-to-end. Additive + flag-gated; legacy events/news render paths **untouched** (empty diff over `api/events`, `(public)/events|news`, event/news services).

## What
- **`PostView`** (`packages/ui/src/post-view/post-view.tsx`) — read-only renderer, one per kind mirroring the editor's 7 kinds (Text=markdown, Person=role+shaped name+bio, Location=address+maps+online-meeting, Time=tz-formatted, Flyer=image/pdf+link, Registration=details+register, Link). Pure display-string logic in `post-view-format.ts` (platform-free, unit-tested). Cross-platform.
- **Public surface** — `get-public-post.ts` is the ONE server boundary for both the page `(public)/posts/[id]` and API `/api/posts/[id]`: **flag gate (fail-closed) → post exists → `status==='ready'` (drafts never leak) → `redactPost(..., { channel: 'public-web' })`**. Returns null → 404/notFound. Admin route untouched, not exposed publicly.
- **Showcases** — `/brand/post-view` (all-7-kinds sample, anon↔member toggle); editor showcase gained a live-preview toggle.

## Verify
- **28 new tests** (22 format + 6 route: flag-off 404, draft-hidden, redaction-applied) + **49 existing** post/redact tests pass. Typecheck clean; lint 0 errors; `next build` compiles all pages + Tamagui extraction (pre-existing GOOGLE-key route aside).
- Only `ready` posts public; flag `owner`-only so the surface is live for owners until widened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)