### PR TITLE
CONSOLIDATED_CMS — connect/series + duplicate a post (#131)

### DIFF
--- a/apps/next/app/admin/(admin-plus)/posts/[id]/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/posts/[id]/page.tsx
@@ -6,7 +6,7 @@ import { YStack, XStack, Text, Spinner, Heading, Button } from '@my/ui'
 import { PostEditor, createEmptyPost, validateForPublish } from '@my/ui/src/post-editor'
 import { useAdminAccess } from '@/hooks/use-admin-access'
 import { useHydrated } from '@my/app/hooks/use-hydrated'
-import { getPost, createPost, updatePost } from '@my/app/provider/get-data'
+import { getPost, createPost, updatePost, getPostSeries } from '@my/app/provider/get-data'
 import { HOME_ECCLESIA } from '@my/app/config/home-ecclesia'
 import type { Post } from '@my/app/types/post'
 
@@ -34,6 +34,7 @@ export default function AdminPostEditorPage() {
   const [post, setPost] = useState<Post | null>(null)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const [seriesPosts, setSeriesPosts] = useState<Array<{ id: string; title: string }>>([])
 
   // The server-assigned id once the draft has been created (starts '' for new).
   const savedIdRef = useRef<string>('')
@@ -68,6 +69,27 @@ export default function AdminPostEditorPage() {
       cancelled = true
     }
   }, [hasAccess, routeId, authorId])
+
+  // ---- Connect/series indicator ("part of a series — N related") -----------
+  useEffect(() => {
+    if (!hasAccess || !post?.id || !post.seriesId) {
+      setSeriesPosts([])
+      return
+    }
+    let cancelled = false
+    getPostSeries(post.id)
+      .then((siblings) => {
+        if (cancelled) return
+        setSeriesPosts(siblings.map((s) => ({ id: s.id, title: s.title })))
+      })
+      .catch(() => {
+        // Non-critical — the indicator simply stays hidden on failure.
+        if (!cancelled) setSeriesPosts([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [hasAccess, post?.id, post?.seriesId])
 
   // ---- Persist (create-then-update) ----------------------------------------
   const persist = useCallback(async (next: Post): Promise<Post | null> => {
@@ -183,7 +205,13 @@ export default function AdminPostEditorPage() {
         </Text>
       </XStack>
 
-      <PostEditor value={post} onChange={handleChange} onPublish={handlePublish} />
+      <PostEditor
+        value={post}
+        onChange={handleChange}
+        onPublish={handlePublish}
+        seriesPosts={seriesPosts}
+        onSeriesPostPress={(id) => router.push(`/admin/posts/${id}`)}
+      />
     </YStack>
   )
 }

--- a/apps/next/app/admin/(admin-plus)/posts/page.tsx
+++ b/apps/next/app/admin/(admin-plus)/posts/page.tsx
@@ -3,10 +3,10 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { YStack, XStack, Card, Text, Spinner, Heading, Button, Paragraph } from '@my/ui'
-import { Plus } from '@tamagui/lucide-icons'
+import { Plus, Copy } from '@tamagui/lucide-icons'
 import { useAdminAccess } from '@/hooks/use-admin-access'
 import { useHydrated } from '@my/app/hooks/use-hydrated'
-import { listPosts } from '@my/app/provider/get-data'
+import { listPosts, duplicatePost } from '@my/app/provider/get-data'
 import type { Post } from '@my/app/types/post'
 
 /**
@@ -48,6 +48,7 @@ export default function AdminPostsPage() {
   const [posts, setPosts] = useState<Post[]>([])
   const [loading, setLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [duplicatingId, setDuplicatingId] = useState<string | null>(null)
 
   useEffect(() => {
     if (!hasAccess) return
@@ -71,6 +72,21 @@ export default function AdminPostsPage() {
       cancelled = true
     }
   }, [hasAccess])
+
+  // Duplicate/replicate (Consolidated CMS epic #131): clone the post's
+  // structure into a fresh draft, then jump straight into editing it.
+  const handleDuplicate = async (postId: string) => {
+    if (duplicatingId) return
+    setDuplicatingId(postId)
+    setErrorMessage(null)
+    try {
+      const draft = await duplicatePost(postId)
+      router.push(`/admin/posts/${draft.id}`)
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : 'Failed to duplicate post')
+      setDuplicatingId(null)
+    }
+  }
 
   if (!isHydrated || isLoading || !hasAccess) {
     return (
@@ -131,6 +147,19 @@ export default function AdminPostsPage() {
                     {post.status}
                   </Text>
                 </XStack>
+                <Button
+                  size="$2"
+                  variant="outlined"
+                  icon={<Copy size={14} />}
+                  disabled={duplicatingId === post.id}
+                  aria-label={`Duplicate ${post.title || 'Untitled post'}`}
+                  onPress={(e: any) => {
+                    e.stopPropagation()
+                    void handleDuplicate(post.id)
+                  }}
+                >
+                  {duplicatingId === post.id ? 'Duplicating…' : 'Duplicate'}
+                </Button>
               </XStack>
 
               <XStack justifyContent="space-between" alignItems="center" gap="$3" flexWrap="wrap">

--- a/apps/next/app/api/admin/posts/[id]/duplicate/route.ts
+++ b/apps/next/app/api/admin/posts/[id]/duplicate/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '../../../../../../utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+import { postRepository } from '@my/app/provider/dynamodb/repositories/post-repository'
+import { checkFeatureFlagFromDB } from '@my/app/features/feature-flags/use-feature-flag-wrapper'
+import { FEATURE_FLAGS } from '@my/app/features/feature-flags/feature-flags'
+
+/**
+ * POST /api/admin/posts/[id]/duplicate — Duplicate/replicate (Consolidated CMS
+ * epic #131). Clones the source post's STRUCTURE (title/occasion/blocks) into
+ * a fresh `draft`, with brand-new block ids, so an annual gathering or study
+ * day isn't rebuilt from scratch. The duplicate auto-joins the source's series
+ * (Connect/series) — see {@link postRepository.duplicatePost}.
+ *
+ * Same three-way gate as the other admin Posts routes: authenticated →
+ * owner/admin → CONSOLIDATED_CMS flag ON (else 404).
+ */
+async function authorize(): Promise<
+  { ok: true; authorId: string } | { ok: false; res: NextResponse }
+> {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return { ok: false, res: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const role = (session.user as any).role
+  if (role !== ROLES.OWNER && role !== ROLES.ADMIN) {
+    return { ok: false, res: NextResponse.json({ error: 'Admin access required' }, { status: 403 }) }
+  }
+  const flagOn = await checkFeatureFlagFromDB(FEATURE_FLAGS.CONSOLIDATED_CMS, session as any)
+  if (!flagOn) {
+    return { ok: false, res: NextResponse.json({ error: 'Not found' }, { status: 404 }) }
+  }
+  return { ok: true, authorId: session.user.email }
+}
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const gate = await authorize()
+  if (!gate.ok) return gate.res
+
+  try {
+    const { id } = await params
+    const post = await postRepository.duplicatePost(id, gate.authorId)
+    return NextResponse.json(post, { status: 201 })
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('not found')) {
+      return NextResponse.json({ error: 'Post not found' }, { status: 404 })
+    }
+    console.error('Error duplicating post:', error)
+    return NextResponse.json({ error: 'Failed to duplicate post' }, { status: 500 })
+  }
+}

--- a/apps/next/app/api/admin/posts/[id]/series/route.ts
+++ b/apps/next/app/api/admin/posts/[id]/series/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '../../../../../../utils/auth'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+import { postRepository } from '@my/app/provider/dynamodb/repositories/post-repository'
+import { getSeriesForPost } from '@my/app/services/post-service'
+import { checkFeatureFlagFromDB } from '@my/app/features/feature-flags/use-feature-flag-wrapper'
+import { FEATURE_FLAGS } from '@my/app/features/feature-flags/feature-flags'
+
+/**
+ * GET /api/admin/posts/[id]/series — Connect/series (Consolidated CMS epic
+ * #131): the OTHER posts sharing this post's `seriesId` (empty array when the
+ * post isn't part of a series). Powers the editor/list "part of a series — N
+ * related" indicator. Unredacted (admin-only surface, same as the other admin
+ * Posts routes) — see {@link getSeriesForPost}.
+ *
+ * Same three-way gate as the other admin Posts routes: authenticated →
+ * owner/admin → CONSOLIDATED_CMS flag ON (else 404).
+ */
+async function authorize(): Promise<{ ok: true } | { ok: false; res: NextResponse }> {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return { ok: false, res: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const role = (session.user as any).role
+  if (role !== ROLES.OWNER && role !== ROLES.ADMIN) {
+    return { ok: false, res: NextResponse.json({ error: 'Admin access required' }, { status: 403 }) }
+  }
+  const flagOn = await checkFeatureFlagFromDB(FEATURE_FLAGS.CONSOLIDATED_CMS, session as any)
+  if (!flagOn) {
+    return { ok: false, res: NextResponse.json({ error: 'Not found' }, { status: 404 }) }
+  }
+  return { ok: true }
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const gate = await authorize()
+  if (!gate.ok) return gate.res
+
+  try {
+    const { id } = await params
+    const post = await postRepository.getPost(id)
+    if (!post) return NextResponse.json({ error: 'Post not found' }, { status: 404 })
+    const series = await getSeriesForPost(post)
+    return NextResponse.json(series)
+  } catch (error) {
+    console.error('Error loading post series:', error)
+    return NextResponse.json({ error: 'Failed to load post series' }, { status: 500 })
+  }
+}

--- a/apps/next/tests/db/post-repository.test.ts
+++ b/apps/next/tests/db/post-repository.test.ts
@@ -275,4 +275,99 @@ describe('PostRepository', () => {
       expect(posts.map((p) => p.id)).toEqual(['p1'])
     })
   })
+
+  describe('listPostsBySeries', () => {
+    it('scans filtering on seriesId + the POST# prefix', async () => {
+      mockSend.mockResolvedValueOnce({
+        Items: [storedRecord({ id: 'p1', seriesId: 'series-1' })],
+        LastEvaluatedKey: undefined,
+      })
+
+      const posts = await repository.listPostsBySeries('series-1')
+
+      const scanCall = mockSend.mock.calls[0][0]
+      expect(scanCall.type).toBe('ScanCommand')
+      expect(scanCall.params.FilterExpression).toBe(
+        'begins_with(pkey, :prefix) AND seriesId = :seriesId'
+      )
+      expect(scanCall.params.ExpressionAttributeValues).toMatchObject({
+        ':prefix': 'POST#',
+        ':seriesId': 'series-1',
+      })
+      expect(posts.map((p) => p.id)).toEqual(['p1'])
+    })
+
+    it('returns [] without querying when seriesId is empty', async () => {
+      const posts = await repository.listPostsBySeries('')
+      expect(posts).toEqual([])
+      expect(mockSend).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('duplicatePost', () => {
+    it('deep-clones blocks with fresh ids, resets id/status/timestamps, and mints a shared seriesId when the source had none', async () => {
+      const source = storedRecord({
+        id: 'src-1',
+        title: 'Toronto Fraternal Gathering 2025',
+        occasion: ['study-weekend'],
+        blocks: [{ id: 'blk-orig', kind: 'text', body: 'Join us', containsPii: false }],
+      })
+      mockSend
+        .mockResolvedValueOnce({ Items: [source] }) // getPost (source)
+        .mockResolvedValueOnce({ Items: [source] }) // updatePost's internal getPost
+        .mockResolvedValueOnce({ Attributes: { ...source, seriesId: 'test-post-uuid' } }) // updatePost's update
+        .mockResolvedValueOnce({}) // createPost's put
+
+      const result = await repository.duplicatePost('src-1', 'duplicator@x.com')
+
+      // 4 calls: getPost(source), updatePost→getPost, updatePost→update, createPost→put.
+      expect(mockSend).toHaveBeenCalledTimes(4)
+
+      // The source is retroactively linked into the freshly-minted series.
+      const backlinkUpdateCall = mockSend.mock.calls[2][0]
+      expect(backlinkUpdateCall.type).toBe('UpdateCommand')
+      expect(Object.values(backlinkUpdateCall.params.ExpressionAttributeValues)).toContain(
+        'test-post-uuid'
+      )
+
+      // The new draft: fresh id/status/authorId, title+occasion carried, blocks
+      // deep-cloned with a FRESH id (not reusing 'blk-orig'), sharing the series.
+      const createPutCall = mockSend.mock.calls[3][0]
+      expect(createPutCall.type).toBe('PutCommand')
+      const item = createPutCall.params.Item
+      expect(item.id).toBe('test-post-uuid')
+      expect(item.status).toBe('draft')
+      expect(item.authorId).toBe('duplicator@x.com')
+      expect(item.title).toBe('Toronto Fraternal Gathering 2025')
+      expect(item.occasion).toEqual(['study-weekend'])
+      expect(item.seriesId).toBe('test-post-uuid')
+      expect(item.blocks).toHaveLength(1)
+      expect(item.blocks[0].id).not.toBe('blk-orig')
+      expect(item.blocks[0].body).toBe('Join us')
+
+      expect(result.id).toBe('test-post-uuid')
+      expect(result.status).toBe('draft')
+    })
+
+    it('reuses the source seriesId (no backlink update) when the source already has one', async () => {
+      const source = storedRecord({ id: 'src-2', seriesId: 'existing-series' })
+      mockSend
+        .mockResolvedValueOnce({ Items: [source] }) // getPost (source)
+        .mockResolvedValueOnce({}) // createPost's put
+
+      const result = await repository.duplicatePost('src-2', 'duplicator@x.com')
+
+      // Only 2 calls — no retroactive backlink update since the source already
+      // had a seriesId.
+      expect(mockSend).toHaveBeenCalledTimes(2)
+      const createPutCall = mockSend.mock.calls[1][0]
+      expect(createPutCall.params.Item.seriesId).toBe('existing-series')
+      expect(result.seriesId).toBe('existing-series')
+    })
+
+    it('throws when the source post does not exist', async () => {
+      mockSend.mockResolvedValueOnce({ Items: [] }) // getPost → none
+      await expect(repository.duplicatePost('missing', 'x@x.com')).rejects.toThrow(/not found/)
+    })
+  })
 })

--- a/apps/next/tests/posts-duplicate-route.test.ts
+++ b/apps/next/tests/posts-duplicate-route.test.ts
@@ -1,0 +1,79 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+
+/**
+ * Guard matrix for POST /api/admin/posts/[id]/duplicate (Consolidated CMS
+ * epic #131, Duplicate/replicate). Same three-way gate as the other admin
+ * Posts routes — authenticated → owner/admin → CONSOLIDATED_CMS flag ON (else
+ * 404) — and the author is always derived from the session, never the client.
+ */
+
+const h = vi.hoisted(() => ({
+  auth: vi.fn(),
+  checkFlag: vi.fn(),
+  duplicatePost: vi.fn(),
+}))
+
+vi.mock('../utils/auth', () => ({ auth: h.auth }))
+vi.mock('@my/app/features/feature-flags/use-feature-flag-wrapper', () => ({
+  checkFeatureFlagFromDB: h.checkFlag,
+}))
+vi.mock('@my/app/provider/dynamodb/repositories/post-repository', () => ({
+  postRepository: { duplicatePost: h.duplicatePost },
+}))
+
+import { POST } from '../app/api/admin/posts/[id]/duplicate/route'
+
+const OWNER = { user: { email: 'owner@tee-admin.com', role: ROLES.OWNER } }
+const MEMBER = { user: { email: 'm@x.com', role: ROLES.MEMBER } }
+
+function req() {
+  return {} as any
+}
+function ctx(id: string) {
+  return { params: Promise.resolve({ id }) }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.auth.mockResolvedValue(OWNER)
+  h.checkFlag.mockResolvedValue(true)
+  h.duplicatePost.mockResolvedValue({ id: 'new-draft-id', status: 'draft', title: 'Copy' })
+})
+
+describe('POST /api/admin/posts/[id]/duplicate — gate', () => {
+  it('401 when unauthenticated', async () => {
+    h.auth.mockResolvedValue(null)
+    const res = await POST(req(), ctx('src-1'))
+    expect(res.status).toBe(401)
+    expect(h.duplicatePost).not.toHaveBeenCalled()
+  })
+
+  it('403 when not owner/admin', async () => {
+    h.auth.mockResolvedValue(MEMBER)
+    const res = await POST(req(), ctx('src-1'))
+    expect(res.status).toBe(403)
+    expect(h.duplicatePost).not.toHaveBeenCalled()
+  })
+
+  it('404 when the CONSOLIDATED_CMS flag is OFF (feature hidden)', async () => {
+    h.checkFlag.mockResolvedValue(false)
+    const res = await POST(req(), ctx('src-1'))
+    expect(res.status).toBe(404)
+    expect(h.duplicatePost).not.toHaveBeenCalled()
+  })
+
+  it('404 when the source post does not exist', async () => {
+    h.duplicatePost.mockRejectedValue(new Error('Post src-1 not found'))
+    const res = await POST(req(), ctx('src-1'))
+    expect(res.status).toBe(404)
+  })
+
+  it('201 duplicates with the author derived from the session, never the client', async () => {
+    const res = await POST(req(), ctx('src-1'))
+    expect(res.status).toBe(201)
+    expect(await res.json()).toEqual({ id: 'new-draft-id', status: 'draft', title: 'Copy' })
+    expect(h.duplicatePost).toHaveBeenCalledTimes(1)
+    expect(h.duplicatePost).toHaveBeenCalledWith('src-1', 'owner@tee-admin.com')
+  })
+})

--- a/apps/next/tests/posts-series-route.test.ts
+++ b/apps/next/tests/posts-series-route.test.ts
@@ -1,0 +1,83 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { ROLES } from '@my/app/provider/auth/auth-roles'
+
+/**
+ * Guard matrix for GET /api/admin/posts/[id]/series (Consolidated CMS epic
+ * #131, Connect/series). Same three-way gate as the other admin Posts routes
+ * — authenticated → owner/admin → CONSOLIDATED_CMS flag ON (else 404).
+ */
+
+const h = vi.hoisted(() => ({
+  auth: vi.fn(),
+  checkFlag: vi.fn(),
+  getPost: vi.fn(),
+  getSeriesForPost: vi.fn(),
+}))
+
+vi.mock('../utils/auth', () => ({ auth: h.auth }))
+vi.mock('@my/app/features/feature-flags/use-feature-flag-wrapper', () => ({
+  checkFeatureFlagFromDB: h.checkFlag,
+}))
+vi.mock('@my/app/provider/dynamodb/repositories/post-repository', () => ({
+  postRepository: { getPost: h.getPost },
+}))
+vi.mock('@my/app/services/post-service', () => ({
+  getSeriesForPost: h.getSeriesForPost,
+}))
+
+import { GET } from '../app/api/admin/posts/[id]/series/route'
+
+const OWNER = { user: { email: 'owner@tee-admin.com', role: ROLES.OWNER } }
+const MEMBER = { user: { email: 'm@x.com', role: ROLES.MEMBER } }
+
+function req() {
+  return {} as any
+}
+function ctx(id: string) {
+  return { params: Promise.resolve({ id }) }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.auth.mockResolvedValue(OWNER)
+  h.checkFlag.mockResolvedValue(true)
+  h.getPost.mockResolvedValue({ id: 'p1', seriesId: 'tfg' })
+  h.getSeriesForPost.mockResolvedValue([{ id: 'p2', title: 'Sibling' }])
+})
+
+describe('GET /api/admin/posts/[id]/series — gate', () => {
+  it('401 when unauthenticated', async () => {
+    h.auth.mockResolvedValue(null)
+    const res = await GET(req(), ctx('p1'))
+    expect(res.status).toBe(401)
+    expect(h.getSeriesForPost).not.toHaveBeenCalled()
+  })
+
+  it('403 when not owner/admin', async () => {
+    h.auth.mockResolvedValue(MEMBER)
+    const res = await GET(req(), ctx('p1'))
+    expect(res.status).toBe(403)
+    expect(h.getSeriesForPost).not.toHaveBeenCalled()
+  })
+
+  it('404 when the CONSOLIDATED_CMS flag is OFF', async () => {
+    h.checkFlag.mockResolvedValue(false)
+    const res = await GET(req(), ctx('p1'))
+    expect(res.status).toBe(404)
+    expect(h.getSeriesForPost).not.toHaveBeenCalled()
+  })
+
+  it('404 when the post does not exist', async () => {
+    h.getPost.mockResolvedValue(null)
+    const res = await GET(req(), ctx('missing'))
+    expect(res.status).toBe(404)
+    expect(h.getSeriesForPost).not.toHaveBeenCalled()
+  })
+
+  it('200 returns the series siblings when authorized + flag ON', async () => {
+    const res = await GET(req(), ctx('p1'))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([{ id: 'p2', title: 'Sibling' }])
+    expect(h.getSeriesForPost).toHaveBeenCalledWith({ id: 'p1', seriesId: 'tfg' })
+  })
+})

--- a/apps/next/tests/redact-post.test.ts
+++ b/apps/next/tests/redact-post.test.ts
@@ -243,6 +243,18 @@ describe('redactPost — reach gating', () => {
     expect(redactPost(post, member)!.blocks).toHaveLength(0)
     expect(redactPost(post, admin)!.blocks).toHaveLength(1)
   })
+
+  it('seriesId (pii:none, Connect/series) carries through unchanged for every viewer tier', () => {
+    const post: Post = { ...base, visibility: 'public', blocks: [], seriesId: 'series-abc' }
+    expect(redactPost(post, anon)!.seriesId).toBe('series-abc')
+    expect(redactPost(post, member)!.seriesId).toBe('series-abc')
+    expect(redactPost(post, admin)!.seriesId).toBe('series-abc')
+  })
+
+  it('a post with no seriesId redacts with seriesId still undefined', () => {
+    const post: Post = { ...base, visibility: 'public', blocks: [] }
+    expect(redactPost(post, member)).not.toHaveProperty('seriesId')
+  })
 })
 
 // ── canSee tier matrix ───────────────────────────────────────────────────────

--- a/apps/next/tests/services/post-service.test.ts
+++ b/apps/next/tests/services/post-service.test.ts
@@ -6,6 +6,7 @@ vi.mock('@my/app/provider/dynamodb/repositories/post-repository', () => ({
   postRepository: {
     listPosts: vi.fn(),
     listAllPosts: vi.fn(),
+    listPostsBySeries: vi.fn(),
   },
 }))
 vi.mock('@my/app/services/event-service', () => ({
@@ -15,7 +16,11 @@ vi.mock('@my/app/services/news-service', () => ({
   listNewsItems: vi.fn(),
 }))
 
-import { getPostsForViewer, getPostsForViewerWithState } from '@my/app/services/post-service'
+import {
+  getPostsForViewer,
+  getPostsForViewerWithState,
+  getSeriesForPost,
+} from '@my/app/services/post-service'
 import { postRepository } from '@my/app/provider/dynamodb/repositories/post-repository'
 import { getPublishedEvents } from '@my/app/services/event-service'
 import { listNewsItems } from '@my/app/services/news-service'
@@ -216,5 +221,28 @@ describe('getPostsForViewer', () => {
     expect(postRepository.listAllPosts).not.toHaveBeenCalled()
     // The Hamilton event is filtered out; Toronto East legacy + native remain.
     expect(posts.map((p) => p.id).sort()).toEqual(['ev-1', 'native-1', 'nw-1'])
+  })
+})
+
+describe('getSeriesForPost', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns [] without querying when the post has no seriesId', async () => {
+    const result = await getSeriesForPost(nativePost)
+    expect(result).toEqual([])
+    expect(postRepository.listPostsBySeries).not.toHaveBeenCalled()
+  })
+
+  it('returns the OTHER series members, excluding the post itself', async () => {
+    const self: Post = { ...nativePost, id: 'gathering-2026', seriesId: 'tfg' }
+    const sibling2025: Post = { ...nativePost, id: 'gathering-2025', seriesId: 'tfg' }
+    ;(postRepository.listPostsBySeries as any).mockResolvedValue([self, sibling2025])
+
+    const result = await getSeriesForPost(self)
+
+    expect(postRepository.listPostsBySeries).toHaveBeenCalledWith('tfg')
+    expect(result.map((p) => p.id)).toEqual(['gathering-2025'])
   })
 })

--- a/packages/app/provider/dynamodb/repositories/post-repository.ts
+++ b/packages/app/provider/dynamodb/repositories/post-repository.ts
@@ -47,6 +47,7 @@ export interface CreatePostInput {
   lifecycle?: Post['lifecycle']
   blocks?: Post['blocks']
   status?: Post['status']
+  seriesId?: Post['seriesId']
 }
 
 /** Fields a caller may patch. Keys, id, tenant and createdAt are immutable here. */
@@ -61,6 +62,7 @@ export type UpdatePostInput = Partial<
     | 'lifecycle'
     | 'blocks'
     | 'status'
+    | 'seriesId'
   >
 >
 
@@ -84,6 +86,19 @@ export interface ListPostsResult {
 /** The date a post sorts by in gsi2: its publishDate, else its createdAt. */
 function sortDate(lifecycle: Post['lifecycle'] | undefined, createdAt: string): string {
   return lifecycle?.publishDate || createdAt
+}
+
+/**
+ * Mint a fresh block id for a duplicated post. Same compact time+random
+ * scheme as the client editor's `genId` (packages/ui/src/post-editor/
+ * post-reducer.ts) so server- and client-minted block ids are
+ * indistinguishable — duplicated here (rather than imported) so this
+ * server-side repository stays free of a `packages/ui` dependency
+ * (CLAUDE.md cross-platform layering: shared data code never reaches into UI).
+ */
+function mintBlockId(prefix = 'blk'): string {
+  const rand = Math.random().toString(36).slice(2, 10)
+  return `${prefix}_${Date.now().toString(36)}_${rand}`
 }
 
 /**
@@ -160,6 +175,7 @@ export class PostRepository extends BaseRepository<PostRecord> {
       createdAt: now,
       updatedAt: now,
       status: input.status ?? 'draft',
+      seriesId: input.seriesId,
     }
 
     const record: PostRecord = {
@@ -269,6 +285,78 @@ export class PostRepository extends BaseRepository<PostRecord> {
     } while (lastKey)
 
     return posts
+  }
+
+  /**
+   * List every post sharing a `seriesId` (Connect/series, Consolidated CMS
+   * epic #131). Series are small (a handful of related posts), so — like
+   * {@link listAllPosts} — a filtered scan mirrors the existing query style
+   * instead of adding a dedicated GSI for what is, today, a rare lookup.
+   */
+  async listPostsBySeries(seriesId: string): Promise<Post[]> {
+    if (!seriesId) return []
+    const posts: Post[] = []
+    let lastKey: Record<string, any> | undefined
+
+    do {
+      const result = await this.scan({
+        filterExpression: 'begins_with(pkey, :prefix) AND seriesId = :seriesId',
+        expressionAttributeValues: { ':prefix': 'POST#', ':seriesId': seriesId },
+        lastEvaluatedKey: lastKey,
+      })
+      posts.push(...result.items.map(PostRepository.toPost))
+      lastKey = result.lastEvaluatedKey
+    } while (lastKey)
+
+    return posts
+  }
+
+  /**
+   * Duplicate a post's STRUCTURE into a fresh draft (Consolidated CMS epic
+   * #131 "Duplicate/replicate"): so an annual gathering or study day isn't
+   * rebuilt from scratch every year. Deep-clones `blocks` with FRESH block ids
+   * (mirrors the client editor's `genId` scheme — see {@link mintBlockId}) so
+   * neither post's blocks alias the other's. `title`/`occasion`/`blocks`
+   * (structure) carry over verbatim for the author to edit; `id`/`createdAt`/
+   * `updatedAt` are freshly minted by {@link createPost} and `status` resets to
+   * `'draft'`.
+   *
+   * `seriesId` = the source's existing series, or a brand-new one — either way
+   * the source AND the new draft end up sharing ONE seriesId (Connect/series:
+   * "a duplicate auto-joins the original's series"). When the source had no
+   * `seriesId` yet, it is retroactively updated to the new series id so the
+   * pair is linked from both sides.
+   *
+   * `authorId` is caller-supplied (never trusts a client body — mirrors
+   * {@link createPost}'s convention; the API route derives it from the session).
+   */
+  async duplicatePost(id: string, authorId: string): Promise<Post> {
+    const source = await this.getPost(id)
+    if (!source) throw new Error(`Post ${id} not found`)
+
+    const seriesId = source.seriesId ?? uuidv4()
+    if (!source.seriesId) {
+      await this.updatePost(source.id, { seriesId })
+    }
+
+    const blocks = source.blocks.map((block) => ({
+      ...(JSON.parse(JSON.stringify(block)) as typeof block),
+      id: mintBlockId(),
+    }))
+
+    return this.createPost({
+      tenant: source.tenant,
+      authorId,
+      title: source.title,
+      occasion: source.occasion,
+      summary: source.summary,
+      visibility: source.visibility,
+      sharingScope: source.sharingScope,
+      lifecycle: { ...source.lifecycle },
+      blocks,
+      status: 'draft',
+      seriesId,
+    })
   }
 }
 

--- a/packages/app/provider/get-data.ts
+++ b/packages/app/provider/get-data.ts
@@ -537,3 +537,31 @@ export const updatePost = async (id: string, patch: Partial<Post>): Promise<Post
   }
   return await response.json()
 }
+
+/**
+ * Duplicate/replicate (Consolidated CMS epic #131): clone a post's structure
+ * (title/occasion/blocks, fresh block ids) into a brand-new draft that
+ * auto-joins the source's series (Connect/series). Returns the new draft —
+ * callers navigate to `/admin/posts/{newId}`.
+ */
+export const duplicatePost = async (id: string): Promise<Post> => {
+  const url = `${API_PATH}api/admin/posts/${encodeURIComponent(id)}/duplicate`
+  const response = await fetch(url, { cache: 'no-store', method: 'POST' })
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}))
+    throw new Error(data.error || `Failed to duplicate post (${response.status})`)
+  }
+  return await response.json()
+}
+
+/**
+ * Connect/series (Consolidated CMS epic #131): the other posts sharing this
+ * post's `seriesId` (empty array when it isn't part of a series). Powers the
+ * "part of a series — N related" indicator.
+ */
+export const getPostSeries = async (id: string): Promise<Post[]> => {
+  const url = `${API_PATH}api/admin/posts/${encodeURIComponent(id)}/series`
+  const response = await fetch(url, { cache: 'no-store' })
+  if (!response.ok) throw new Error(`Failed to load post series (${response.status})`)
+  return await response.json()
+}

--- a/packages/app/services/post-service.ts
+++ b/packages/app/services/post-service.ts
@@ -142,3 +142,15 @@ export async function getPostsForViewer(
   const withState = await getPostsForViewerWithState(viewer, options)
   return withState.map((w) => w.post)
 }
+
+/**
+ * Connect/series (Consolidated CMS epic #131): the OTHER posts sharing
+ * `post.seriesId` — excludes `post` itself. Empty when the post has no
+ * `seriesId` (not part of a series). Unredacted — this is the admin-facing
+ * "part of a series" read (editor / posts list), not a public surface.
+ */
+export async function getSeriesForPost(post: Post): Promise<Post[]> {
+  if (!post.seriesId) return []
+  const members = await postRepository.listPostsBySeries(post.seriesId)
+  return members.filter((p) => p.id !== post.id)
+}

--- a/packages/app/types/post.ts
+++ b/packages/app/types/post.ts
@@ -216,6 +216,16 @@ export interface Post {
   occasion: OccasionTag[] // DATA, not a code path
   summary?: string // short, PII-safe headline/teaser (public floor)
 
+  /**
+   * pii:'none' — shared id linking related Posts into ONE story/series (design
+   * "Connect/series"): a death's separate events (funeral, celebration-of-life
+   * weeks later), or a recurring annual gathering's yearly instances. Posts
+   * with the same `seriesId` cross-reference and can be browsed as a series.
+   * Unset for a post with no known relations. Never PII — just an internal
+   * grouping id, so the redactor carries it through unchanged.
+   */
+  seriesId?: string
+
   // Reach — coarse gate resolved vs viewer tier.
   visibility: Visibility
   sharingScope: SharingScope

--- a/packages/ui/src/post-editor/post-editor.tsx
+++ b/packages/ui/src/post-editor/post-editor.tsx
@@ -30,9 +30,28 @@ export interface PostEditorProps {
   value: Post
   onChange: (next: Post) => void
   onPublish?: (post: Post) => void
+  /**
+   * Connect/series (Consolidated CMS epic #131): the OTHER posts sharing
+   * `value.seriesId`, for the "part of a series — N related" indicator. Omit
+   * (or pass an empty array) to hide it — e.g. while the page's own series
+   * fetch is still loading, or the post has no `seriesId`.
+   */
+  seriesPosts?: Array<{ id: string; title: string }>
+  /**
+   * Navigate to a sibling series post. Platform navigation (next/navigation on
+   * web, a different stack on native) is kept OUT of this shared editor —
+   * the page supplies it, same as auth state elsewhere in this package.
+   */
+  onSeriesPostPress?: (postId: string) => void
 }
 
-export function PostEditor({ value, onChange, onPublish }: PostEditorProps) {
+export function PostEditor({
+  value,
+  onChange,
+  onPublish,
+  seriesPosts,
+  onSeriesPostPress,
+}: PostEditorProps) {
   const dispatch = (action: PostAction) => onChange(postReducer(value, action))
   const [toolbarExpanded, setToolbarExpanded] = useState(true)
 
@@ -152,6 +171,27 @@ export function PostEditor({ value, onChange, onPublish }: PostEditorProps) {
           </YStack>
         </XStack>
       </Card>
+
+      {/* ---- Connect/series indicator ---------------------------------------- */}
+      {(seriesPosts?.length ?? 0) > 0 ? (
+        <Card bordered padding="$3" gap="$2" backgroundColor="$blue2">
+          <Text fontSize="$3" fontWeight="600">
+            Part of a series — {seriesPosts!.length} related
+          </Text>
+          <XStack gap="$2" flexWrap="wrap">
+            {seriesPosts!.map((sibling) => (
+              <Button
+                key={sibling.id}
+                size="$2"
+                chromeless
+                onPress={() => onSeriesPostPress?.(sibling.id)}
+              >
+                {sibling.title || 'Untitled post'}
+              </Button>
+            ))}
+          </XStack>
+        </Card>
+      ) : null}
 
       {/* ---- Block canvas --------------------------------------------------- */}
       <YStack gap="$3">


### PR DESCRIPTION
Two Ken-requested features on the unified model. Additive, flag-gated.

## Connect / series
- `Post.seriesId?: string` (`pii:'none'`) links related Posts into one story: a death's separate events (funeral → celebration weeks later), or a recurring gathering's yearly instances. Redactor carries it through; adapter doesn't set it.
- `PostRepository.listPostsBySeries` + `getSeriesForPost` + `GET /api/admin/posts/[id]/series`; the editor shows **"Part of a series — N related"** with clickable siblings (nav via props, kept out of `packages/ui`).

## Duplicate / replicate
- `duplicatePost(id)` → fresh `id`/`createdAt`/`updatedAt`/`status:'draft'` + **fresh block ids** (deep clone); carries title/occasion/blocks/summary/visibility/lifecycle; **shares the source's `seriesId`** (minted + retroactively backlinked if the source had none). `POST /api/admin/posts/[id]/duplicate` (owner/admin + flag gate) + a per-row **Duplicate** button on the posts list → new draft → navigate. Perfect for annual gatherings/study-days — no rebuild from scratch.
- **Deferred:** manual 'link two arbitrary posts' UI (plumbing complete, trivial to add).

## Verify
- **68 tests** (duplicate clone semantics, series query, redactor carry, both routes' owner/admin + `CONSOLIDATED_CMS` gates). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)