### PR TITLE
fix(bible-class): subject matches "no class" body + drop "Brother" for generic leaders

### DIFF
--- a/apps/email-builder/emails/BibleClass.tsx
+++ b/apps/email-builder/emails/BibleClass.tsx
@@ -47,17 +47,44 @@ const isNoClass = (event: BibleClassType): boolean => {
   return !event.Speaker || event.Topic.toLowerCase().includes('no class')
 }
 
+// Whether tonight has no class, honoring the override precedence: 'cancelled'
+// forces no-class, 'active' forces the class to show, otherwise the Speaker/Topic
+// heuristic. Exported so the SEND path can brand the subject line to match the
+// body — subject and body must never contradict (a "no class" body under a
+// "Bible Class Tonight!" subject).
+export const bibleClassHasNoClass = (currentEvent?: BibleClassType): boolean => {
+  if (!currentEvent) return false
+  if (currentEvent.overrideStatus === 'cancelled') return true
+  if (currentEvent.overrideStatus === 'active') return false
+  return isNoClass(currentEvent)
+}
+
+// The subject line for a Bible Class send, reflecting whether there's a class
+// tonight. (The send appends the date, so this is just the lead phrase.)
+export const bibleClassSubject = (events?: BibleClassType[]): string =>
+  bibleClassHasNoClass(events?.[0]) ? 'No Bible Class Tonight' : 'Bible Class Tonight!'
+
+// Generic, non-name leader values that should NOT take the "Brother" honorific —
+// e.g. an attendee-led / open-discussion class reads "Led by attendees", not
+// "Led by Brother attendees". Matched case-insensitively; display keeps the
+// original casing.
+const GENERIC_LEADERS = new Set(['attendees', 'all', 'open', 'discussion', 'group', 'tba', 'tbd'])
+
+// Format a class leader for display, adding the "Brother" honorific only when the
+// leader is an actual name (not a generic term like "attendees").
+export const formatLeader = (speaker?: string): string => {
+  const name = (speaker ?? '').trim()
+  if (!name) return ''
+  return GENERIC_LEADERS.has(name.toLowerCase()) ? name : `Brother ${name}`
+}
+
 // `identity` is passed as a prop (not via the client EmailIdentityProvider) so this
 // renders from an App Router server route (the email-queue cron processor).
 const BibleClass: React.FC<NextBibleClassProps & { identity?: EmailIdentity }> = ({ events, note, identity }) => {
   const bibleClassEvents = events || mockEvents
   const currentEvent = bibleClassEvents[0]
   const nextEvent = bibleClassEvents[1]
-  // Override precedence: 'cancelled' forces no-class; 'active' forces the class to
-  // show; otherwise fall back to the Speaker/Topic heuristic.
-  const isCancelled = currentEvent?.overrideStatus === 'cancelled'
-  const isForcedActive = currentEvent?.overrideStatus === 'active'
-  const hasNoClass = isCancelled || (!isForcedActive && !!currentEvent && isNoClass(currentEvent))
+  const hasNoClass = bibleClassHasNoClass(currentEvent)
   // Find the next actual class (skipping any "no class" entries)
   const nextActualClass = hasNoClass && nextEvent && !isNoClass(nextEvent) ? nextEvent : undefined
 
@@ -172,7 +199,7 @@ const BibleClass: React.FC<NextBibleClassProps & { identity?: EmailIdentity }> =
                     <br />
                     {nextActualClass.Date.toString()} at 7:30pm
                     <br />
-                    Led by Brother {nextActualClass.Speaker}
+                    Led by {formatLeader(nextActualClass.Speaker)}
                     {nextActualClass.Topic ? (
                       <>
                         <br />

--- a/apps/next/app/api/cron/email-queue/route.ts
+++ b/apps/next/app/api/cron/email-queue/route.ts
@@ -192,9 +192,11 @@ export async function GET(req: NextRequest) {
 
         const emailReason = emailTypeMap[queueEntry.emailType]
 
-        // Get email content for this type
+        // Get email content for this type. Some templates return a content-aware
+        // subject as a 3rd element (e.g. Bible Class → "No Bible Class Tonight"
+        // when there's no class), which must override the static per-reason subject.
         const emailContent = await getEmailContent(emailReason)
-        const [emailHtml, emailText] = emailContent || ['', '']
+        const [emailHtml, emailText, generatedSubject] = emailContent || ['', '']
 
         if (!emailHtml || !emailText) {
           throw new Error(`Failed to generate email content for ${emailReason}`)
@@ -206,6 +208,7 @@ export async function GET(req: NextRequest) {
           emailHtml,
           emailText,
           test: queueEntry.testMode || false,
+          customSubject: generatedSubject || undefined,
         })
 
         if (sendResult instanceof Error) {

--- a/apps/next/tests/email/bible-class-subject-leader.test.ts
+++ b/apps/next/tests/email/bible-class-subject-leader.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Bible Class subject ⇄ body + leader honorific tests.
+ *
+ * BUG HISTORY (2026-08-05):
+ * - A "no class" Bible Class email went out with subject "Bible Class Tonight!"
+ *   while the body read "There is no scheduled Bible class tonight." — the subject
+ *   was a static per-reason string, decoupled from the template's no-class logic.
+ * - The "next scheduled class" line rendered "Led by Brother attendees" — the
+ *   "Brother" honorific was prepended unconditionally, even to the generic,
+ *   non-name leader "attendees".
+ *
+ * These pin the fix: `bibleClassSubject` mirrors the body's no-class decision, and
+ * `formatLeader` only adds "Brother" for actual names.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  bibleClassHasNoClass,
+  bibleClassSubject,
+  formatLeader,
+} from 'email-builder/emails/BibleClass'
+import { ProgramsTypes, type BibleClassType } from '@my/app/types'
+
+const klass = (over: Partial<BibleClassType> = {}): BibleClassType => ({
+  Key: ProgramsTypes.bibleClass,
+  Presider: 'Presiding Brother',
+  Speaker: 'John Smith',
+  Topic: 'A study',
+  Date: 'Aug 5, 2026',
+  ...over,
+})
+
+describe('bibleClassHasNoClass', () => {
+  it('is no-class when the speaker is empty', () => {
+    expect(bibleClassHasNoClass(klass({ Speaker: '' }))).toBe(true)
+  })
+  it('is no-class when the topic says "no class"', () => {
+    expect(bibleClassHasNoClass(klass({ Topic: 'No Class this week' }))).toBe(true)
+  })
+  it('is a class for a normal event', () => {
+    expect(bibleClassHasNoClass(klass())).toBe(false)
+  })
+  it("honors override 'cancelled' over an otherwise-valid event", () => {
+    expect(bibleClassHasNoClass(klass({ overrideStatus: 'cancelled' }))).toBe(true)
+  })
+  it("honors override 'active' over an empty speaker", () => {
+    expect(bibleClassHasNoClass(klass({ Speaker: '', overrideStatus: 'active' }))).toBe(false)
+  })
+  it('is not no-class when there is no event at all', () => {
+    expect(bibleClassHasNoClass(undefined)).toBe(false)
+  })
+})
+
+describe('bibleClassSubject', () => {
+  it('reads "No Bible Class Tonight" when tonight is cancelled', () => {
+    expect(bibleClassSubject([klass({ Speaker: '' })])).toBe('No Bible Class Tonight')
+  })
+  it('reads "Bible Class Tonight!" when there is a class', () => {
+    expect(bibleClassSubject([klass()])).toBe('Bible Class Tonight!')
+  })
+  it('subject reflects tonight (index 0), not a later listed class', () => {
+    // No class tonight, a real class next — subject must still say "No ..."
+    expect(bibleClassSubject([klass({ Speaker: '' }), klass()])).toBe('No Bible Class Tonight')
+  })
+})
+
+describe('formatLeader', () => {
+  it('adds the "Brother" honorific for an actual name', () => {
+    expect(formatLeader('John Smith')).toBe('Brother John Smith')
+  })
+  it('does NOT add "Brother" for the generic "attendees"', () => {
+    expect(formatLeader('attendees')).toBe('attendees')
+  })
+  it('matches generic leaders case-insensitively but keeps display casing', () => {
+    expect(formatLeader('Attendees')).toBe('Attendees')
+    expect(formatLeader('TBD')).toBe('TBD')
+  })
+  it('trims surrounding whitespace', () => {
+    expect(formatLeader('  Jane Doe  ')).toBe('Brother Jane Doe')
+  })
+  it('returns empty string for an empty/undefined leader', () => {
+    expect(formatLeader('')).toBe('')
+    expect(formatLeader(undefined)).toBe('')
+  })
+})

--- a/apps/next/utils/email/get-email-content.tsx
+++ b/apps/next/utils/email/get-email-content.tsx
@@ -13,7 +13,7 @@ import { Event, LocationInfo } from '@my/app/types/events'
 import MemorialService from 'email-builder/emails/Memorial'
 import Newsletter from 'email-builder/emails/Newsletter'
 import { emailReasons } from './email-send'
-import BibleClass from 'email-builder/emails/BibleClass'
+import BibleClass, { bibleClassSubject } from 'email-builder/emails/BibleClass'
 import BusinessMeeting from 'email-builder/emails/BusinessMeeting'
 import CustomEmail from 'email-builder/emails/CustomEmail'
 import FuneralEmail from 'email-builder/emails/Funeral'
@@ -220,7 +220,10 @@ export const getEmailContent = async (
           plainText: true,
         }
       )
-      return [bibleClassHtmlContent, bibleClassTextContent]
+      // Brand the subject from the same "no class" logic the body uses, so the
+      // subject never contradicts the body (e.g. "No Bible Class Tonight").
+      const bibleClassSubjectLine = bibleClassSubject(bibleClassEvents as BibleClassType[])
+      return [bibleClassHtmlContent, bibleClassTextContent, bibleClassSubjectLine]
     case 'newsletter':
       // Fallback: Sync YouTube URLs if any are missing (primary sync happens at livestream creation)
       const newsletterSyncResult = await syncYouTubeUrlsForEmail(14)


### PR DESCRIPTION
## Two "Oh No" bugs on the automated Bible Class email

From a real send (screenshot): subject **"Bible Class Tonight! 2026-08-05"** over a body reading **"There is no scheduled Bible class tonight."**, and a next-class line reading **"Led by Brother attendees"**.

### 1. Subject contradicted the body
The subject was a static per-reason string (`senders['bible-class'].subject = 'Bible Class Tonight!'`), computed with no knowledge of whether there's actually a class. The template already knew (`hasNoClass`), but that never reached the subject.

**Fix:** export the no-class decision (`bibleClassHasNoClass`) + a `bibleClassSubject()` helper from the `BibleClass` template (single-sourced with the body, override precedence preserved), return it as the content-aware subject from `getEmailContent('bible-class')`, and thread the 3rd (subject) element through the **cron** send path (`/api/cron/email-queue`). The manual `pages/api/email/[reason].ts` path already consumed it. Now a no-class send subjects as **"No Bible Class Tonight"**.

### 2. "Led by Brother attendees"
The next-class line prepended the "Brother" honorific unconditionally. When the leader is the generic term *attendees* (an attendee-led / open class), that reads wrong.

**Fix:** `formatLeader()` adds "Brother" only for actual names; generic terms (`attendees`, `all`, `open`, `discussion`, `group`, `tba`, `tbd`) render bare → **"Led by attendees"**. Case-insensitive match, original casing preserved.

## Testing
- 14 new unit tests (`tests/email/bible-class-subject-leader.test.ts`) pinning both behaviours + override precedence + "subject reflects tonight, not a later class".
- `yarn workspace next-app typecheck` clean.
- 48 email tests pass.

## Notes
- Not urgent — next "no class" is a while out — but batched now so it isn't forgotten.
- No schema/data changes; purely template + send-path wiring. Both send paths (cron + manual) now branded consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)