### PR TITLE
CONSOLIDATED_CMS 4b-1 — gradual cutover: native Posts on the live events/news pages (#131)

### DIFF
--- a/apps/next/app/(public)/news/page.tsx
+++ b/apps/next/app/(public)/news/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import React, { useEffect, useState } from 'react'
-import { H1, Paragraph, Spinner, YStack } from '@my/ui'
+import { H1, Paragraph, PostView, Spinner, YStack } from '@my/ui'
 import { useHydrated } from '@my/app/hooks/use-hydrated'
 import { NewsCard } from '@my/ui/src/news/news-card'
 import type { NewsItem } from '@my/app/types/news'
+import type { Post } from '@my/app/types/post'
 import { getPreviewImageUrl } from '@my/app/types/events'
 
 export default function NewsListPage() {
@@ -12,6 +13,11 @@ export default function NewsListPage() {
   const [items, setItems] = useState<NewsItem[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  // Consolidated CMS #131 (Phase 4b-1): native, news-shaped Posts surfaced
+  // ADDITIVELY. Empty when the CONSOLIDATED_CMS flag is OFF (server returns
+  // `{ news: [] }`), so the section below renders nothing and the legacy list
+  // above is byte-identical to today.
+  const [nativeNews, setNativeNews] = useState<Post[]>([])
 
   useEffect(() => {
     let cancelled = false
@@ -28,6 +34,23 @@ export default function NewsListPage() {
       })
       .finally(() => {
         if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Additive, flag-gated native Posts. Isolated from the legacy fetch above so a
+  // failure here can never affect the existing news list.
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/posts/public')
+      .then((r) => (r.ok ? r.json() : { news: [] }))
+      .then((data) => {
+        if (!cancelled) setNativeNews(Array.isArray(data?.news) ? data.news : [])
+      })
+      .catch(() => {
+        /* additive surface — ignore, leave native section empty */
       })
     return () => {
       cancelled = true
@@ -68,6 +91,19 @@ export default function NewsListPage() {
           ))}
         </YStack>
       )}
+
+      {/* Native Posts (Consolidated CMS #131) — a clearly-labelled section rather
+          than interleaved: legacy news uses compact NewsCards while native posts
+          render the full read-only PostView, so keeping them distinct reads far
+          cleaner than mixing the two inline. Skipped entirely when the flag is
+          OFF (empty array). */}
+      {nativeNews.length > 0 ? (
+        <YStack gap="$4">
+          {nativeNews.map((post) => (
+            <PostView key={post.id} post={post} />
+          ))}
+        </YStack>
+      ) : null}
     </YStack>
   )
 }

--- a/apps/next/app/api/posts/public/route.ts
+++ b/apps/next/app/api/posts/public/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+import { getPublicPosts } from '../../../../utils/get-public-posts'
+
+/**
+ * Public unified-Post read for the live web pages (Consolidated CMS #131,
+ * Phase 4b-1). Returns the ACTIVE, viewer-redacted NATIVE posts split by facet:
+ * `{ events, news }` — the events page renders `events`, the news page renders
+ * `news`, each via the shared read-only `<PostView>`.
+ *
+ * ADDITIVE + FLAG-GATED: with `CONSOLIDATED_CMS` OFF this returns
+ * `{ events: [], news: [] }` (see {@link getPublicPosts}) so the live pages show
+ * nothing extra and stay byte-identical to today. Legacy events/news render
+ * through their OWN untouched endpoints (`/api/events/public`, `/api/news`) — this
+ * route never double-renders them.
+ *
+ * Per-viewer + PII-aware, so it is never shared-cached (private, no-store).
+ */
+export async function GET() {
+  try {
+    const posts = await getPublicPosts()
+    return NextResponse.json(posts, {
+      headers: {
+        'Cache-Control': 'private, no-store',
+        Vary: 'Cookie',
+      },
+    })
+  } catch (error) {
+    // Additive surface — a native-post read failure must NOT break the legacy
+    // page. Fail closed to "nothing extra".
+    console.error('Error loading public posts:', error)
+    return NextResponse.json({ events: [], news: [] })
+  }
+}

--- a/apps/next/tests/get-public-posts.test.ts
+++ b/apps/next/tests/get-public-posts.test.ts
@@ -1,0 +1,136 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import type { Post } from '@my/app/types/post'
+
+/**
+ * Public-page unified-Post read (Consolidated CMS #131, Phase 4b-1).
+ *
+ * The safety-critical bits: the block is HIDDEN while the CONSOLIDATED_CMS flag
+ * is OFF (returns nothing extra → live pages byte-identical); only NATIVE posts
+ * are surfaced (legacy events/news are NOT pulled in here, so nothing double-
+ * renders); drafts never leak; and active native posts are split by lifecycle
+ * facet (event-shaped → events page, news-shaped → news page) at an injected
+ * `now`. The data sources are stubbed, but `getPostsForViewer`, the lifecycle
+ * engine and `redactPost` are left REAL so the pipeline is genuinely exercised.
+ */
+
+const h = vi.hoisted(() => ({
+  auth: vi.fn(),
+  checkFlag: vi.fn(),
+  resolveViewer: vi.fn(),
+  listAllPosts: vi.fn(),
+  getPublishedEvents: vi.fn(),
+  listNewsItems: vi.fn(),
+}))
+
+vi.mock('../utils/auth', () => ({ auth: h.auth }))
+vi.mock('../utils/resolve-viewer', () => ({ resolveViewer: h.resolveViewer }))
+vi.mock('@my/app/features/feature-flags/use-feature-flag-wrapper', () => ({
+  checkFeatureFlagFromDB: h.checkFlag,
+}))
+vi.mock('@my/app/provider/dynamodb/repositories/post-repository', () => ({
+  postRepository: { listAllPosts: h.listAllPosts, listPosts: vi.fn() },
+}))
+vi.mock('@my/app/services/event-service', () => ({ getPublishedEvents: h.getPublishedEvents }))
+vi.mock('@my/app/services/news-service', () => ({ listNewsItems: h.listNewsItems }))
+
+import { getPublicPosts } from '../utils/get-public-posts'
+import type { Viewer } from '@my/app/utils/viewer-pii'
+
+const member: Viewer = {
+  assurance: 'authenticated',
+  role: 'member',
+  tenant: 'Toronto East',
+  email: 'm@x.z',
+}
+
+// 2026-07-05: everything published 2026-07-01 is still inside its window.
+const NOW = new Date('2026-07-05T00:00:00.000Z')
+
+function basePost(overrides: Partial<Post>): Post {
+  return {
+    id: 'p',
+    tenant: 'Toronto East',
+    authorId: 'a',
+    title: 'Post',
+    occasion: ['general'],
+    visibility: 'public',
+    sharingScope: 'own',
+    lifecycle: { publishDate: '2026-07-01T00:00:00.000Z' },
+    blocks: [],
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    status: 'ready',
+    ...overrides,
+  }
+}
+
+// Event-shaped: a TimeBlock ~6 weeks out (upcoming at NOW) → belongs on events.
+const eventShaped = basePost({
+  id: 'event-1',
+  title: 'Wedding Shower',
+  occasion: ['shower'],
+  blocks: [{ id: 't', kind: 'time', label: 'Shower', startsAt: '2026-08-15T18:00:00.000Z' }],
+})
+
+// News-shaped: no dated happening → belongs on news (active in its window at NOW).
+const newsShaped = basePost({
+  id: 'news-1',
+  title: 'Sunday School resumes',
+  occasion: ['news'],
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.auth.mockResolvedValue(null)
+  h.checkFlag.mockResolvedValue(true)
+  h.resolveViewer.mockResolvedValue(member)
+  h.listAllPosts.mockResolvedValue([eventShaped, newsShaped])
+  h.getPublishedEvents.mockResolvedValue([])
+  h.listNewsItems.mockResolvedValue([])
+})
+
+describe('getPublicPosts — flag gate', () => {
+  it('returns nothing extra when CONSOLIDATED_CMS is OFF (repo untouched)', async () => {
+    h.checkFlag.mockResolvedValue(false)
+    const result = await getPublicPosts(NOW)
+    expect(result).toEqual({ events: [], news: [] })
+    expect(h.listAllPosts).not.toHaveBeenCalled()
+    expect(h.resolveViewer).not.toHaveBeenCalled()
+  })
+})
+
+describe('getPublicPosts — native only', () => {
+  it('never pulls in legacy events/news (no double-render of the legacy path)', async () => {
+    await getPublicPosts(NOW)
+    expect(h.getPublishedEvents).not.toHaveBeenCalled()
+    expect(h.listNewsItems).not.toHaveBeenCalled()
+  })
+})
+
+describe('getPublicPosts — facet split', () => {
+  it('splits active native posts into event-shaped vs news-shaped at `now`', async () => {
+    const { events, news } = await getPublicPosts(NOW)
+    expect(events.map((p) => p.id)).toEqual(['event-1'])
+    expect(news.map((p) => p.id)).toEqual(['news-1'])
+  })
+
+  it('drops drafts — a public surface never shows unpublished native posts', async () => {
+    h.listAllPosts.mockResolvedValue([
+      eventShaped,
+      basePost({ id: 'draft-1', title: 'Draft', status: 'draft' }),
+    ])
+    const { events, news } = await getPublicPosts(NOW)
+    const allIds = [...events, ...news].map((p) => p.id)
+    expect(allIds).not.toContain('draft-1')
+  })
+
+  it('drops posts that are not active at `now` (lifecycle gate)', async () => {
+    // At 2026-09-01 the news-shaped fixture (published 07-01, 2-week window) has
+    // expired; the shower (event 08-15) has also passed → both gone.
+    const { events, news } = await getPublicPosts(new Date('2026-09-01T00:00:00.000Z'))
+    expect(events).toEqual([])
+    // The shower is now news-shaped (event passed) but its retrospective window
+    // (2 weeks after 08-15 ≈ 08-29) has also ended → dropped.
+    expect(news).toEqual([])
+  })
+})

--- a/apps/next/utils/get-public-posts.ts
+++ b/apps/next/utils/get-public-posts.ts
@@ -1,0 +1,69 @@
+import { auth } from './auth'
+import { resolveViewer } from './resolve-viewer'
+import { getPostsForViewer } from '@my/app/services/post-service'
+import { resolvePostNextDate } from '@my/app/utils/post-lifecycle'
+import { checkFeatureFlagFromDB } from '@my/app/features/feature-flags/use-feature-flag-wrapper'
+import { FEATURE_FLAGS } from '@my/app/features/feature-flags/feature-flags'
+import type { Post } from '@my/app/types/post'
+
+/** Active native posts for a public page, split by lifecycle facet. */
+export interface PublicPosts {
+  /** Event-shaped: has an upcoming happening at `now` → belongs on the events page. */
+  events: Post[]
+  /** News-shaped: no upcoming happening (none, or all past) → belongs on the news page. */
+  news: Post[]
+}
+
+const EMPTY: PublicPosts = { events: [], news: [] }
+
+/**
+ * THE public-page read for the unified Post model (Consolidated CMS #131,
+ * Phase 4b-1 — gradual cutover of the live web pages).
+ *
+ * This is the ADDITIVE half of the cutover: it surfaces NATIVE Posts (content
+ * authored in the block editor) alongside the existing legacy events/news, which
+ * keep rendering through their OWN untouched paths. It mirrors the discipline of
+ * {@link getPublicPost} (the single-post read):
+ *
+ *   1. FLAG OFF → `{ events: [], news: [] }`. `CONSOLIDATED_CMS` gates the whole
+ *      feature; while it's OFF this returns nothing extra and the live pages are
+ *      byte-identical to today (fails closed on any flag-store error).
+ *   2. Native-ONLY (`source: 'native'`) — legacy events/news are NOT pulled in
+ *      here (they render via their existing path), so nothing double-renders.
+ *      Native and legacy are disjoint today (no migration), so no dedup is needed.
+ *   3. `getPostsForViewer` already redacts for the resolved viewer at the hard
+ *      `public-web` tier and lifecycle-filters to ACTIVE at `now` — so a surname /
+ *      precise address is present only if this viewer may see it, and only
+ *      currently-active posts survive.
+ *   4. Drafts/archived never leak: only `status: 'ready'` posts are kept (the
+ *      unified read does not itself filter status — this public door does).
+ *
+ * Facet split uses the ONE lifecycle engine: {@link resolvePostNextDate} — a post
+ * with an upcoming happening is event-shaped (events page), otherwise news-shaped
+ * (news page). `now` is INJECTABLE so callers/tests are deterministic.
+ */
+export async function getPublicPosts(now: Date = new Date()): Promise<PublicPosts> {
+  // Flag gate first — feature hidden entirely while OFF.
+  const session = await auth()
+  const flagOn = await checkFeatureFlagFromDB(FEATURE_FLAGS.CONSOLIDATED_CMS, session as any)
+  if (!flagOn) return EMPTY
+
+  const viewer = await resolveViewer()
+  // native only — legacy keeps its own render path (no double-render); redacted +
+  // lifecycle-filtered to active by getPostsForViewer.
+  const posts = await getPostsForViewer(viewer, {
+    channel: 'public-web',
+    source: 'native',
+    now,
+  })
+
+  const events: Post[] = []
+  const news: Post[] = []
+  for (const post of posts) {
+    // A public surface never shows drafts/archived (unified read doesn't gate status).
+    if (post.status !== 'ready') continue
+    if (resolvePostNextDate(post, now)) events.push(post)
+    else news.push(post)
+  }
+  return { events, news }
+}

--- a/packages/app/features/events/index.tsx
+++ b/packages/app/features/events/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 import React, { useState, useEffect } from 'react'
 import { Wrapper } from '@my/app/provider/wrapper'
-import { Button, Heading, Paragraph } from '@my/ui'
+import { Button, Heading, Paragraph, PostView } from '@my/ui'
 import { useRouter } from 'solito/navigation'
 import { StudyWeekend2024 } from '@my/app/features/events/study-weekend-2024'
 import { XStack, YStack, Card, Text } from 'tamagui'
@@ -9,6 +9,7 @@ import { Section } from '@my/app/features/newsletter/Section'
 import { EventSummaryCard } from '@my/ui/src/events/event-summary-card'
 import { EventDetailView } from '@my/ui/src/events/event-detail-view'
 import { Event, isEventActive } from '@my/app/types/events'
+import type { Post } from '@my/app/types/post'
 
 export type BackLink = {
   href: string
@@ -51,6 +52,11 @@ export const EventListing: React.FC<EventListingProps> = ({ isNotFound, userRole
   const [events, setEvents] = useState<Event[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  // Consolidated CMS #131 (Phase 4b-1): native, event-shaped Posts surfaced
+  // ADDITIVELY. Empty when the CONSOLIDATED_CMS flag is OFF (server returns
+  // `{ events: [] }`), so the section below renders nothing and the legacy list
+  // above is byte-identical to today.
+  const [nativeEvents, setNativeEvents] = useState<Post[]>([])
 
   useEffect(() => {
     const fetchEvents = async () => {
@@ -71,6 +77,23 @@ export const EventListing: React.FC<EventListingProps> = ({ isNotFound, userRole
     }
 
     fetchEvents()
+  }, [])
+
+  // Additive, flag-gated native Posts. Isolated from the legacy fetch above so a
+  // failure here can never affect the existing events list.
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/posts/public')
+      .then((r) => (r.ok ? r.json() : { events: [] }))
+      .then((data) => {
+        if (!cancelled) setNativeEvents(Array.isArray(data?.events) ? data.events : [])
+      })
+      .catch(() => {
+        /* additive surface — ignore, leave native section empty */
+      })
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   const handleEventPress = (eventId: string) => {
@@ -124,6 +147,22 @@ export const EventListing: React.FC<EventListingProps> = ({ isNotFound, userRole
           <Paragraph>No events found.</Paragraph>
         </Section>
       )}
+
+      {/* Native Posts (Consolidated CMS #131) — rendered in a clearly-labelled
+          section rather than interleaved: legacy events use compact summary
+          cards (click → detail) while native posts render the full read-only
+          PostView, so a distinct section reads far cleaner than mixing the two
+          card styles inline. Skipped entirely when the flag is OFF (empty array). */}
+      {nativeEvents.length > 0 ? (
+        <Section>
+          <Heading size={5}>More upcoming events</Heading>
+          <YStack gap="$4">
+            {nativeEvents.map((post) => (
+              <PostView key={post.id} post={post} />
+            ))}
+          </YStack>
+        </Section>
+      ) : null}
     </Wrapper>
   )
 }

--- a/packages/app/services/post-service.ts
+++ b/packages/app/services/post-service.ts
@@ -48,6 +48,15 @@ export interface GetPostsOptions {
    * window) are dropped.
    */
   now?: Date
+  /**
+   * Which underlying sources to merge (Phase 4b-1). Defaults to `'all'` — the
+   * historical behaviour: native {@link PostRepository} posts PLUS legacy events
+   * + news adapted through {@link legacyToPost}. `'native'` returns ONLY id-backed
+   * native posts (legacy is skipped entirely — not even fetched); `'legacy'`
+   * returns only the adapted legacy set. The public-web cutover uses `'native'`
+   * so legacy records keep rendering through their OWN path with no double-render.
+   */
+  source?: 'all' | 'native' | 'legacy'
 }
 
 /** A viewer-ready Post plus its lifecycle state (whether `now` is its eve-of reminder). */
@@ -103,9 +112,10 @@ export async function getPostsForViewerWithState(
   viewer: Viewer,
   options: GetPostsOptions = {}
 ): Promise<PostWithDisplayState[]> {
+  const source = options.source ?? 'all'
   const [native, legacy] = await Promise.all([
-    loadNativePosts(options),
-    loadLegacyPosts(options),
+    source === 'legacy' ? Promise.resolve<Post[]>([]) : loadNativePosts(options),
+    source === 'native' ? Promise.resolve<Post[]>([]) : loadLegacyPosts(options),
   ])
 
   const now = options.now ?? new Date()


### PR DESCRIPTION
Phase 4b-1 of #131 — gradual cutover (option A) of the public web pages. **Additive**; flag-OFF byte-identical.

## What
Flag ON → the live events + news pages show today's legacy content **plus** the active **native** Posts, rendered via the built `PostView` in a labelled section. Flag OFF → nothing extra; **legacy render paths untouched**.

- **`get-public-posts.ts`** (new) — the public read: fail-closed flag gate → `resolveViewer` → `getPostsForViewer(viewer,{channel:'public-web', source:'native', now})` (redacted + lifecycle-filtered to active) → `status:'ready'` only (drafts never leak) → split by `resolvePostNextDate` into **event-shaped** (events page) vs **news-shaped** (news page).
- **`/api/posts/public`** (new) — additive, `private,no-store`, returns `{events:[],news:[]}` when flag off, fails closed to empty on error (can never break the legacy page).
- **`source: 'native'|'legacy'|'all'`** added to `getPostsForViewer` — native-only here so legacy is never double-rendered (native + legacy are disjoint today).
- Pages: `EventListing` + news page gain an isolated additive fetch + `PostView` section.

## Flag-OFF proof
Legacy `EventSummaryCard`/`NewsCard` paths + `/api/events/public`/`/api/news` are untouched; the native block is a separate `useEffect` + `length>0 ? <section> : null`. Flag off → empty arrays → DOM unchanged. Asserted (repo never touched when off).

## Design note
Native posts render as full `PostView` in an **adjacent labelled section** (not interleaved with the compact legacy cards) — keeps the legacy path 100% untouched and avoids mixing card styles; the section grows/legacy shrinks as content moves to native. Fine for the transitional/gradual phase; you eyeball on preview before flipping.

## Verify
- **51 tests** (flag-off empty + repo-untouched; native-only; facet split; ready-only). Typecheck clean; build compiles (pre-existing GOOGLE-key route aside).

Next: **4b-2** — the newsletter (needs an email-flavored Post renderer), where the shower-stays-in-the-Thursday-email payoff lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)