### PR TITLE
CONSOLIDATED_CMS Phase 4a — unified sequence-aware lifecycle engine (#131)

### DIFF
--- a/apps/next/tests/post-lifecycle.test.ts
+++ b/apps/next/tests/post-lifecycle.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from 'vitest'
+import type { Block, Post } from '@my/app/types/post'
+import {
+  DEFAULT_NEWS_WINDOW_WEEKS,
+  getPostDisplayState,
+  isPostActive,
+  resolvePostLastDate,
+  resolvePostNextDate,
+  resolvePostStartsAt,
+} from '@my/app/utils/post-lifecycle'
+
+/**
+ * Unit tests for the unified Post lifecycle / display-rules engine (Phase 4a).
+ *
+ * ALL dates are constructed at NOON UTC so the engine's timezone-aware day
+ * comparison (`isUserDateOnOrBefore`, UTC accessors) and its local-time
+ * weekday check (`getThursdayBefore`/`isSameDay`) both resolve to the intended
+ * calendar day regardless of the machine running the test. `now` is always
+ * injected — no `Date.now()` in any assertion.
+ */
+
+/** ISO-8601 at noon UTC on the given calendar day (month is 1-based). */
+function iso(y: number, m: number, d: number, h = 12): string {
+  return new Date(Date.UTC(y, m - 1, d, h)).toISOString()
+}
+/** A Date at noon UTC — the injected `now`. */
+function at(y: number, m: number, d: number, h = 12): Date {
+  return new Date(Date.UTC(y, m - 1, d, h))
+}
+
+function makePost(overrides: Partial<Post> = {}): Post {
+  return {
+    id: 'p',
+    tenant: 'Toronto East',
+    authorId: 'a',
+    title: 'Test Post',
+    occasion: ['general'],
+    visibility: 'public',
+    sharingScope: 'own',
+    lifecycle: {},
+    blocks: [],
+    createdAt: iso(2026, 7, 1),
+    updatedAt: iso(2026, 7, 1),
+    status: 'ready',
+    ...overrides,
+  }
+}
+
+function timeBlock(id: string, startsAt: string, label?: string, endsAt?: string): Block {
+  return { id, kind: 'time', startsAt, ...(endsAt ? { endsAt } : {}), ...(label ? { label } : {}) }
+}
+
+// ── resolvePostStartsAt ───────────────────────────────────────────────────────
+describe('resolvePostStartsAt', () => {
+  it('prefers lifecycle.startsAt when set', () => {
+    const post = makePost({
+      lifecycle: { startsAt: iso(2026, 9, 1) },
+      blocks: [timeBlock('t', iso(2026, 8, 1))],
+    })
+    expect(resolvePostStartsAt(post)).toBe(iso(2026, 9, 1))
+  })
+
+  it('falls back to the EARLIEST TimeBlock start when lifecycle.startsAt absent', () => {
+    const post = makePost({
+      blocks: [timeBlock('t2', iso(2026, 9, 19)), timeBlock('t1', iso(2026, 8, 14))],
+    })
+    expect(resolvePostStartsAt(post)).toBe(iso(2026, 8, 14))
+  })
+
+  it('is undefined when the post has no date at all (news-shaped)', () => {
+    expect(resolvePostStartsAt(makePost())).toBeUndefined()
+  })
+})
+
+// ── resolvePostNextDate / resolvePostLastDate ─────────────────────────────────
+describe('resolvePostNextDate / resolvePostLastDate (sequence-aware)', () => {
+  const arc = makePost({
+    blocks: [
+      timeBlock('funeral', iso(2026, 8, 14), 'Funeral'),
+      timeBlock('celebration', iso(2026, 9, 19), 'Celebration'),
+    ],
+  })
+
+  it('resolvePostNextDate returns the earliest STILL-UPCOMING happening', () => {
+    // Before both → funeral is next.
+    expect(resolvePostNextDate(arc, at(2026, 8, 1))?.label).toBe('Funeral')
+    // After the funeral, before the celebration → celebration is next (not the
+    // earliest-overall, which is in the past).
+    expect(resolvePostNextDate(arc, at(2026, 8, 20))?.label).toBe('Celebration')
+    // After the last happening → undefined.
+    expect(resolvePostNextDate(arc, at(2026, 10, 1))).toBeUndefined()
+  })
+
+  it('resolvePostLastDate returns the latest happening boundary', () => {
+    expect(resolvePostLastDate(arc)).toBe(iso(2026, 9, 19))
+  })
+
+  it('resolvePostLastDate uses endsAt for a multi-day happening', () => {
+    const md = makePost({ blocks: [timeBlock('t', iso(2026, 8, 15), 'Weekend', iso(2026, 8, 17))] })
+    expect(resolvePostLastDate(md)).toBe(iso(2026, 8, 17))
+  })
+})
+
+// ── THE shower scenario ───────────────────────────────────────────────────────
+describe('getPostDisplayState — the Wedding Shower (event-shaped stays up)', () => {
+  // Published 2026-07-01; the shower is 2026-08-15 (a Saturday), ~6.5 weeks out.
+  const shower = makePost({
+    id: 'shower',
+    title: 'Wedding Shower',
+    occasion: ['shower'],
+    lifecycle: { publishDate: iso(2026, 7, 1) },
+    blocks: [timeBlock('t', iso(2026, 8, 15), 'Shower')],
+  })
+
+  it('is active early (soon after publish)', () => {
+    const s = getPostDisplayState(shower, at(2026, 7, 5))
+    expect(s.active).toBe(true)
+    expect(s.isReminder).toBe(false)
+    expect(s.reason).toMatch(/Event-shaped/)
+  })
+
+  it('STAYS active mid-gap — unlike a news item, which would already be expired', () => {
+    // The shower is still active 3 weeks after publish because of its future date.
+    expect(isPostActive(shower, at(2026, 7, 20))).toBe(true)
+
+    // Same post WITHOUT the future TimeBlock is news-shaped and has expired by now
+    // (publish + default 2-week window). This is the exact bug 4a fixes.
+    const asNews = makePost({
+      ...shower,
+      blocks: [],
+    })
+    expect(isPostActive(asNews, at(2026, 7, 20))).toBe(false)
+  })
+
+  it('flags the eve-of reminder on the Thursday immediately before the shower', () => {
+    // 2026-08-15 is a Saturday → Thursday-before is 2026-08-13.
+    const s = getPostDisplayState(shower, at(2026, 8, 13))
+    expect(s.active).toBe(true)
+    expect(s.isReminder).toBe(true)
+    expect(s.reason).toMatch(/final reminder/i)
+    expect(s.reason).toContain('Shower')
+  })
+
+  it('is still active on the event day, no longer a reminder', () => {
+    const s = getPostDisplayState(shower, at(2026, 8, 15))
+    expect(s.active).toBe(true)
+    expect(s.isReminder).toBe(false)
+  })
+
+  it('is inactive well after the event (retrospective window elapsed)', () => {
+    // Retrospective anchors at the last happening (08-15) + 2 weeks = 08-29.
+    expect(isPostActive(shower, at(2026, 9, 10))).toBe(false)
+  })
+})
+
+// ── news-shaped post ──────────────────────────────────────────────────────────
+describe('getPostDisplayState — news-shaped (retrospective window)', () => {
+  it('honours an explicit expiresAt (subsumes isNewsActive)', () => {
+    const news = makePost({
+      lifecycle: { publishDate: iso(2026, 7, 1), expiresAt: iso(2026, 7, 15) },
+    })
+    expect(isPostActive(news, at(2026, 7, 5))).toBe(true)
+    expect(isPostActive(news, at(2026, 7, 14))).toBe(true)
+    expect(isPostActive(news, at(2026, 7, 20))).toBe(false)
+  })
+
+  it('falls back to a default window from publish when expiresAt is absent', () => {
+    const news = makePost({ lifecycle: { publishDate: iso(2026, 7, 1) } })
+    // publish + DEFAULT_NEWS_WINDOW_WEEKS (2) = 2026-07-15.
+    expect(DEFAULT_NEWS_WINDOW_WEEKS).toBe(2)
+    expect(isPostActive(news, at(2026, 7, 10))).toBe(true)
+    expect(isPostActive(news, at(2026, 7, 20))).toBe(false)
+    const s = getPostDisplayState(news, at(2026, 7, 20))
+    expect(s.reason).toMatch(/News-shaped/)
+  })
+
+  it('respects a custom defaultNewsWindowWeeks', () => {
+    const news = makePost({ lifecycle: { publishDate: iso(2026, 7, 1) } })
+    const s = getPostDisplayState(news, at(2026, 7, 20), { defaultNewsWindowWeeks: 4 })
+    // publish + 4 weeks = 2026-07-29 → still active on 07-20.
+    expect(s.active).toBe(true)
+  })
+})
+
+// ── not yet published ─────────────────────────────────────────────────────────
+describe('getPostDisplayState — not yet published', () => {
+  it('is inactive while publishDate is in the future, even with a future event', () => {
+    const post = makePost({
+      lifecycle: { publishDate: iso(2026, 8, 1) },
+      blocks: [timeBlock('t', iso(2026, 9, 1), 'Event')],
+    })
+    const s = getPostDisplayState(post, at(2026, 7, 5))
+    expect(s.active).toBe(false)
+    expect(s.isReminder).toBe(false)
+    expect(s.reason).toMatch(/Not yet published/)
+  })
+})
+
+// ── exact Thursday-before boundary ────────────────────────────────────────────
+describe('getPostDisplayState — exact Thursday-before boundary', () => {
+  // Event 2026-08-15 (Saturday) → Thursday-before is 2026-08-13.
+  const post = makePost({
+    lifecycle: { publishDate: iso(2026, 7, 1) },
+    blocks: [timeBlock('t', iso(2026, 8, 15), 'Service')],
+  })
+
+  it('Wednesday before: active, NOT a reminder', () => {
+    const s = getPostDisplayState(post, at(2026, 8, 12))
+    expect(s.active).toBe(true)
+    expect(s.isReminder).toBe(false)
+  })
+  it('Thursday before: reminder fires', () => {
+    expect(getPostDisplayState(post, at(2026, 8, 13)).isReminder).toBe(true)
+  })
+  it('Friday before: active, reminder no longer fires', () => {
+    const s = getPostDisplayState(post, at(2026, 8, 14))
+    expect(s.active).toBe(true)
+    expect(s.isReminder).toBe(false)
+  })
+})
+
+// ── the death arc (sequence of happenings) ────────────────────────────────────
+describe('getPostDisplayState — death arc (funeral → celebration of life)', () => {
+  // Death announced 2026-07-01. Funeral 2026-08-14 (Fri). Celebration 2026-09-19
+  // (Sat) — five weeks later, a separate event.
+  const arc = makePost({
+    id: 'death-arc',
+    title: 'Passing of Brother X',
+    occasion: ['funeral'],
+    lifecycle: { publishDate: iso(2026, 7, 1) },
+    blocks: [
+      timeBlock('funeral', iso(2026, 8, 14), 'Funeral Service'),
+      timeBlock('celebration', iso(2026, 9, 19), 'Celebration of Life'),
+    ],
+  })
+
+  it('reminder before the FUNERAL (Thu 2026-08-13), naming that happening', () => {
+    const s = getPostDisplayState(arc, at(2026, 8, 13))
+    expect(s.active).toBe(true)
+    expect(s.isReminder).toBe(true)
+    expect(s.reason).toContain('Funeral Service')
+  })
+
+  it('stays active in the gap between the funeral and the celebration', () => {
+    const s = getPostDisplayState(arc, at(2026, 8, 20))
+    expect(s.active).toBe(true)
+    expect(s.isReminder).toBe(false)
+  })
+
+  it('is active INTO the second window, before the celebration', () => {
+    expect(isPostActive(arc, at(2026, 9, 10))).toBe(true)
+  })
+
+  it('reminder before the CELEBRATION (Thu 2026-09-17), naming that happening', () => {
+    const s = getPostDisplayState(arc, at(2026, 9, 17))
+    expect(s.active).toBe(true)
+    expect(s.isReminder).toBe(true)
+    expect(s.reason).toContain('Celebration of Life')
+  })
+
+  it('is retrospective/inactive only AFTER the last happening passes', () => {
+    // Still active on the celebration day.
+    expect(isPostActive(arc, at(2026, 9, 19))).toBe(true)
+    // After the last happening + retrospective window (09-19 + 2wk = 10-03) → inactive.
+    const s = getPostDisplayState(arc, at(2026, 10, 10))
+    expect(s.active).toBe(false)
+    expect(s.reason).toMatch(/News-shaped/)
+  })
+})

--- a/apps/next/tests/services/post-service.test.ts
+++ b/apps/next/tests/services/post-service.test.ts
@@ -15,7 +15,7 @@ vi.mock('@my/app/services/news-service', () => ({
   listNewsItems: vi.fn(),
 }))
 
-import { getPostsForViewer } from '@my/app/services/post-service'
+import { getPostsForViewer, getPostsForViewerWithState } from '@my/app/services/post-service'
 import { postRepository } from '@my/app/provider/dynamodb/repositories/post-repository'
 import { getPublishedEvents } from '@my/app/services/event-service'
 import { listNewsItems } from '@my/app/services/news-service'
@@ -28,6 +28,13 @@ const member: Viewer = {
   tenant: 'Toronto East',
   email: 'm@x.z',
 }
+
+// Deterministic reference time for the Phase 4a lifecycle filter. All fixtures
+// below are published 2026-07-01 (native + baptism have no future date → news-
+// shaped, active for their retrospective window; the medical news expires
+// 2026-12-01), so at this instant every fixture is active and the merge/redaction
+// assertions are unaffected by the lifecycle gate.
+const NOW = new Date('2026-07-05T00:00:00.000Z')
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -102,7 +109,7 @@ describe('getPostsForViewer', () => {
   })
 
   it('merges native + legacy (events & news) into one set', async () => {
-    const posts = await getPostsForViewer(member)
+    const posts = await getPostsForViewer(member, { now: NOW })
     expect(posts.map((p) => p.id).sort()).toEqual(['ev-1', 'native-1', 'nw-1'])
     // Legacy came through the adapter (news defaults to includeExpired:false).
     expect(getPublishedEvents).toHaveBeenCalledTimes(1)
@@ -111,7 +118,7 @@ describe('getPostsForViewer', () => {
   })
 
   it('redacts PII for an anonymous viewer (first-name floor, bio + members-only text dropped)', async () => {
-    const posts = await getPostsForViewer(ANONYMOUS_VIEWER)
+    const posts = await getPostsForViewer(ANONYMOUS_VIEWER, { now: NOW })
 
     // native person: first name only, no surname. id (pii:'none') is carried through.
     expect(person(byId(posts, 'native-1'))).toEqual({ id: 'ppl-mary', firstName: 'Mary' })
@@ -128,7 +135,7 @@ describe('getPostsForViewer', () => {
   })
 
   it('reveals full PII for an authenticated member', async () => {
-    const posts = await getPostsForViewer(member)
+    const posts = await getPostsForViewer(member, { now: NOW })
 
     expect(person(byId(posts, 'native-1')).lastName).toBe('Jones')
 
@@ -141,13 +148,67 @@ describe('getPostsForViewer', () => {
     expect(text && text.kind === 'text' ? text.body : null).toBe('Private medical details')
   })
 
+  it('filters out posts that are not active at the injected `now` (lifecycle gate)', async () => {
+    // A native post with a FUTURE happening (TimeBlock ~6 weeks out) stays active
+    // even far past its createdAt — the whole point of the unified rule.
+    const futureShower: Post = {
+      ...nativePost,
+      id: 'shower-1',
+      title: 'Wedding Shower',
+      occasion: ['shower'],
+      lifecycle: { publishDate: '2026-07-01T00:00:00.000Z' },
+      blocks: [
+        { id: 't', kind: 'time', label: 'Shower', startsAt: '2026-08-15T18:00:00.000Z' },
+      ],
+    }
+    ;(postRepository.listAllPosts as any).mockResolvedValue([nativePost, futureShower])
+
+    // At 2026-08-01 the news-shaped fixtures (native + baptism, published 07-01,
+    // 2-week window) have EXPIRED, but the shower (event 08-15) is still active.
+    const posts = await getPostsForViewer(member, { now: new Date('2026-08-01T00:00:00.000Z') })
+    const ids = posts.map((p) => p.id).sort()
+    expect(ids).toContain('shower-1') // future event → stays up
+    expect(ids).toContain('nw-1') // medical news expires 2026-12-01 → still active
+    expect(ids).not.toContain('native-1') // news-shaped, window ended → dropped
+    expect(ids).not.toContain('ev-1') // baptism, no future date → dropped
+  })
+
+  it('surfaces the eve-of reminder flag via getPostsForViewerWithState', async () => {
+    const funeralArc: Post = {
+      ...nativePost,
+      id: 'arc-1',
+      title: 'Funeral',
+      occasion: ['funeral'],
+      lifecycle: { publishDate: '2026-07-01T00:00:00.000Z' },
+      blocks: [{ id: 't', kind: 'time', label: 'Service', startsAt: '2026-08-14T12:00:00.000Z' }],
+    }
+    ;(postRepository.listAllPosts as any).mockResolvedValue([funeralArc])
+    ;(getPublishedEvents as any).mockResolvedValue([])
+    ;(listNewsItems as any).mockResolvedValue([])
+
+    // 2026-08-14 is a Friday → Thursday-before is 2026-08-13. (Noon-UTC times keep
+    // the calendar day stable under the engine's local-time weekday check.)
+    const onThursday = await getPostsForViewerWithState(member, {
+      now: new Date('2026-08-13T12:00:00.000Z'),
+    })
+    expect(onThursday.find((w) => w.post.id === 'arc-1')?.isReminder).toBe(true)
+
+    const weekEarlier = await getPostsForViewerWithState(member, {
+      now: new Date('2026-08-06T12:00:00.000Z'),
+    })
+    // Still active (event upcoming) but NOT the reminder day.
+    const w = weekEarlier.find((x) => x.post.id === 'arc-1')
+    expect(w?.post).toBeDefined()
+    expect(w?.isReminder).toBe(false)
+  })
+
   it('scopes to a tenant via listPosts and filters legacy by tenant', async () => {
     ;(getPublishedEvents as any).mockResolvedValue([
       legacyEvent,
       { ...legacyEvent, id: 'ev-other', ownerEcclesia: 'Hamilton' },
     ])
 
-    const posts = await getPostsForViewer(member, { tenant: 'Toronto East' })
+    const posts = await getPostsForViewer(member, { tenant: 'Toronto East', now: NOW })
 
     expect(postRepository.listPosts).toHaveBeenCalledWith(
       expect.objectContaining({ tenant: 'Toronto East' })

--- a/packages/app/services/post-service.ts
+++ b/packages/app/services/post-service.ts
@@ -2,6 +2,7 @@ import type { Post } from '@my/app/types/post'
 import type { Channel, Viewer } from '@my/app/utils/viewer-pii'
 import { redactPosts } from '@my/app/utils/redact-post'
 import { legacyToPost } from '@my/app/utils/legacy-to-post'
+import { getPostDisplayState } from '@my/app/utils/post-lifecycle'
 import { postRepository } from '@my/app/provider/dynamodb/repositories/post-repository'
 import { getPublishedEvents } from '@my/app/services/event-service'
 import { listNewsItems } from '@my/app/services/news-service'
@@ -40,6 +41,20 @@ export interface GetPostsOptions {
   tenant?: string
   /** Include archived native posts / inactive legacy records. Default false. */
   includeArchived?: boolean
+  /**
+   * Reference time for the unified lifecycle filter (Phase 4a). Defaults to
+   * `new Date()`; INJECTABLE so callers/tests are deterministic. Posts that are
+   * not active at this instant (unpublished, expired, or past their retrospective
+   * window) are dropped.
+   */
+  now?: Date
+}
+
+/** A viewer-ready Post plus its lifecycle state (whether `now` is its eve-of reminder). */
+export interface PostWithDisplayState {
+  post: Post
+  /** True when `now` is the bounded Thursday-before reminder for the next happening. */
+  isReminder: boolean
 }
 
 /** Load native posts, honoring the optional tenant scope. */
@@ -71,20 +86,59 @@ async function loadLegacyPosts(opts: GetPostsOptions): Promise<Post[]> {
 }
 
 /**
- * THE unified read: merged native + legacy posts, each redacted for the viewer.
- * Posts the viewer cannot reach are dropped by `redactPosts`.
+ * THE unified read WITH lifecycle state: merged native + legacy posts, filtered
+ * to those ACTIVE at `now` by the ONE display-rules engine
+ * ({@link getPostDisplayState}), then redacted for the viewer. Each surviving
+ * post carries its `isReminder` flag (the bounded Thursday-before eve-of).
+ *
+ * The lifecycle filter runs BEFORE redaction (it is reach-independent — a post's
+ * active window doesn't depend on who is looking); `redactPosts` then reach-gates
+ * and PII-scrubs, dropping anything the viewer can't see.
+ *
+ * NOTE (Phase 4a scope): this only governs the unified Post READ path (Phase 3
+ * surface + future cutover). It does NOT touch the live legacy newsletter / events
+ * / news code paths — that cutover is Phase 4b.
  */
-export async function getPostsForViewer(
+export async function getPostsForViewerWithState(
   viewer: Viewer,
   options: GetPostsOptions = {}
-): Promise<Post[]> {
+): Promise<PostWithDisplayState[]> {
   const [native, legacy] = await Promise.all([
     loadNativePosts(options),
     loadLegacyPosts(options),
   ])
 
-  // Disjoint today → concat is the correct merge. redactPosts reach-gates and
-  // PII-scrubs, dropping anything the viewer can't see.
-  const merged = [...native, ...legacy]
-  return redactPosts(merged, viewer, { channel: options.channel })
+  const now = options.now ?? new Date()
+
+  // Disjoint today → concat is the correct merge. Apply the unified lifecycle
+  // rule, keeping the reminder flag alongside each active post.
+  const active = [...native, ...legacy].flatMap((post) => {
+    const state = getPostDisplayState(post, now)
+    return state.active ? [{ post, isReminder: state.isReminder }] : []
+  })
+
+  const redacted = redactPosts(
+    active.map((a) => a.post),
+    viewer,
+    { channel: options.channel }
+  )
+
+  // redactPosts preserves order and drops unreachable posts; re-attach the
+  // reminder flag by id (ids are unique across the merged set).
+  const reminderById = new Map(active.map((a) => [a.post.id, a.isReminder]))
+  return redacted.map((post) => ({ post, isReminder: reminderById.get(post.id) ?? false }))
+}
+
+/**
+ * THE unified read: merged native + legacy posts, filtered to those active at
+ * `now` (unified lifecycle engine, Phase 4a), each redacted for the viewer.
+ * Posts the viewer cannot reach are dropped by `redactPosts`. Callers that need
+ * the eve-of reminder flag should use {@link getPostsForViewerWithState}.
+ */
+export async function getPostsForViewer(
+  viewer: Viewer,
+  options: GetPostsOptions = {}
+): Promise<Post[]> {
+  const withState = await getPostsForViewerWithState(viewer, options)
+  return withState.map((w) => w.post)
 }

--- a/packages/app/utils/newsletter/date-helpers.ts
+++ b/packages/app/utils/newsletter/date-helpers.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure, timezone-aware date helpers for the newsletter / display-rules engines.
+ *
+ * These were previously private static methods on {@link EventDurationCalculator}
+ * (event-duration.ts). They are extracted here VERBATIM (behaviour-identical) so
+ * the unified Post lifecycle engine (post-lifecycle.ts) can reuse the exact same
+ * "Thursday-before" + timezone-aware day comparison logic WITHOUT duplicating it —
+ * the two engines must never disagree about what day an event falls on.
+ *
+ * Pure + I/O-free. Cross-platform: no platform imports.
+ */
+
+/**
+ * Get the Thursday before a given date.
+ * If the date is itself a Thursday, returns the PREVIOUS Thursday (7 days before).
+ * Uses LOCAL day-of-week (matches the legacy funeral reminder semantics).
+ */
+export function getThursdayBefore(date: Date): Date {
+  const result = new Date(date)
+  const dayOfWeek = result.getDay()
+  // Days to go back to reach Thursday (4). If the date IS Thursday, go back a
+  // full week so the reminder lands on the prior Thursday, not the event day.
+  const daysBack = dayOfWeek === 4 ? 7 : (dayOfWeek + 3) % 7 || 7
+  result.setDate(result.getDate() - daysBack)
+  return result
+}
+
+/**
+ * True when two dates fall on the same calendar day (LOCAL time, ignoring time).
+ */
+export function isSameDay(date1: Date, date2: Date): boolean {
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  )
+}
+
+/**
+ * Timezone-aware "is `currentDate` on or before `eventDate`?" (day granularity).
+ *
+ * Event dates stored as "YYYY-MM-DD" become midnight UTC, so we read them with
+ * UTC accessors to recover the intended calendar day; `currentDate` (a browser
+ * `new Date()`) is read with LOCAL accessors to get the viewer's calendar day.
+ * Net effect: an event stays "on or before" until midnight in the USER's zone.
+ */
+export function isUserDateOnOrBefore(currentDate: Date, eventDate: Date): boolean {
+  const currentStr = `${currentDate.getFullYear()}-${String(currentDate.getMonth() + 1).padStart(2, '0')}-${String(currentDate.getDate()).padStart(2, '0')}`
+  const eventStr = `${eventDate.getUTCFullYear()}-${String(eventDate.getUTCMonth() + 1).padStart(2, '0')}-${String(eventDate.getUTCDate()).padStart(2, '0')}`
+  return currentStr <= eventStr
+}

--- a/packages/app/utils/newsletter/event-duration.ts
+++ b/packages/app/utils/newsletter/event-duration.ts
@@ -1,4 +1,5 @@
 import { DisplayDuration, EventTypeRule, DurationCalculationResult, EventDurationContext } from '@my/app/types/newsletter-rules'
+import { getThursdayBefore, isSameDay, isUserDateOnOrBefore } from './date-helpers'
 
 /**
  * Event Duration Calculator
@@ -354,53 +355,19 @@ export class EventDurationCalculator {
     }
   }
 
-  /**
-   * Get the Thursday before a given date
-   * If the date is a Thursday, returns the previous Thursday (7 days before)
-   */
+  // Date helpers (getThursdayBefore / isSameDay / isUserDateOnOrBefore) now live
+  // in ./date-helpers so the unified Post lifecycle engine reuses the identical
+  // logic. Thin private wrappers keep the existing call sites unchanged.
   private static getThursdayBefore(date: Date): Date {
-    const result = new Date(date)
-    const dayOfWeek = result.getDay()
-    // Calculate days to go back to reach Thursday (4)
-    // If date is Thursday (4), go back 7 days to previous Thursday
-    // If date is Friday (5), go back 1 day
-    // If date is Saturday (6), go back 2 days
-    // If date is Sunday (0), go back 3 days
-    // If date is Monday (1), go back 4 days
-    // If date is Tuesday (2), go back 5 days
-    // If date is Wednesday (3), go back 6 days
-    const daysBack = dayOfWeek === 4 ? 7 : (dayOfWeek + 3) % 7 || 7
-    result.setDate(result.getDate() - daysBack)
-    return result
+    return getThursdayBefore(date)
   }
 
-  /**
-   * Check if two dates are the same day (ignoring time)
-   * Both dates use the same timezone context (local methods)
-   */
   private static isSameDay(date1: Date, date2: Date): boolean {
-    return (
-      date1.getFullYear() === date2.getFullYear() &&
-      date1.getMonth() === date2.getMonth() &&
-      date1.getDate() === date2.getDate()
-    )
+    return isSameDay(date1, date2)
   }
 
-  /**
-   * Timezone-aware date comparison for event filtering.
-   *
-   * Event dates stored as "YYYY-MM-DD" create midnight UTC dates, so we use
-   * UTC accessors (getUTCFullYear etc.) to get the intended calendar date.
-   *
-   * currentDate (from browser's new Date()) uses local accessors to get the
-   * user's actual calendar date in their timezone.
-   *
-   * This ensures events show until midnight in the USER's timezone.
-   */
   private static isUserDateOnOrBefore(currentDate: Date, eventDate: Date): boolean {
-    const currentStr = `${currentDate.getFullYear()}-${String(currentDate.getMonth() + 1).padStart(2, '0')}-${String(currentDate.getDate()).padStart(2, '0')}`
-    const eventStr = `${eventDate.getUTCFullYear()}-${String(eventDate.getUTCMonth() + 1).padStart(2, '0')}-${String(eventDate.getUTCDate()).padStart(2, '0')}`
-    return currentStr <= eventStr
+    return isUserDateOnOrBefore(currentDate, eventDate)
   }
 
   /**

--- a/packages/app/utils/post-lifecycle.ts
+++ b/packages/app/utils/post-lifecycle.ts
@@ -1,0 +1,240 @@
+/**
+ * Unified Post lifecycle / display-rules engine (Consolidated CMS #131, Phase 4a).
+ *
+ * ONE lifetime rule for News AND Events (design §6). Today News and Events have
+ * two DIFFERENT lifetime rules, and it's wrong: News expires on a flat publish
+ * window (`isNewsActive` / `expiresAt` / `durationWeeks`) that IGNORES any future
+ * event it announces — so a "Wedding Shower" news item expired 2 weeks BEFORE the
+ * shower and missed the newsletter. Events, meanwhile, only date-anchor a
+ * "Thursday-before" reminder for funerals. This engine collapses both into one
+ * rule over the {@link Post} model:
+ *
+ *   - A Post with a FUTURE happening is **event-shaped**: it stays active through
+ *     that happening (it does NOT expire early like news), and fires a bounded
+ *     eve-of reminder on the Thursday immediately before it.
+ *   - A Post with NO future happening (none, or all past) is **news-shaped**:
+ *     active from publish for a retrospective window (subsumes `isNewsActive`).
+ *
+ * Sequence-aware: a Post can carry a SEQUENCE of happenings (multiple
+ * {@link TimeBlock}s), e.g. a death that evolves into visitation → funeral →
+ * graveside → celebration-of-life, "sometimes all separate events" weeks apart.
+ * The Post is event-shaped while ANY happening is still upcoming; the eve-of
+ * reminder fires before EACH one (the "next" advances as each passes); it becomes
+ * news-shaped only after the LAST happening passes.
+ *
+ * ── The "future date" caveat (crux of "the shower stays up") ──
+ * TODAY legacy News has NO explicit future-event-date field. `legacyToPost` maps a
+ * news item's future date only if it carries a TimeBlock — which legacy news never
+ * does. So a migrated news item is NEWS-shaped (and can still expire early) UNLESS
+ * an author adds a TimeBlock in the editor, or Phase 4b's migration infers one.
+ * The event-shaped "stays up until the date" behaviour lands the moment a future
+ * TimeBlock exists on the Post — not before.
+ *
+ * Pure + I/O-free, platform-free, fully unit-testable. Reuses the legacy date
+ * helpers (Thursday-before + timezone-aware day compare) from
+ * `newsletter/date-helpers.ts` — no duplication.
+ */
+
+import type { Post, TimeBlock } from '../types/post'
+import { getThursdayBefore, isSameDay, isUserDateOnOrBefore } from './newsletter/date-helpers'
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+/** Retrospective window (weeks) for a news-shaped Post when `expiresAt` is absent. */
+export const DEFAULT_NEWS_WINDOW_WEEKS = 2
+
+export interface PostDisplayState {
+  /** Should the Post be shown / included right now? */
+  active: boolean
+  /** Is `now` the bounded eve-of (Thursday-before) reminder for the next happening? */
+  isReminder: boolean
+  /** Human-readable rationale (mirrors the legacy engine's debuggable reasons). */
+  reason: string
+}
+
+export interface DisplayStateOptions {
+  /**
+   * Retrospective window in weeks for news-shaped posts when `lifecycle.expiresAt`
+   * is absent. Defaults to {@link DEFAULT_NEWS_WINDOW_WEEKS}.
+   */
+  defaultNewsWindowWeeks?: number
+}
+
+/** A single time happening on a Post (a TimeBlock, or the lifecycle-level date). */
+interface Happening {
+  startsAt: string
+  endsAt?: string
+  label?: string
+}
+
+function parseDate(value?: string): Date | undefined {
+  if (!value) return undefined
+  const d = new Date(value)
+  return isNaN(d.getTime()) ? undefined : d
+}
+
+function sameInstant(a: string, b: string): boolean {
+  const da = parseDate(a)
+  const db = parseDate(b)
+  return !!da && !!db && da.getTime() === db.getTime()
+}
+
+/**
+ * All time happenings on a Post: every {@link TimeBlock} with a `startsAt`, plus
+ * the lifecycle-level `startsAt` when it is not already represented by a TimeBlock
+ * (native posts may set `lifecycle.startsAt` without a TimeBlock; the legacy
+ * adapter sets both to the same instant, which we de-dupe).
+ */
+function collectHappenings(post: Post): Happening[] {
+  const out: Happening[] = []
+  for (const block of post.blocks) {
+    if (block.kind === 'time') {
+      const tb = block as TimeBlock
+      if (tb.startsAt) {
+        out.push({ startsAt: tb.startsAt, endsAt: tb.endsAt, label: tb.label })
+      }
+    }
+  }
+  const ls = post.lifecycle.startsAt
+  if (ls && !out.some((h) => sameInstant(h.startsAt, ls))) {
+    out.push({ startsAt: ls, endsAt: post.lifecycle.endsAt, label: post.title })
+  }
+  return out
+}
+
+/** The date through which a happening keeps a post active (multi-day → its end). */
+function happeningBoundary(h: Happening): Date {
+  return parseDate(h.endsAt) ?? parseDate(h.startsAt)!
+}
+
+/**
+ * The Post's effective START date — `lifecycle.startsAt` if set, else the EARLIEST
+ * `TimeBlock.startsAt`. Undefined ⇒ the post has no date at all (news-shaped).
+ *
+ * NOTE: this is the earliest-OVERALL start (which may be in the past). For the
+ * lifecycle decision use {@link resolvePostNextDate} (the earliest still-upcoming).
+ */
+export function resolvePostStartsAt(post: Post): string | undefined {
+  if (post.lifecycle.startsAt) return post.lifecycle.startsAt
+  let earliest: string | undefined
+  for (const block of post.blocks) {
+    if (block.kind === 'time') {
+      const s = (block as TimeBlock).startsAt
+      if (s && (!earliest || parseDate(s)! < parseDate(earliest)!)) earliest = s
+    }
+  }
+  return earliest
+}
+
+/**
+ * The NEXT upcoming happening relative to `now`: the earliest happening whose
+ * boundary (its end, or start) is still today-or-later. Undefined ⇒ every
+ * happening has passed (or there are none) ⇒ news-shaped. Sequence-aware: as each
+ * happening passes, the next one is returned.
+ */
+export function resolvePostNextDate(post: Post, now: Date): Happening | undefined {
+  const upcoming = collectHappenings(post).filter((h) =>
+    isUserDateOnOrBefore(now, happeningBoundary(h))
+  )
+  if (upcoming.length === 0) return undefined
+  return upcoming.reduce((next, h) =>
+    parseDate(h.startsAt)! < parseDate(next.startsAt)! ? h : next
+  )
+}
+
+/**
+ * The LAST date on the Post — the latest happening boundary (end, or start).
+ * Undefined ⇒ the post has no dated happenings. Used to anchor the retrospective
+ * window so a post lingers briefly AFTER its final happening (e.g. a
+ * celebration-of-life), rather than vanishing the instant the event ends.
+ */
+export function resolvePostLastDate(post: Post): string | undefined {
+  let latest: Date | undefined
+  let latestIso: string | undefined
+  for (const h of collectHappenings(post)) {
+    const b = h.endsAt ?? h.startsAt
+    const d = parseDate(b)
+    if (d && (!latest || d > latest)) {
+      latest = d
+      latestIso = b
+    }
+  }
+  return latestIso
+}
+
+/**
+ * THE unified lifecycle rule. Given a Post and `now`, decide whether it is active
+ * and whether `now` is its bounded eve-of reminder.
+ *
+ * 1. Not yet published (`publishDate` in the future) ⇒ inactive.
+ * 2. Has a future happening ({@link resolvePostNextDate}) ⇒ **event-shaped**:
+ *    active through that happening; `isReminder` on the Thursday immediately
+ *    before the NEXT happening. As each happening passes the next becomes current.
+ * 3. No future happening (none, or all past) ⇒ **news-shaped**: active from
+ *    publish for its retrospective window (`lifecycle.expiresAt`, else a default
+ *    window anchored at the later of publish / last happening). Subsumes
+ *    `isNewsActive`.
+ */
+export function getPostDisplayState(
+  post: Post,
+  now: Date,
+  opts: DisplayStateOptions = {}
+): PostDisplayState {
+  // 1. Not yet published.
+  const publishDate = parseDate(post.lifecycle.publishDate)
+  if (publishDate && publishDate.getTime() > now.getTime()) {
+    return {
+      active: false,
+      isReminder: false,
+      reason: `Not yet published (publishDate ${publishDate.toDateString()})`,
+    }
+  }
+
+  // 2. Event-shaped: any happening still upcoming.
+  const next = resolvePostNextDate(post, now)
+  if (next) {
+    const nextStart = parseDate(next.startsAt)!
+    const thursdayBefore = getThursdayBefore(nextStart)
+    const isReminder = isSameDay(now, thursdayBefore)
+    const which = next.label ?? post.title
+    return {
+      active: true,
+      isReminder,
+      reason: isReminder
+        ? `Event-shaped: final reminder — Thursday before ${which} (${nextStart.toDateString()})`
+        : `Event-shaped: next happening ${which} on ${nextStart.toDateString()} — active until then`,
+    }
+  }
+
+  // 3. News-shaped: no upcoming happening → retrospective window.
+  const hadHappening = collectHappenings(post).length > 0
+  const lastDate = parseDate(resolvePostLastDate(post))
+  const windowStart =
+    // Anchor at the later of publish / last happening so a post that HAD events
+    // lingers `defaultNewsWindowWeeks` after the final one; pure news anchors at
+    // publish (subsuming isNewsActive exactly when expiresAt is set).
+    [publishDate, lastDate, parseDate(post.createdAt)]
+      .filter((d): d is Date => !!d)
+      .reduce((a, b) => (a && a.getTime() >= b.getTime() ? a : b), undefined as Date | undefined) ??
+    now
+
+  const windowWeeks = opts.defaultNewsWindowWeeks ?? DEFAULT_NEWS_WINDOW_WEEKS
+  const expiresAt =
+    parseDate(post.lifecycle.expiresAt) ??
+    new Date(windowStart.getTime() + windowWeeks * WEEK_MS)
+
+  const active = now.getTime() < expiresAt.getTime()
+  const tail = hadHappening ? ' (all happenings passed)' : ''
+  return {
+    active,
+    isReminder: false,
+    reason: active
+      ? `News-shaped: within retrospective window until ${expiresAt.toDateString()}${tail}`
+      : `News-shaped: retrospective window ended ${expiresAt.toDateString()}${tail}`,
+  }
+}
+
+/** Convenience: is the Post active at `now` (defaults to the current time)? */
+export function isPostActive(post: Post, now: Date = new Date()): boolean {
+  return getPostDisplayState(post, now).active
+}


### PR DESCRIPTION
Phase 4a of #131 — **one lifetime engine** over the Post model (design §6). This is the last place News and Events had *different* lifetime rules; after this they share one, keyed off 'has a future happening'. Additive + flag-gated (`getPostsForViewer` has no production consumers yet); legacy newsletter/events/news read paths untouched.

## The unified rule (`packages/app/utils/post-lifecycle.ts`)
`getPostDisplayState(post, now) → { active, isReminder, reason }`:
1. `publishDate` future → inactive.
2. **Any happening still upcoming → event-shaped**: active through it; `isReminder` on the Thursday before the **next** happening.
3. **No upcoming happening → news-shaped**: retrospective window (`expiresAt`, else default) — subsumes `isNewsActive`.

**Sequence-aware** (the death arc): `resolvePostNextDate` = earliest **still-upcoming** happening, so a Post with visitation→funeral→graveside→celebration stays event-shaped and gets an eve-of reminder before **each**, going retrospective only after the **last**. `resolvePostStartsAt`/`resolvePostLastDate` exposed.

## Applied
`getPostsForViewer` now filters to `active` posts at an injectable `now`; `getPostsForViewerWithState` surfaces the per-post `isReminder` flag. Only the (additive) Post read path — no legacy path changed.

## Reuse (not duplication)
Extracted `getThursdayBefore`/`isSameDay`/`isUserDateOnOrBefore` into `newsletter/date-helpers.ts`; the legacy `EventDurationCalculator` delegates (behavior-identical — 20 funeral tests still pass).

## Verify
- **49 tests** (post-lifecycle 23: shower scenario, death arc, news expiry/`isNewsActive`-subsumption, not-yet-published, exact Wed/Thu/Fri boundary — all dates injected; post-service 6; funeral 20 unchanged) + 54 adapter/redact/route. Typecheck clean.

## Caveat (documented)
Legacy News has no future-date field → a migrated news item is news-shaped UNLESS it carries a `TimeBlock`. 'Shower stays up until the date' lands when an author adds a TimeBlock (or 4b's migration infers one). Default retrospective window 2w (tunable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)