### PR TITLE
CONSOLIDATED_CMS 4b-2 — native Posts in the newsletter email (the shower-stays-in payoff) (#131)

### DIFF
--- a/apps/email-builder/components/PostEmailView.tsx
+++ b/apps/email-builder/components/PostEmailView.tsx
@@ -1,0 +1,337 @@
+import React from 'react'
+import { Column, Heading, Img, Link, Row, Section, Text } from '@react-email/components'
+import type {
+  Block,
+  FlyerBlock,
+  LinkBlock,
+  LocationBlock,
+  PersonBlock,
+  Post,
+  RegistrationBlock,
+  TextBlock,
+  TimeBlock,
+} from '@my/app/types/post'
+import { getPlatformDisplayName } from '@my/app/types/events'
+import {
+  formatDateFacet,
+  formatOccasions,
+  formatPersonName,
+  formatTimeBlock,
+  locationAddressLines,
+  locationMapsHref,
+  looksLikeImage,
+  personMetaLine,
+  personRoleLabel,
+} from '@my/ui/src/post-view/post-view-format'
+import { AutoLinkText } from './AutoLinkText'
+
+/**
+ * PostEmailView — the EMAIL render twin of the web `PostView`
+ * (packages/ui/src/post-view/post-view.tsx), for the Consolidated CMS newsletter
+ * cutover (epic #131, Phase 4b-2). Given an ALREADY-REDACTED {@link Post} it
+ * renders the header + each block as email-safe HTML, one renderer per block kind,
+ * mirroring `PostView`'s 7-kind coverage so the two surfaces stay in lock-step.
+ *
+ * CONTRACT (identical to `PostView`): `post` MUST be the output of
+ * `redactPost(post, viewer, { channel: 'newsletter-email' })`. This component does
+ * NO gating and NO PII scrubbing — a surname / precise address / bio is present
+ * here ONLY because the redactor chose to reveal it (the newsletter goes to the
+ * member audience, so the channel reveals full PII, design §8.2).
+ *
+ * SERVER-SAFE (critical — the react-email `render()` runs from an App Router server
+ * route: the cron newsletter). This module imports ONLY:
+ *   - `@react-email/components` (server render primitives),
+ *   - the sibling `AutoLinkText` (a server component — no `'use client'`),
+ *   - the PURE, platform-free `post-view-format` helpers, and
+ *   - pure types.
+ * It imports NO `'use client'` module (provider OR hook), NO React context/hooks,
+ * NO `packages/ui` React component / Tamagui — so it cannot throw the "client
+ * module in a server render" failure that would silently break the live cron
+ * newsletter. All data arrives as PROPS.
+ */
+export interface PostEmailViewProps {
+  post: Post
+}
+
+// ---- shared inline styles (email-safe; mirrors the newsletter's idioms) ------
+
+const bodyText: React.CSSProperties = { fontSize: '16px', color: '#00102c', margin: '0' }
+const blockLabel: React.CSSProperties = {
+  fontSize: '13px',
+  fontWeight: 'bold',
+  color: '#5a6472',
+  textTransform: 'uppercase',
+  letterSpacing: '0.5px',
+  margin: '0 0 4px 0',
+}
+const primaryLine: React.CSSProperties = { fontSize: '16px', fontWeight: 'bold', color: '#00102c', margin: '0' }
+const metaLine: React.CSSProperties = { fontSize: '13px', color: '#5a6472', margin: '2px 0 0 0' }
+const subLine: React.CSSProperties = { fontSize: '14px', color: '#3a4453', margin: '2px 0 0 0' }
+const inlineLink: React.CSSProperties = { color: '#003da9', textDecoration: 'underline' }
+const blockSection: React.CSSProperties = { margin: '0 0 16px 0' }
+
+// ---- per-kind block renderers (mirror PostView's coverage) -------------------
+
+function TextBlockView({ block }: { block: TextBlock }) {
+  if (!block.body.trim()) return null
+  return (
+    <Section style={blockSection}>
+      <Text style={{ ...bodyText, whiteSpace: 'pre-wrap' }}>
+        <AutoLinkText text={block.body} />
+      </Text>
+    </Section>
+  )
+}
+
+function PersonBlockView({ block }: { block: PersonBlock }) {
+  if (block.people.length === 0) return null
+  return (
+    <Section style={blockSection}>
+      <Text style={blockLabel}>{personRoleLabel(block.role)}</Text>
+      {block.people.map((person) => {
+        const meta = personMetaLine(person)
+        return (
+          <Section key={person.id} style={{ margin: '0 0 8px 0' }}>
+            <Text style={primaryLine}>{formatPersonName(person)}</Text>
+            {meta ? <Text style={metaLine}>{meta}</Text> : null}
+            {person.contact ? <Text style={subLine}>{person.contact}</Text> : null}
+            {person.bio ? (
+              <Text style={{ ...subLine, whiteSpace: 'pre-wrap' }}>
+                <AutoLinkText text={person.bio} />
+              </Text>
+            ) : null}
+          </Section>
+        )
+      })}
+    </Section>
+  )
+}
+
+function LocationBlockView({ block }: { block: LocationBlock }) {
+  const lines = locationAddressLines(block)
+  const mapsHref = locationMapsHref(block)
+  const online = block.onlineMeeting
+
+  // An 'ecclesia'-mode block with no captured fields is a read-time inherit
+  // placeholder — nothing to show (mirrors PostView).
+  if (lines.length === 0 && !online && block.mode === 'ecclesia') {
+    return null
+  }
+
+  return (
+    <Section style={blockSection}>
+      <Text style={blockLabel}>{block.label || 'Location'}</Text>
+      {lines.map((line, i) => (
+        <Text key={i} style={i === 0 ? primaryLine : subLine}>
+          {line}
+        </Text>
+      ))}
+      {mapsHref ? (
+        <Text style={{ ...subLine, margin: '4px 0 0 0' }}>
+          <Link href={mapsHref} style={inlineLink}>
+            Get directions
+          </Link>
+        </Text>
+      ) : null}
+      {block.directions ? <Text style={subLine}>{block.directions}</Text> : null}
+      {block.parkingInfo ? <Text style={subLine}>Parking: {block.parkingInfo}</Text> : null}
+      {online ? (
+        <Section
+          style={{
+            margin: '8px 0 0 0',
+            padding: '8px 12px',
+            borderRadius: '6px',
+            backgroundColor: '#eef2f8',
+          }}
+        >
+          <Text style={{ ...primaryLine, fontSize: '14px' }}>
+            {online.platform ? getPlatformDisplayName(online.platform) : 'Online meeting'}
+          </Text>
+          {online.link ? (
+            <Text style={{ ...subLine, margin: '4px 0 0 0' }}>
+              <Link href={online.link} style={inlineLink}>
+                Join online
+              </Link>
+            </Text>
+          ) : null}
+          {online.meetingId ? <Text style={subLine}>Meeting ID: {online.meetingId}</Text> : null}
+          {online.password ? <Text style={subLine}>Password: {online.password}</Text> : null}
+          {online.dialInNumber ? <Text style={subLine}>Dial-in: {online.dialInNumber}</Text> : null}
+          {online.additionalInfo ? <Text style={subLine}>{online.additionalInfo}</Text> : null}
+        </Section>
+      ) : null}
+    </Section>
+  )
+}
+
+function TimeBlockView({ block }: { block: TimeBlock }) {
+  const { label, dateLine, timeLine } = formatTimeBlock(block)
+  if (!dateLine && !timeLine && !label) return null
+  return (
+    <Section style={blockSection}>
+      <Text style={blockLabel}>{label || 'Date & time'}</Text>
+      {dateLine ? <Text style={primaryLine}>{dateLine}</Text> : null}
+      {timeLine ? <Text style={subLine}>{timeLine}</Text> : null}
+    </Section>
+  )
+}
+
+function FlyerBlockView({ block }: { block: FlyerBlock }) {
+  const { document } = block
+  const url = document.fileUrl?.trim()
+  if (!url) return null
+
+  const title = document.originalName || 'Attachment'
+  const isImage = looksLikeImage(url, document.mimeType)
+  const imageSrc = isImage ? url : document.thumbnailUrl
+
+  return (
+    <Section style={blockSection}>
+      <Text style={blockLabel}>Flyer</Text>
+      {imageSrc ? (
+        <Img
+          src={imageSrc}
+          alt={title}
+          style={{
+            width: '100%',
+            maxWidth: '480px',
+            height: 'auto',
+            borderRadius: '6px',
+            border: '1px solid #dee2e6',
+          }}
+        />
+      ) : null}
+      {document.description ? <Text style={subLine}>{document.description}</Text> : null}
+      <Text style={{ ...subLine, margin: '4px 0 0 0' }}>
+        <Link href={url} style={inlineLink}>
+          {isImage ? `View ${title}` : `Open ${title}`}
+        </Link>
+      </Text>
+    </Section>
+  )
+}
+
+function RegistrationBlockView({ block }: { block: RegistrationBlock }) {
+  const hasAnything =
+    block.required ||
+    block.deadline ||
+    block.registrationUrl ||
+    block.contactEmail ||
+    block.contactPhone ||
+    block.hasFee ||
+    block.notes
+  if (!hasAnything) return null
+
+  return (
+    <Section style={blockSection}>
+      <Text style={blockLabel}>Registration</Text>
+      {block.required ? <Text style={primaryLine}>Registration required</Text> : null}
+      {block.deadline ? <Text style={subLine}>Deadline: {block.deadline}</Text> : null}
+      {block.hasFee ? (
+        <Text style={subLine}>
+          Fee: {typeof block.fee === 'number' ? `$${block.fee}` : 'see details'}
+        </Text>
+      ) : null}
+      {block.paymentInstructions ? <Text style={subLine}>{block.paymentInstructions}</Text> : null}
+      {block.contactEmail ? (
+        <Text style={subLine}>
+          <Link href={`mailto:${block.contactEmail}`} style={inlineLink}>
+            {block.contactEmail}
+          </Link>
+        </Text>
+      ) : null}
+      {block.contactPhone ? <Text style={subLine}>{block.contactPhone}</Text> : null}
+      {block.notes ? <Text style={subLine}>{block.notes}</Text> : null}
+      {block.registrationUrl ? (
+        <Text style={{ ...subLine, margin: '4px 0 0 0' }}>
+          <Link href={block.registrationUrl} style={inlineLink}>
+            Register
+          </Link>
+        </Text>
+      ) : null}
+    </Section>
+  )
+}
+
+function LinkBlockView({ block }: { block: LinkBlock }) {
+  const url = block.url?.trim()
+  if (!url) return null
+  return (
+    <Section style={blockSection}>
+      <Text style={bodyText}>
+        <Link href={url} style={inlineLink}>
+          {block.label || url}
+        </Link>
+      </Text>
+    </Section>
+  )
+}
+
+/** Render a single block by kind — mirrors the editor/PostView 7-kind coverage. */
+function BlockView({ block }: { block: Block }) {
+  switch (block.kind) {
+    case 'text':
+      return <TextBlockView block={block} />
+    case 'person':
+      return <PersonBlockView block={block} />
+    case 'location':
+      return <LocationBlockView block={block} />
+    case 'time':
+      return <TimeBlockView block={block} />
+    case 'flyer':
+      return <FlyerBlockView block={block} />
+    case 'registration':
+      return <RegistrationBlockView block={block} />
+    case 'link':
+      return <LinkBlockView block={block} />
+    default:
+      return null
+  }
+}
+
+export function PostEmailView({ post }: PostEmailViewProps) {
+  const dateFacet = formatDateFacet(post)
+  const occasions = formatOccasions(post.occasion)
+
+  return (
+    <Section style={{ margin: '0 0 8px 0' }}>
+      {/* ---- Header ---- */}
+      {occasions ? (
+        <Text
+          style={{
+            fontSize: '12px',
+            fontWeight: 'bold',
+            color: '#5a6472',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+            margin: '0 0 2px 0',
+          }}
+        >
+          {occasions}
+        </Text>
+      ) : null}
+      <Heading style={{ fontSize: '20px', fontWeight: 'bold', color: '#00102c', margin: '0 0 4px 0' }}>
+        {post.title || 'Untitled'}
+      </Heading>
+      {dateFacet ? (
+        <Row>
+          <Column>
+            <Text style={{ fontSize: '14px', color: '#3a4453', margin: '0 0 8px 0' }}>{dateFacet}</Text>
+          </Column>
+        </Row>
+      ) : null}
+      {post.summary ? (
+        <Text style={{ fontSize: '15px', color: '#3a4453', margin: '0 0 12px 0' }}>{post.summary}</Text>
+      ) : null}
+
+      {/* ---- Blocks ---- */}
+      {post.blocks.length === 0 ? (
+        <Text style={metaLine}>This post has no content to display.</Text>
+      ) : (
+        post.blocks.map((block) => <BlockView key={block.id} block={block} />)
+      )}
+    </Section>
+  )
+}
+
+export default PostEmailView

--- a/apps/email-builder/emails/Newsletter.tsx
+++ b/apps/email-builder/emails/Newsletter.tsx
@@ -16,6 +16,8 @@ import React from 'react'
 import { BibleClassType, MemorialServiceType, ProgramsTypes, SundaySchoolType } from '@my/app/types'
 import { Event } from '@my/app/types/events'
 import type { NewsItem } from '@my/app/types/news'
+import type { Post } from '@my/app/types/post'
+import { PostEmailView } from '../components/PostEmailView'
 import { FooterContent } from '../components/FooterContent'
 import { EmailBrandLinkContent } from '../components/EmailBrandLinkContent'
 import type { EmailIdentity } from '@my/app/types/brand-profile'
@@ -686,6 +688,15 @@ interface EmailNewsletterProps {
   note?: string
   /** Active news items (Issue #41) — rendered before events, dateless, no section heading */
   newsItems?: NewsItem[]
+  /**
+   * Active NATIVE Posts (Consolidated CMS #131, Phase 4b-2) — ADDITIVE, rendered
+   * in a "Community Posts" section via {@link PostEmailView}. ALREADY redacted at
+   * member tier + lifecycle-filtered by the caller. Defaults to `[]` (none): the
+   * caller passes posts ONLY when the CONSOLIDATED_CMS flag is on, so with the
+   * flag OFF this is empty and the section renders nothing → newsletter is
+   * BYTE-IDENTICAL to today.
+   */
+  posts?: Post[]
   /** Per-ecclesia service times — replaces hardcoded "9:30am" / "11:00am" */
   serviceTimes?: {
     sundaySchool?: ServiceTimeDisplay
@@ -708,6 +719,7 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
   newsItems = [],
   serviceTimes,
   identity,
+  posts = [],
 }) => {
   const todaysDate = new Date().toLocaleDateString('en-US', {
     weekday: 'short',
@@ -1819,6 +1831,36 @@ const Newsletter: React.FC<EmailNewsletterProps> = ({
             </Container>
           )
         })()}
+
+        {/* Community Posts (Consolidated CMS #131, Phase 4b-2) — ADDITIVE native
+            Posts, rendered as email via the server-safe PostEmailView. `posts` is
+            passed ONLY when the CONSOLIDATED_CMS flag is on (a broadcast reads it
+            with a null session → on only at 'everyone'), so with the flag OFF this
+            is empty and renders NOTHING → the newsletter is byte-identical. */}
+        {posts.length > 0 ? (
+          <Container style={container} className="container">
+            <hr style={{ borderWidth: '0', background: '#000', color: '#000', height: '2px' }} />
+            <Heading style={defaultText}>Community Posts</Heading>
+            {posts.map((post, index) => (
+              <React.Fragment key={post.id}>
+                {index > 0 ? (
+                  <hr
+                    style={{
+                      borderWidth: '0',
+                      background: '#ccc',
+                      color: '#ccc',
+                      height: '1px',
+                      margin: '16px 0',
+                    }}
+                  />
+                ) : null}
+                <Section style={program}>
+                  <PostEmailView post={post} />
+                </Section>
+              </React.Fragment>
+            ))}
+          </Container>
+        ) : null}
 
         {/* Learn to Read the Bible Seminars */}
         {(() => {

--- a/apps/next/tests/get-newsletter-posts.test.ts
+++ b/apps/next/tests/get-newsletter-posts.test.ts
@@ -1,0 +1,149 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import type { Post } from '@my/app/types/post'
+
+/**
+ * Newsletter native-Post fetch (Consolidated CMS #131, Phase 4b-2 — gradual
+ * cutover of the NEWSLETTER email).
+ *
+ * The safety-critical bits, mirroring get-public-posts.test.ts:
+ *  - the section is HIDDEN while CONSOLIDATED_CMS is OFF (returns `[]`, repo
+ *    untouched → newsletter byte-identical to today);
+ *  - the flag is read with a NULL session (broadcast context);
+ *  - only NATIVE posts are surfaced (legacy events/news are NOT pulled in →
+ *    nothing double-renders);
+ *  - MEMBER TIER: full names survive redaction (the newsletter-email channel);
+ *  - drafts never leak;
+ *  - event-shaped posts are ordered before news-shaped.
+ * The data sources are stubbed, but `getPostsForViewer`, the lifecycle engine and
+ * `redactPost` are left REAL so the pipeline is genuinely exercised.
+ */
+
+const h = vi.hoisted(() => ({
+  checkFlag: vi.fn(),
+  listPosts: vi.fn(),
+  listAllPosts: vi.fn(),
+  getPublishedEvents: vi.fn(),
+  listNewsItems: vi.fn(),
+}))
+
+vi.mock('@my/app/features/feature-flags/use-feature-flag-wrapper', () => ({
+  checkFeatureFlagFromDB: h.checkFlag,
+}))
+vi.mock('@my/app/provider/dynamodb/repositories/post-repository', () => ({
+  postRepository: { listPosts: h.listPosts, listAllPosts: h.listAllPosts },
+}))
+vi.mock('@my/app/services/event-service', () => ({ getPublishedEvents: h.getPublishedEvents }))
+vi.mock('@my/app/services/news-service', () => ({ listNewsItems: h.listNewsItems }))
+
+import { getNewsletterNativePosts } from '../utils/email/get-newsletter-posts'
+
+const TENANT = 'Toronto East'
+// 2026-07-05: everything published 2026-07-01 is still inside its window.
+const NOW = new Date('2026-07-05T00:00:00.000Z')
+
+function basePost(overrides: Partial<Post>): Post {
+  return {
+    id: 'p',
+    tenant: TENANT,
+    authorId: 'a',
+    title: 'Post',
+    occasion: ['general'],
+    visibility: 'members',
+    sharingScope: 'own',
+    lifecycle: { publishDate: '2026-07-01T00:00:00.000Z' },
+    blocks: [],
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    status: 'ready',
+    ...overrides,
+  }
+}
+
+// Event-shaped: a TimeBlock ~6 weeks out (upcoming at NOW) → ordered first.
+const eventShaped = basePost({
+  id: 'event-1',
+  title: 'Wedding Shower',
+  occasion: ['shower'],
+  blocks: [
+    { id: 't', kind: 'time', label: 'Shower', startsAt: '2026-08-15T18:00:00.000Z' },
+    {
+      id: 'per',
+      kind: 'person',
+      role: 'bride',
+      people: [{ id: 'ppl-1', firstName: 'Sarah', lastName: 'Johnson' }],
+    },
+  ],
+})
+
+// News-shaped: no dated happening → ordered after event-shaped.
+const newsShaped = basePost({
+  id: 'news-1',
+  title: 'Sunday School resumes',
+  occasion: ['news'],
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.checkFlag.mockResolvedValue(true)
+  h.listPosts.mockResolvedValue({ posts: [eventShaped, newsShaped] })
+  h.listAllPosts.mockResolvedValue([])
+  h.getPublishedEvents.mockResolvedValue([])
+  h.listNewsItems.mockResolvedValue([])
+})
+
+describe('getNewsletterNativePosts — flag gate', () => {
+  it('returns [] when CONSOLIDATED_CMS is OFF (repo untouched → byte-identical newsletter)', async () => {
+    h.checkFlag.mockResolvedValue(false)
+    const result = await getNewsletterNativePosts(TENANT, NOW)
+    expect(result).toEqual([])
+    expect(h.listPosts).not.toHaveBeenCalled()
+    expect(h.listAllPosts).not.toHaveBeenCalled()
+  })
+
+  it('reads the flag with a NULL session (broadcast context — on only at "everyone")', async () => {
+    await getNewsletterNativePosts(TENANT, NOW)
+    expect(h.checkFlag).toHaveBeenCalledWith(expect.any(String), null)
+  })
+})
+
+describe('getNewsletterNativePosts — native only', () => {
+  it('never pulls in legacy events/news (no double-render of the legacy newsletter sections)', async () => {
+    await getNewsletterNativePosts(TENANT, NOW)
+    expect(h.getPublishedEvents).not.toHaveBeenCalled()
+    expect(h.listNewsItems).not.toHaveBeenCalled()
+  })
+
+  it('scopes the native read to the tenant', async () => {
+    await getNewsletterNativePosts(TENANT, NOW)
+    expect(h.listPosts).toHaveBeenCalledWith(expect.objectContaining({ tenant: TENANT }))
+  })
+})
+
+describe('getNewsletterNativePosts — member tier + ordering', () => {
+  it('orders event-shaped posts before news-shaped', async () => {
+    const posts = await getNewsletterNativePosts(TENANT, NOW)
+    expect(posts.map((p) => p.id)).toEqual(['event-1', 'news-1'])
+  })
+
+  it('reveals FULL names (member-tier newsletter-email channel)', async () => {
+    const posts = await getNewsletterNativePosts(TENANT, NOW)
+    const event = posts.find((p) => p.id === 'event-1')!
+    const personBlock = event.blocks.find((b) => b.kind === 'person') as any
+    expect(personBlock.people[0].lastName).toBe('Johnson')
+  })
+
+  it('drops drafts — a broadcast never sends unpublished native posts', async () => {
+    h.listPosts.mockResolvedValue({
+      posts: [eventShaped, basePost({ id: 'draft-1', title: 'Draft', status: 'draft' })],
+    })
+    const posts = await getNewsletterNativePosts(TENANT, NOW)
+    expect(posts.map((p) => p.id)).not.toContain('draft-1')
+  })
+
+  it('drops posts not active at `now` (lifecycle gate)', async () => {
+    // At 2026-09-01 both the shower (08-15) and the news window (07-01 + 2wk) have
+    // passed, and the shower's retrospective window (~08-29) has also ended.
+    const posts = await getNewsletterNativePosts(TENANT, new Date('2026-09-01T00:00:00.000Z'))
+    expect(posts).toEqual([])
+  })
+})

--- a/apps/next/tests/newsletter-community-posts.test.tsx
+++ b/apps/next/tests/newsletter-community-posts.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { render } from '@react-email/render'
+import Newsletter from 'email-builder/emails/Newsletter'
+import type { Post } from '@my/app/types/post'
+
+/**
+ * Newsletter × Community Posts wiring (Consolidated CMS #131, Phase 4b-2).
+ *
+ * Proves the flag-gated inclusion AT THE TEMPLATE LEVEL — the guarantee the
+ * community's primary email channel depends on:
+ *   - `posts` present → a "Community Posts" section appears (the additive cutover);
+ *   - `posts` empty / absent → NO section, and (byte-identical proof) the rendered
+ *     HTML is EXACTLY what the same template produces with no `posts` prop at all.
+ * The caller (`getNewsletterNativePosts`) passes a non-empty `posts` ONLY when the
+ * CONSOLIDATED_CMS flag is on, so "flag OFF" ≡ "posts empty" ≡ byte-identical.
+ *
+ * Renders the real `<Newsletter>` (server-safe: no `'use client'` / Tamagui in its
+ * module graph) with the template's built-in mock schedule/events/readings, so no
+ * DynamoDB/Google mocking is needed.
+ */
+
+const communityPost: Post = {
+  id: 'post-1',
+  tenant: 'Toronto East',
+  authorId: 'a',
+  title: 'Community Picnic Announcement',
+  occasion: ['general'],
+  visibility: 'members',
+  sharingScope: 'own',
+  lifecycle: { publishDate: '2026-07-01T00:00:00.000Z', startsAt: '2026-08-15T18:00:00.000Z' },
+  blocks: [{ id: 't', kind: 'time', label: 'Picnic', startsAt: '2026-08-15T18:00:00.000Z' }],
+  createdAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+  status: 'ready',
+}
+
+describe('Newsletter — Community Posts section (flag-gated via `posts`)', () => {
+  it('includes the section + post title when posts are passed', async () => {
+    const html = await render(<Newsletter posts={[communityPost]} />)
+    expect(html).toContain('Community Posts')
+    expect(html).toContain('Community Picnic Announcement')
+  })
+
+  it('omits the section entirely when posts is empty', async () => {
+    const html = await render(<Newsletter posts={[]} />)
+    expect(html).not.toContain('Community Posts')
+    expect(html).not.toContain('Community Picnic Announcement')
+  })
+
+  it('flag OFF is BYTE-IDENTICAL: posts=[] equals the no-posts-prop render', async () => {
+    const withEmptyPosts = await render(<Newsletter posts={[]} />)
+    const withoutProp = await render(<Newsletter />)
+    expect(withEmptyPosts).toBe(withoutProp)
+    expect(withoutProp).not.toContain('Community Posts')
+  })
+})

--- a/apps/next/tests/post-email-view.test.tsx
+++ b/apps/next/tests/post-email-view.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { render } from '@react-email/render'
+import { PostEmailView } from 'email-builder/components/PostEmailView'
+import type { Post } from '@my/app/types/post'
+
+/**
+ * PostEmailView render smoke test (Consolidated CMS #131, Phase 4b-2).
+ *
+ * PostEmailView is the SERVER-SAFE email twin of the web `PostView`: a plain
+ * react-email component with no `'use client'` import, no context/hooks, no
+ * Tamagui — so it renders cleanly from a plain-Node context (the same context the
+ * cron newsletter renders in). This exercises `render()` of PostEmailView alone
+ * (avoiding the Tamagui/lucide vitest wall the web PostView hits) and asserts each
+ * block kind reaches expected strings. Input is an ALREADY-REDACTED post at member
+ * tier (full names/locations present), matching what the newsletter feeds it.
+ */
+
+// A member-tier (already-redacted) post exercising all 7 block kinds.
+const post: Post = {
+  id: 'post-1',
+  tenant: 'Toronto East',
+  authorId: 'a',
+  title: 'Wedding Shower for Sarah',
+  occasion: ['wedding', 'shower'],
+  summary: 'Please join us to celebrate.',
+  visibility: 'members',
+  sharingScope: 'own',
+  lifecycle: { publishDate: '2026-07-01T00:00:00.000Z', startsAt: '2026-08-15T18:00:00.000Z' },
+  blocks: [
+    { id: 'b-text', kind: 'text', body: 'A **joyful** occasion — https://example.com/rsvp', containsPii: false },
+    {
+      id: 'b-person',
+      kind: 'person',
+      role: 'bride',
+      people: [
+        {
+          id: 'ppl-1',
+          firstName: 'Sarah',
+          lastName: 'Johnson',
+          ecclesia: 'Toronto East',
+          bio: 'A cherished member.',
+          contact: '416-555-1212',
+        },
+      ],
+    },
+    {
+      id: 'b-loc',
+      kind: 'location',
+      mode: 'geo',
+      label: 'Reception',
+      venueName: 'Fellowship Hall',
+      address: '975 Cosburn Avenue',
+      city: 'Toronto',
+      province: 'ON',
+      onlineMeeting: { platform: 'zoom', link: 'https://zoom.us/j/123' } as any,
+    },
+    { id: 'b-time', kind: 'time', label: 'Shower', startsAt: '2026-08-15T18:00:00.000Z', timezone: 'America/Toronto' },
+    {
+      id: 'b-flyer',
+      kind: 'flyer',
+      document: {
+        id: 'd1',
+        fileName: 'shower.jpg',
+        originalName: 'Shower Flyer.jpg',
+        fileUrl: 'https://example.com/shower.jpg',
+        mimeType: 'image/jpeg',
+      } as any,
+    },
+    {
+      id: 'b-reg',
+      kind: 'registration',
+      required: true,
+      deadline: '2026-08-10',
+      registrationUrl: 'https://example.com/register',
+      contactEmail: 'host@example.com',
+    },
+    { id: 'b-link', kind: 'link', url: 'https://example.com/more', label: 'More info' },
+  ],
+  createdAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+  status: 'ready',
+}
+
+describe('PostEmailView — block coverage', () => {
+  it('renders the header (occasion, title, summary)', async () => {
+    const html = await render(<PostEmailView post={post} />)
+    expect(html).toContain('Wedding Shower for Sarah')
+    expect(html).toContain('Wedding') // occasion, title-cased
+    expect(html).toContain('Please join us to celebrate.')
+  })
+
+  it('renders the text block with markdown-lite (bold + auto-link)', async () => {
+    const html = await render(<PostEmailView post={post} />)
+    expect(html).toContain('joyful')
+    expect(html).toContain('https://example.com/rsvp')
+  })
+
+  it('renders the person block with FULL name, bio and contact (member tier)', async () => {
+    const html = await render(<PostEmailView post={post} />)
+    expect(html).toContain('Sarah Johnson')
+    expect(html).toContain('A cherished member.')
+    expect(html).toContain('416-555-1212')
+  })
+
+  it('renders the location block (venue, address, directions link, online meeting)', async () => {
+    const html = await render(<PostEmailView post={post} />)
+    expect(html).toContain('Fellowship Hall')
+    expect(html).toContain('975 Cosburn Avenue')
+    expect(html).toContain('Get directions')
+    expect(html).toContain('Join online')
+  })
+
+  it('renders the time block (formatted date)', async () => {
+    const html = await render(<PostEmailView post={post} />)
+    expect(html).toContain('August') // formatted date line
+  })
+
+  it('renders the flyer block (image + link)', async () => {
+    const html = await render(<PostEmailView post={post} />)
+    expect(html).toContain('https://example.com/shower.jpg')
+    expect(html).toContain('Shower Flyer.jpg')
+  })
+
+  it('renders the registration block (deadline + register link)', async () => {
+    const html = await render(<PostEmailView post={post} />)
+    expect(html).toContain('Registration required')
+    expect(html).toContain('2026-08-10')
+    expect(html).toContain('https://example.com/register')
+    expect(html).toContain('Register')
+  })
+
+  it('renders the link block', async () => {
+    const html = await render(<PostEmailView post={post} />)
+    expect(html).toContain('More info')
+    expect(html).toContain('https://example.com/more')
+  })
+})

--- a/apps/next/utils/email/get-email-content.tsx
+++ b/apps/next/utils/email/get-email-content.tsx
@@ -35,6 +35,7 @@ import { emailIdentityFromProfile } from '@my/app/types/brand-profile'
 import { meetingRepository } from '@my/app/provider/dynamodb/repositories/meeting-repository'
 import MeetingEmail from 'email-builder/emails/MeetingEmail'
 import { meetingRecordToEmailProps } from './meeting-email-helpers'
+import { getNewsletterNativePosts } from './get-newsletter-posts'
 
 // Event display duration rules live in event-display-rules.ts (shared with the
 // web newsletter and the public Events listing so all surfaces stay in sync).
@@ -228,14 +229,29 @@ export const getEmailContent = async (
       }
 
       // Fetch all required data for newsletter (including per-ecclesia service times)
-      const [scheduleData, upcomingEvents, readingsData, homeEcclesia, newsletterNewsItems] =
-        await Promise.all([
+      const [
+        scheduleData,
+        upcomingEvents,
+        readingsData,
+        homeEcclesia,
+        newsletterNewsItems,
+        communityPosts,
+      ] = await Promise.all([
           get_upcoming_program(['memorial', 'sundaySchool', 'bibleClass']),
           fetchEvents(),
           fetchBibleReadings(),
           getEcclesiaByName(contentEcclesiaName),
           listNewsItems({ includeExpired: false }).catch((err) => {
             console.error('Failed to fetch news for newsletter (non-fatal):', err)
+            return []
+          }),
+          // Consolidated CMS (#131, Phase 4b-2) — ADDITIVE native Posts, flag-gated
+          // inside this helper. With CONSOLIDATED_CMS not 'everyone' this returns
+          // `[]`, so `posts` is empty and the template renders BYTE-IDENTICAL to
+          // today. Non-fatal: a native-post read failure must never break the
+          // community's primary email channel.
+          getNewsletterNativePosts(contentEcclesiaName).catch((err) => {
+            console.error('Failed to fetch native posts for newsletter (non-fatal):', err)
             return []
           }),
         ])
@@ -245,6 +261,7 @@ export const getEmailContent = async (
         upcomingEvents: upcomingEvents.length,
         readingsData: readingsData.length,
         newsItems: newsletterNewsItems.length,
+        communityPosts: communityPosts.length,
       })
 
       // Resolve per-ecclesia service times (falls back to catalogue defaults)
@@ -275,6 +292,7 @@ export const getEmailContent = async (
           newsItems={newsletterNewsItems}
           serviceTimes={newsletterServiceTimes}
           identity={emailIdentity}
+          posts={communityPosts}
         />
       )
       const newsletterHtmlContent = await render(newsletterEl)

--- a/apps/next/utils/email/get-newsletter-posts.ts
+++ b/apps/next/utils/email/get-newsletter-posts.ts
@@ -1,0 +1,85 @@
+import { getPostsForViewer } from '@my/app/services/post-service'
+import { resolvePostNextDate } from '@my/app/utils/post-lifecycle'
+import { checkFeatureFlagFromDB } from '@my/app/features/feature-flags/use-feature-flag-wrapper'
+import { FEATURE_FLAGS } from '@my/app/features/feature-flags/feature-flags'
+import type { Post } from '@my/app/types/post'
+import type { Viewer } from '@my/app/utils/viewer-pii'
+
+/**
+ * Active NATIVE Posts to fold into the weekly newsletter email (Consolidated CMS
+ * epic #131, Phase 4b-2 — gradual cutover of the newsletter).
+ *
+ * This is the ADDITIVE half of the cutover: it surfaces NATIVE Posts (content
+ * authored in the block editor) alongside the untouched legacy newsletter
+ * sections, which keep rendering through their OWN path. It mirrors the
+ * discipline of {@link getPublicPosts} (the web cutover):
+ *
+ *   1. FLAG OFF → `[]`. `CONSOLIDATED_CMS` gates the whole feature. The newsletter
+ *      is a BROADCAST — there is no per-recipient session at assembly time — so
+ *      the flag is read with a NULL session, which (like UNIVERSAL_EMAIL_LOGIN) is
+ *      ON only when the flag is set to `'everyone'`. While it is anything else the
+ *      newsletter gets NO extra content and is BYTE-IDENTICAL to today (fails
+ *      closed on any flag-store error).
+ *   2. Native-ONLY (`source: 'native'`) — legacy events/news are NOT pulled in
+ *      here (they render via the newsletter's existing sections), so nothing
+ *      double-renders. Native and legacy are disjoint today (no migration) → no
+ *      dedup.
+ *   3. MEMBER TIER. The newsletter goes to the opted-in member audience, so it
+ *      renders at member tier — full names + full locations (redactor §8.2). The
+ *      `'newsletter-email'` channel itself forces member reach + full-PII reveal;
+ *      we ALSO pass a matching member-tier viewer so reach and PII agree.
+ *   4. Lifecycle-governed: `getPostsForViewer` filters to posts ACTIVE at `now`
+ *      via the ONE display-rules engine — so a "shower" Post with a FUTURE
+ *      TimeBlock stays in the Thursday newsletter until the shower, then lingers
+ *      its retrospective window (the whole point of the unified lifecycle).
+ *   5. Drafts/archived never leak: only `status: 'ready'` posts are kept (the
+ *      unified read does not gate status — this door does).
+ *
+ * Ordering: event-shaped (an upcoming happening at `now`) FIRST, then news-shaped,
+ * using the ONE lifecycle engine ({@link resolvePostNextDate}). `now` is
+ * INJECTABLE so callers/tests are deterministic.
+ *
+ * Cross-platform / server-safe: no `next-*` imports (repos are server-only), no
+ * JSX — pure data. The returned posts are already redacted, ready to hand to the
+ * server-safe `PostEmailView`.
+ *
+ * @param tenant Owning ecclesia/org name — scopes the read so a tenant's
+ *   newsletter carries only its own native posts (multi-tenant correctness).
+ */
+export async function getNewsletterNativePosts(
+  tenant: string,
+  now: Date = new Date()
+): Promise<Post[]> {
+  // Flag gate first — feature hidden entirely (and the repo untouched) while OFF.
+  // Broadcast context → null session → ON only at 'everyone'.
+  const flagOn = await checkFeatureFlagFromDB(FEATURE_FLAGS.CONSOLIDATED_CMS, null)
+  if (!flagOn) return []
+
+  // Member-tier viewer for the newsletter audience. The channel already forces
+  // member reach + full-PII reveal; this viewer keeps the two axes consistent.
+  const viewer: Viewer = {
+    assurance: 'authenticated',
+    role: 'member',
+    tenant,
+    email: null,
+  }
+
+  const posts = await getPostsForViewer(viewer, {
+    channel: 'newsletter-email',
+    source: 'native',
+    tenant,
+    now,
+  })
+
+  // A broadcast surface never sends drafts/archived (unified read doesn't gate status).
+  const ready = posts.filter((p) => p.status === 'ready')
+
+  // Event-shaped (upcoming happening) first, then news-shaped.
+  const eventShaped: Post[] = []
+  const newsShaped: Post[] = []
+  for (const post of ready) {
+    if (resolvePostNextDate(post, now)) eventShaped.push(post)
+    else newsShaped.push(post)
+  }
+  return [...eventShaped, ...newsShaped]
+}


### PR DESCRIPTION
Phase 4b-2 of #131 — gradual cutover (A) of the **newsletter**. Additive; **flag-off byte-identical**; server-safe. This is where 'a future-dated Post stays in the Thursday newsletter until its event' lands.

## What
- **`PostEmailView`** (`apps/email-builder/components/`) — server-safe react-email renderer, email twin of `PostView` (7-kind coverage). Imports only `@react-email/components`, the **pure** `post-view-format` helpers, pure types, and the sibling server-component `AutoLinkText` — **no `'use client'`, no Tamagui, no hooks**, so `render()` from the server route (incl. the **cron**) can't hit the client-module-in-server-render failure. All data + identity as props.
- **`get-newsletter-posts.ts`** — `getNewsletterNativePosts`: flag-gated (broadcast → **null session → ON only at `'everyone'`**, fail-closed), member-tier viewer (`channel:'newsletter-email'` → full names/locations per §8.2), `source:'native'` (no legacy double-render), `status:'ready'` only, event-shaped first.
- **`get-email-content.tsx`** `case 'newsletter'`: fetches `communityPosts` in the existing `Promise.all` **non-fatal** (`.catch(→[])`), passes to `<Newsletter posts={}>`.
- **`Newsletter.tsx`**: optional `posts?: Post[]` (default `[]`) + a **'Community Posts'** section rendered only when non-empty.

## Flag-off proof + cron safety
Null-session flag ⇒ `[]` unless `'everyone'` ⇒ empty section ⇒ template byte-identical (asserted: `render(<Newsletter posts={[]}/>) === render(<Newsletter/>)`). Non-fatal fetch can't break the send. `PostEmailView` provably free of client imports (the exact cron failure mode). Cron/`test-thursday`/`send-one`/`email-queue` all route through `getEmailContent` — no extra change.

## Verify
- **19 new tests** (flag/tier/ordering/native-only/drafts/lifecycle; per-block email strings incl. full names; section on/off + byte-identical) + related suites green. Typecheck clean; build compiles (pre-existing GOOGLE-key route aside).

## The switch
This completes the cutover **build**. Native posts go live everywhere (pages + newsletter) when **`CONSOLIDATED_CMS` is set to `'everyone'`** — that flip is Ken's, after eyeballing the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)