### PR TITLE
Redesign Profile → Contact Info (edit affordances, per-row email actions, save-in-place)

### DIFF
--- a/apps/next/app/(public)/profile/page.tsx
+++ b/apps/next/app/(public)/profile/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { UserProfile } from '@my/app/features/profile/user-profile'
@@ -19,6 +19,23 @@ export default function ProfilePage() {
   // from require-fresh-auth) is satisfied via <Verify>. Wrapped in an object so a
   // function value isn't mistaken for a state updater.
   const [stepUp, setStepUp] = useState<{ retry: () => void } | null>(null)
+
+  // Is the secure change-login flow (SECURE_EMAIL_CHANGE) available to this
+  // session? Probed once server-side; drives whether the "Set as login" menu item
+  // and the login-row change pencil are shown at all.
+  const [canChangeLogin, setCanChangeLogin] = useState(false)
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/user/email-change/available')
+      .then((r) => r.json())
+      .then((d) => { if (!cancelled) setCanChangeLogin(!!d?.available) })
+      .catch(() => { if (!cancelled) setCanChangeLogin(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  // Launch state for the secure change-login flow. `email` pre-fills the flow when
+  // promoting an already-verified address ("Set as login").
+  const [changeLogin, setChangeLogin] = useState<{ open: boolean; email?: string }>({ open: false })
 
   if (!isHydrated || status === 'loading') {
     return (
@@ -54,14 +71,35 @@ export default function ProfilePage() {
         userEcclesia={(session.user as any).ecclesia || undefined}
         onNavigateToPerson={(personId) => router.push(`/people/${encodeURIComponent(personId)}`)}
         onStepUpRequired={(retry) => setStepUp({ retry })}
+        canChangeLogin={canChangeLogin}
+        onChangeLogin={() => setChangeLogin({ open: true })}
+        onSetLogin={(email) => setChangeLogin({ open: true, email })}
       />
 
-      {/* Self-serve login-email change — self-hides unless SECURE_EMAIL_CHANGE is on. */}
-      <Wrapper>
-        <Section gap={'$4'}>
-          <ChangeEmailFlow />
-        </Section>
-      </Wrapper>
+      {/* Secure login-email change — launched from the login-row pencil or the
+          per-address "Set as login" menu item; rendered as a modal overlay.
+          Self-hides internally unless SECURE_EMAIL_CHANGE is on. */}
+      {changeLogin.open ? (
+        <YStack
+          position="absolute"
+          top={0}
+          left={0}
+          right={0}
+          bottom={0}
+          zIndex={1000}
+          justifyContent="center"
+          alignItems="center"
+          padding="$4"
+          backgroundColor="rgba(0,0,0,0.5)"
+        >
+          <YStack maxWidth={480} width="100%">
+            <ChangeEmailFlow
+              initialEmail={changeLogin.email}
+              onClose={() => setChangeLogin({ open: false })}
+            />
+          </YStack>
+        </YStack>
+      ) : null}
 
       {/* Step-up overlay: shown when a profile mutation is refused with
           403 stepUpRequired. On success we re-run the challenged mutation. */}

--- a/apps/next/features/account/change-email-flow.tsx
+++ b/apps/next/features/account/change-email-flow.tsx
@@ -39,7 +39,14 @@ type Step = 'email' | 'code' | 'done'
  *
  * The whole component self-hides unless the `SECURE_EMAIL_CHANGE` flag is on.
  */
-export function ChangeEmailFlow() {
+interface ChangeEmailFlowProps {
+  /** Pre-fill the "new email" field (e.g. "Set as login" on an already-verified address). */
+  initialEmail?: string
+  /** Optional dismiss affordance (e.g. when launched in a modal). */
+  onClose?: () => void
+}
+
+export function ChangeEmailFlow({ initialEmail, onClose }: ChangeEmailFlowProps = {}) {
   const isHydrated = useHydrated()
 
   // Launch-dark visibility resolved per session server-side (the client flag hook
@@ -55,7 +62,7 @@ export function ChangeEmailFlow() {
   }, [])
 
   const [step, setStep] = useState<Step>('email')
-  const [newEmail, setNewEmail] = useState('')
+  const [newEmail, setNewEmail] = useState(initialEmail ?? '')
   const [newEmailMasked, setNewEmailMasked] = useState('')
   const [code, setCode] = useState('')
   const [error, setError] = useState('')
@@ -180,12 +187,26 @@ export function ChangeEmailFlow() {
 
   return (
     <Card elevate bordered padding="$4" gap="$4">
-      <YStack gap="$2">
-        <Heading size="$6" color="$color12">Change your login email</Heading>
-        <Paragraph color="$color11">
-          Changing your email is simple if you can receive one more email — at your new address.
-        </Paragraph>
-      </YStack>
+      <XStack justifyContent="space-between" alignItems="flex-start" gap="$2">
+        <YStack gap="$2" flex={1}>
+          <Heading size="$6" color="$color12">Change your login email</Heading>
+          <Paragraph color="$color11">
+            Changing your email is simple if you can receive one more email — at your new address.
+          </Paragraph>
+        </YStack>
+        {onClose ? (
+          <Button
+            size="$2"
+            chromeless
+            circular
+            aria-label="Close"
+            onPress={onClose}
+            disabled={loading || signingOut}
+          >
+            ✕
+          </Button>
+        ) : null}
+      </XStack>
 
       {step === 'email' ? (
         <YStack gap="$3">

--- a/apps/next/tests/email-ordering.test.ts
+++ b/apps/next/tests/email-ordering.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { moveEmailToFront } from '@my/ui/src/profile/email-ordering'
+
+/**
+ * "Set as preferred" == move the chosen address to index 0, then PUT the whole
+ * ordered set. These cover the pure ordering helper that model relies on.
+ */
+describe('moveEmailToFront', () => {
+  const list = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
+
+  it('moves a middle item to the front, preserving relative order of the rest', () => {
+    expect(moveEmailToFront(list, 'c').map((e) => e.id)).toEqual(['c', 'a', 'b'])
+    expect(moveEmailToFront(list, 'b').map((e) => e.id)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('is a no-op (new array) when the item is already first', () => {
+    const out = moveEmailToFront(list, 'a')
+    expect(out.map((e) => e.id)).toEqual(['a', 'b', 'c'])
+    expect(out).not.toBe(list) // returns a copy, never mutates input
+  })
+
+  it('returns a copy unchanged when the id is not found', () => {
+    const out = moveEmailToFront(list, 'zzz')
+    expect(out.map((e) => e.id)).toEqual(['a', 'b', 'c'])
+    expect(out).not.toBe(list)
+  })
+
+  it('does not mutate the input array', () => {
+    const input = [{ id: 'x' }, { id: 'y' }]
+    moveEmailToFront(input, 'y')
+    expect(input.map((e) => e.id)).toEqual(['x', 'y'])
+  })
+})

--- a/packages/app/features/profile/user-profile.tsx
+++ b/packages/app/features/profile/user-profile.tsx
@@ -5,12 +5,12 @@ import { Section, Text, YStack, XStack, Heading, Separator, Spinner, Tabs, Card,
 import { Wrapper } from '@my/app/provider/wrapper'
 import { AddressList } from '@my/ui/src/profile/address-list'
 import { PhoneManager, type PhoneEntry } from '@my/ui/src/profile/phone-manager'
-import { EmailManager, type EmailEntry } from '@my/ui/src/profile/email-manager'
+import { EmailManager, moveEmailToFront, type EmailEntry } from '@my/ui/src/profile/email-manager'
 import { FamilyMembers, type AddFamilyMemberData } from '@my/ui/src/profile/family-members'
 import { ConnectionsList } from '@my/ui/src/profile/connections-list'
 import { PrivacySettings } from '@my/ui/src/profile/privacy-settings'
 import { ContactRequestsList } from '@my/ui/src/profile/contact-requests-list'
-import { Church, Search, Pencil, Check, X, User } from '@tamagui/lucide-icons'
+import { Church, Search, Pencil, Check, X } from '@tamagui/lucide-icons'
 import type { AddressType, PhoneType, RelationshipType, VisibilityLevel } from '@my/app/provider/dynamodb/types'
 
 interface UserProfileProps {
@@ -26,6 +26,16 @@ interface UserProfileProps {
    * Kept as a prop because this shared package cannot import next-auth/Verify.
    */
   onStepUpRequired?: (retry: () => void) => void
+  /**
+   * Whether the secure change-login flow (SECURE_EMAIL_CHANGE) is available to
+   * this session — resolved server-side by the platform layer and threaded down.
+   * Gates the "Set as login" menu item and the login-row change pencil.
+   */
+  canChangeLogin?: boolean
+  /** Launch the secure change-login flow (owned by the platform layer). */
+  onChangeLogin?: () => void
+  /** Launch the secure change-login flow pre-filled with an already-verified address. */
+  onSetLogin?: (email: string) => void
 }
 
 interface Address {
@@ -90,13 +100,15 @@ export const UserProfile: React.FC<UserProfileProps> = ({
   userEcclesia,
   onNavigateToPerson,
   onStepUpRequired,
+  canChangeLogin = false,
+  onChangeLogin,
+  onSetLogin,
 }) => {
   const [loading, setLoading] = useState(true)
   const [addresses, setAddresses] = useState<Address[]>([])
   const [phones, setPhones] = useState<PhoneEntry[]>([])
   const [emails, setEmails] = useState<EmailEntry[]>([])
   const [savingPhones, setSavingPhones] = useState(false)
-  const [savingEmails, setSavingEmails] = useState(false)
   const [familyMembers, setFamilyMembers] = useState<FamilyMember[]>([])
   const [connections, setConnections] = useState<Connection[]>([])
   const [blockedUsers, setBlockedUsers] = useState<string[]>([])
@@ -275,30 +287,58 @@ export const UserProfile: React.FC<UserProfileProps> = ({
     return false
   }
 
-  // Email handlers for EmailManager
-  const handleSaveEmails = async () => {
-    setSavingEmails(true)
-    try {
-      const res = await fetch('/api/user/emails', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          emails: emails.map(e => ({
-            id: e.id,
-            email: e.email,
-            verified: e.verified,
-            isPrimary: e.isPrimary,
-          })),
-        }),
-      })
-      if (res.ok) {
-        await fetchData()
-        return
-      }
-      await handledStepUp(res, () => { void handleSaveEmails() })
-    } finally {
-      setSavingEmails(false)
+  // Email handlers for EmailManager — each saves in place, then refetches the
+  // list so the UI reflects server state. All route a 403 { stepUpRequired }
+  // through the platform step-up mechanism instead of failing silently.
+  const handleAddEmail = async (email: string): Promise<boolean> => {
+    const res = await fetch('/api/user/emails', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    })
+    if (res.ok) {
+      await fetchData()
+      return true
     }
+    // 403 → step up and retry the ADD alone (never the delete); other errors just
+    // stop. Returning false lets a rename keep the old address until the new one
+    // is actually added, so a stale-session rename can't drop an address.
+    await handledStepUp(res, () => { void handleAddEmail(email) })
+    return false
+  }
+
+  const handleDeleteEmail = async (emailId: string) => {
+    const res = await fetch(`/api/user/emails?emailId=${encodeURIComponent(emailId)}`, {
+      method: 'DELETE',
+    })
+    if (res.ok) {
+      await fetchData()
+      return
+    }
+    await handledStepUp(res, () => { void handleDeleteEmail(emailId) })
+  }
+
+  // "Set as preferred" = move the address to index 0 and PUT the whole ordered
+  // set (the replace-all model; first = preferred).
+  const handleSetPreferred = async (emailId: string) => {
+    const reordered = moveEmailToFront(emails, emailId)
+    const res = await fetch('/api/user/emails', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        emails: reordered.map(e => ({
+          id: e.id,
+          email: e.email,
+          verified: e.verified,
+          isPrimary: e.isPrimary,
+        })),
+      }),
+    })
+    if (res.ok) {
+      await fetchData()
+      return
+    }
+    await handledStepUp(res, () => { void handleSetPreferred(emailId) })
   }
 
   const handleSendVerification = async (emailId: string) => {
@@ -677,14 +717,13 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                     </Card>
                   ) : (
                     <Card padding="$3" backgroundColor="$backgroundHover">
-                      <XStack gap="$3" alignItems="center" justifyContent="space-between">
-                        <XStack gap="$3" alignItems="center" flex={1}>
-                          <User size={20} color="$blue10" />
-                          <Text fontSize="$4" fontWeight="500">
-                            {displayName || 'No name set'}
-                          </Text>
+                      <XStack gap="$2" alignItems="center">
+                        <XStack width={34} justifyContent="flex-start">
+                          <Button size="$2" icon={Pencil} chromeless circular aria-label="Edit name" onPress={startEditingName} />
                         </XStack>
-                        <Button size="$2" icon={Pencil} chromeless circular onPress={startEditingName} />
+                        <Text fontSize="$4" fontWeight="500">
+                          {displayName || 'No name set'}
+                        </Text>
                       </XStack>
                     </Card>
                   )}
@@ -776,14 +815,13 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                     </Card>
                   ) : (
                     <Card padding="$3" backgroundColor="$backgroundHover">
-                      <XStack gap="$3" alignItems="center" justifyContent="space-between">
-                        <XStack gap="$3" alignItems="center" flex={1}>
-                          <Church size={20} color="$blue10" />
-                          <Text fontSize="$4" fontWeight="500">
-                            {ecclesia || 'No ecclesia set'}
-                          </Text>
+                      <XStack gap="$2" alignItems="center">
+                        <XStack width={34} justifyContent="flex-start">
+                          <Button size="$2" icon={Pencil} chromeless circular aria-label="Edit ecclesia" onPress={startEditingEcclesia} />
                         </XStack>
-                        <Button size="$2" icon={Pencil} chromeless circular onPress={startEditingEcclesia} />
+                        <Text fontSize="$4" fontWeight="500">
+                          {ecclesia || 'No ecclesia set'}
+                        </Text>
                       </XStack>
                     </Card>
                   )}
@@ -792,10 +830,13 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                 <Separator />
                 <EmailManager
                   emails={emails}
-                  onChange={setEmails}
-                  onSave={handleSaveEmails}
+                  onAddEmail={handleAddEmail}
+                  onDeleteEmail={handleDeleteEmail}
                   onSendVerification={handleSendVerification}
-                  saving={savingEmails}
+                  onSetPreferred={handleSetPreferred}
+                  onSetLogin={(email) => onSetLogin?.(email)}
+                  onChangeLogin={() => onChangeLogin?.()}
+                  canChangeLogin={canChangeLogin}
                 />
                 <Separator />
                 <PhoneManager

--- a/packages/ui/src/profile/email-manager.tsx
+++ b/packages/ui/src/profile/email-manager.tsx
@@ -1,102 +1,130 @@
 import React, { useState } from 'react'
-import { YStack, XStack, Text, Card, Input, Spinner } from 'tamagui'
+import { YStack, XStack, Text, Card, Input, Spinner, Popover, Separator } from 'tamagui'
 import { Button } from '../Button'
-import { Mail, Plus, Trash2, GripVertical, Check, AlertCircle, Send, Bell } from '@tamagui/lucide-icons'
+import {
+  Mail,
+  Plus,
+  Trash2,
+  Check,
+  AlertCircle,
+  Send,
+  Pencil,
+  MoreHorizontal,
+  Star,
+  Shield,
+  X,
+} from '@tamagui/lucide-icons'
+import { moveEmailToFront } from './email-ordering'
+
+export { moveEmailToFront }
 
 export interface EmailEntry {
   id: string
   email: string
   verified: boolean
   verificationSentAt?: string
-  subscribed?: boolean // Whether subscribed to communications
-  subscriptionCount?: number // How many mailing lists this address is opted into
   isPrimary?: boolean // Primary login email (cannot be removed)
+  // NOTE: `subscribed`/`subscriptionCount` used to render here; subscriptions now
+  // live in their own tab. Kept optional so the API payload still type-checks.
+  subscribed?: boolean
+  subscriptionCount?: number
 }
 
 interface EmailManagerProps {
   emails: EmailEntry[]
-  onChange: (emails: EmailEntry[]) => void
-  onSave?: () => Promise<void>
-  onSendVerification?: (emailId: string) => Promise<void>
-  saving?: boolean
+  /** Add a brand-new (unverified) address. Resolves true only when it actually
+   *  landed (false on a deferred step-up / error) so a rename won't drop the old
+   *  address before the new one exists. */
+  onAddEmail: (email: string) => Promise<boolean> | boolean
+  /** Soft-delete a non-login address by id. */
+  onDeleteEmail: (emailId: string) => Promise<void> | void
+  /** (Re)send the verification code for an address. */
+  onSendVerification: (emailId: string) => Promise<void> | void
+  /** Make this address the preferred (first) contact — soft, in-place. */
+  onSetPreferred: (emailId: string) => Promise<void> | void
+  /** Promote an already-verified address to the login identity (secure flow). */
+  onSetLogin: (email: string) => void
+  /** Change the login/primary address (secure flow). */
+  onChangeLogin: () => void
+  /**
+   * Whether the secure change-login flow is available to this session (the
+   * SECURE_EMAIL_CHANGE launch-dark flag). Gates the "Set as login" menu item and
+   * the login-row change pencil.
+   */
+  canChangeLogin: boolean
+  /** View-only: render addresses + verified badges, no controls. */
   readOnly?: boolean
-  emailPreferencesUrl?: string
 }
+
+const GUTTER = 34
 
 // Simple email validation
 function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
 }
 
-// Generate a simple ID
-function generateId(): string {
-  return `email-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
-}
-
 export const EmailManager: React.FC<EmailManagerProps> = ({
   emails,
-  onChange,
-  onSave,
+  onAddEmail,
+  onDeleteEmail,
   onSendVerification,
-  saving = false,
+  onSetPreferred,
+  onSetLogin,
+  onChangeLogin,
+  canChangeLogin,
   readOnly = false,
-  emailPreferencesUrl = '/email-preferences',
 }) => {
-  const [draggedIndex, setDraggedIndex] = useState<number | null>(null)
-  const [sendingVerification, setSendingVerification] = useState<string | null>(null)
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null)
 
-  const handleAddEmail = () => {
-    const newEmail: EmailEntry = {
-      id: generateId(),
-      email: '',
-      verified: false,
-    }
-    onChange([...emails, newEmail])
-  }
+  // Inline "add a new address" editor (revealed by the Add button).
+  const [adding, setAdding] = useState(false)
+  const [newEmail, setNewEmail] = useState('')
 
-  const handleRemoveEmail = (id: string) => {
-    // Don't allow removing primary email
-    const emailToRemove = emails.find(e => e.id === id)
-    if (emailToRemove?.isPrimary) return
-    onChange(emails.filter(e => e.id !== id))
-  }
+  // Inline "rename an existing address" editor, keyed by row id. Because there is
+  // no rename endpoint, saving a changed value adds the new address and removes
+  // the old one (which also, correctly, resets verification for the new address).
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editValue, setEditValue] = useState('')
 
-  const handleUpdateEmail = (id: string, value: string) => {
-    onChange(emails.map(e => e.id === id ? { ...e, email: value.toLowerCase().trim(), verified: false } : e))
-  }
-
-  const moveEmail = (fromIndex: number, toIndex: number) => {
-    if (toIndex < 0 || toIndex >= emails.length) return
-    const newEmails = [...emails]
-    const [moved] = newEmails.splice(fromIndex, 1)
-    newEmails.splice(toIndex, 0, moved)
-    onChange(newEmails)
-  }
-
-  const handleDragStart = (index: number) => {
-    setDraggedIndex(index)
-  }
-
-  const handleDragOver = (e: React.DragEvent, index: number) => {
-    e.preventDefault()
-    if (draggedIndex !== null && draggedIndex !== index) {
-      moveEmail(draggedIndex, index)
-      setDraggedIndex(index)
-    }
-  }
-
-  const handleDragEnd = () => {
-    setDraggedIndex(null)
-  }
-
-  const handleSendVerification = async (emailId: string) => {
-    if (!onSendVerification) return
-    setSendingVerification(emailId)
+  const run = async (id: string, fn: () => Promise<void> | void) => {
+    setBusyId(id)
     try {
-      await onSendVerification(emailId)
+      await fn()
     } finally {
-      setSendingVerification(null)
+      setBusyId(null)
     }
+  }
+
+  const submitAdd = async () => {
+    const value = newEmail.toLowerCase().trim()
+    if (!isValidEmail(value)) return
+    await run('__add__', async () => {
+      await onAddEmail(value)
+      setNewEmail('')
+      setAdding(false)
+    })
+  }
+
+  const startEdit = (entry: EmailEntry) => {
+    setEditingId(entry.id)
+    setEditValue(entry.email)
+  }
+
+  const submitEdit = async (entry: EmailEntry) => {
+    const value = editValue.toLowerCase().trim()
+    if (!isValidEmail(value)) return
+    if (value === entry.email.toLowerCase()) {
+      setEditingId(null)
+      return
+    }
+    await run(entry.id, async () => {
+      // Only drop the old address once the new one has actually been added — a
+      // deferred step-up (or any failure) returns false and keeps the old address.
+      const added = await onAddEmail(value)
+      if (added) await onDeleteEmail(entry.id)
+      setEditingId(null)
+    })
   }
 
   return (
@@ -106,14 +134,19 @@ export const EmailManager: React.FC<EmailManagerProps> = ({
           <Mail size={20} />
           <Text fontSize="$4" fontWeight="600">Email Addresses</Text>
         </XStack>
-        {!readOnly && (
-          <Button size="$2" icon={Plus} onPress={handleAddEmail}>
+        {readOnly ? null : (
+          <Button
+            size="$2"
+            variant="outlined"
+            icon={Plus}
+            onPress={() => { setAdding(true); setNewEmail('') }}
+          >
             Add
           </Button>
         )}
       </XStack>
 
-      {emails.length === 0 ? (
+      {emails.length === 0 && !adding ? (
         <Card padding="$3" backgroundColor="$backgroundHover">
           <Text fontSize="$3" theme="alt2" textAlign="center">
             No email addresses. Click "Add" to add one.
@@ -121,158 +154,247 @@ export const EmailManager: React.FC<EmailManagerProps> = ({
         </Card>
       ) : (
         <YStack gap="$2">
-          {emails.map((emailEntry, index) => (
-            <Card
-              key={emailEntry.id}
-              padding="$3"
-              backgroundColor={index === 0 ? '$blue2' : '$backgroundHover'}
-              borderWidth={index === 0 ? 1 : 0}
-              borderColor="$blue6"
-              {...({
-                draggable: !readOnly && !emailEntry.isPrimary,
-                onDragStart: () => handleDragStart(index),
-                onDragOver: (e: React.DragEvent) => handleDragOver(e, index),
-                onDragEnd: handleDragEnd,
-              } as any)}
-              opacity={draggedIndex === index ? 0.5 : 1}
-            >
-              <YStack gap="$2">
-                <XStack gap="$3" alignItems="center">
-                  {!readOnly && !emailEntry.isPrimary && (
-                    <YStack cursor="grab" opacity={0.5}>
-                      <GripVertical size={16} />
-                    </YStack>
-                  )}
+          {emails.map((entry, index) => {
+            const isLogin = !!entry.isPrimary
+            const isPreferred = index === 0
+            const isEditing = editingId === entry.id
+            const rowBusy = busyId === entry.id
+            const showMenu = !readOnly && entry.verified && !isLogin
+            const canRename = !readOnly && !isLogin
 
-                  <YStack flex={1} gap="$1">
-                    {readOnly ? (
-                      <XStack gap="$2" alignItems="center" flexWrap="wrap">
-                        <Text fontSize="$4" fontWeight="500">
-                          {emailEntry.email || 'No email'}
-                        </Text>
-                        {index === 0 && (
-                          <Card paddingHorizontal="$2" paddingVertical="$1" backgroundColor="$blue4">
-                            <Text fontSize="$1" color="$blue10">Preferred</Text>
-                          </Card>
-                        )}
-                        {emailEntry.isPrimary && (
-                          <Card paddingHorizontal="$2" paddingVertical="$1" backgroundColor="$gray4">
-                            <Text fontSize="$1" color="$gray11">Login</Text>
-                          </Card>
-                        )}
-                      </XStack>
-                    ) : (
-                      <XStack gap="$2" alignItems="center" flexWrap="wrap">
-                        <Input
-                          flex={1}
-                          minWidth={200}
-                          placeholder="email@example.com"
-                          value={emailEntry.email}
-                          onChangeText={(value) => handleUpdateEmail(emailEntry.id, value)}
-                          keyboardType="email-address"
-                          autoCapitalize="none"
-                          editable={!emailEntry.isPrimary}
-                        />
-                        {index === 0 && (
-                          <Card paddingHorizontal="$2" paddingVertical="$1" backgroundColor="$blue4">
-                            <Text fontSize="$1" color="$blue10">Preferred</Text>
-                          </Card>
-                        )}
-                        {emailEntry.isPrimary && (
-                          <Card paddingHorizontal="$2" paddingVertical="$1" backgroundColor="$gray4">
-                            <Text fontSize="$1" color="$gray11">Login</Text>
-                          </Card>
-                        )}
-                      </XStack>
-                    )}
-
-                    {/* Validation error */}
-                    {emailEntry.email && !isValidEmail(emailEntry.email) && !readOnly && (
-                      <Text fontSize="$2" color="$red10">
-                        Enter a valid email address
-                      </Text>
-                    )}
-                  </YStack>
-
-                  {!readOnly && !emailEntry.isPrimary && (
+            return (
+              <Card
+                key={entry.id}
+                padding="$3"
+                backgroundColor={isLogin ? '$blue2' : '$backgroundHover'}
+                borderWidth={isLogin ? 1 : 0}
+                borderColor="$blue6"
+              >
+                {isEditing ? (
+                  // Inline rename editor
+                  <XStack gap="$2" alignItems="center" flexWrap="wrap">
+                    <Input
+                      flex={1}
+                      minWidth={200}
+                      value={editValue}
+                      onChangeText={setEditValue}
+                      placeholder="email@example.com"
+                      keyboardType="email-address"
+                      autoCapitalize="none"
+                      autoFocus
+                    />
                     <Button
                       size="$2"
-                      circular
-                      icon={Trash2}
-                      theme="red"
-                      onPress={() => handleRemoveEmail(emailEntry.id)}
-                    />
-                  )}
-                </XStack>
-
-                {/* Verification and subscription status */}
-                <XStack gap="$3" alignItems="center" flexWrap="wrap" paddingLeft={!readOnly && !emailEntry.isPrimary ? '$6' : 0}>
-                  {emailEntry.verified ? (
-                    <XStack gap="$1" alignItems="center">
-                      <Check size={14} color="$green10" />
-                      <Text fontSize="$2" color="$green10">Verified</Text>
-                    </XStack>
-                  ) : emailEntry.email && isValidEmail(emailEntry.email) ? (
-                    <XStack gap="$2" alignItems="center">
-                      <XStack gap="$1" alignItems="center">
-                        <AlertCircle size={14} color="$orange10" />
-                        <Text fontSize="$2" color="$orange10">Not verified</Text>
-                      </XStack>
-                      {onSendVerification && (
+                      variant="outlined"
+                      icon={X}
+                      onPress={() => setEditingId(null)}
+                      disabled={rowBusy}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      size="$2"
+                      theme="blue"
+                      icon={rowBusy ? <Spinner size="small" /> : Check}
+                      onPress={() => submitEdit(entry)}
+                      disabled={rowBusy || !isValidEmail(editValue.trim())}
+                    >
+                      Save
+                    </Button>
+                  </XStack>
+                ) : (
+                  <XStack gap="$2" alignItems="flex-start">
+                    {/* Left edit gutter — consistent on every row */}
+                    <XStack width={GUTTER} alignItems="center" justifyContent="flex-start">
+                      {readOnly ? null : isLogin ? (
+                        canChangeLogin ? (
+                          <Button
+                            size="$2"
+                            circular
+                            chromeless
+                            icon={Pencil}
+                            aria-label="Change login email"
+                            onPress={onChangeLogin}
+                          />
+                        ) : null
+                      ) : (
                         <Button
-                          size="$1"
-                          icon={sendingVerification === emailEntry.id ? <Spinner size="small" /> : Send}
-                          onPress={() => handleSendVerification(emailEntry.id)}
-                          disabled={sendingVerification !== null}
-                        >
-                          {emailEntry.verificationSentAt ? 'Resend' : 'Verify'}
-                        </Button>
+                          size="$2"
+                          circular
+                          chromeless
+                          icon={Pencil}
+                          aria-label="Edit email"
+                          onPress={() => startEdit(entry)}
+                          disabled={rowBusy}
+                        />
                       )}
                     </XStack>
-                  ) : null}
 
-                  {emailEntry.verified && (
-                    <>
-                      {emailEntry.subscriptionCount !== undefined && (
-                        <Text fontSize="$2" theme="alt2">
-                          {emailEntry.subscriptionCount === 0
-                            ? 'You are not currently signed up to any emails'
-                            : `You are currently signed up to ${emailEntry.subscriptionCount} email${emailEntry.subscriptionCount === 1 ? '' : 's'}`}
+                    {/* Value + badges */}
+                    <YStack flex={1} gap="$1" minWidth={0}>
+                      <XStack gap="$2" alignItems="center" flexWrap="wrap">
+                        <Text fontSize="$4" fontWeight="500">
+                          {entry.email || 'No email'}
                         </Text>
+                        {isPreferred ? (
+                          <Card paddingHorizontal="$2" paddingVertical="$1" backgroundColor="$blue4">
+                            <Text fontSize="$1" color="$blue10">Preferred</Text>
+                          </Card>
+                        ) : null}
+                        {isLogin ? (
+                          <Card paddingHorizontal="$2" paddingVertical="$1" backgroundColor="$gray4">
+                            <Text fontSize="$1" color="$gray11">Login</Text>
+                          </Card>
+                        ) : null}
+                      </XStack>
+                    </YStack>
+
+                    {/* Right actions */}
+                    <XStack gap="$2" alignItems="center">
+                      {entry.verified ? (
+                        <XStack gap="$1" alignItems="center">
+                          <Check size={15} color="$green10" />
+                          <Text fontSize="$2" color="$green10" fontWeight="600">Verified</Text>
+                        </XStack>
+                      ) : (
+                        <XStack gap="$2" alignItems="center">
+                          <XStack gap="$1" alignItems="center">
+                            <AlertCircle size={14} color="$orange10" />
+                            <Text fontSize="$2" color="$orange10" fontWeight="600">Not verified</Text>
+                          </XStack>
+                          {readOnly ? null : (
+                            <Button
+                              size="$1"
+                              variant="outlined"
+                              icon={busyId === `verify-${entry.id}` ? <Spinner size="small" /> : Send}
+                              onPress={() => run(`verify-${entry.id}`, () => onSendVerification(entry.id))}
+                              disabled={busyId !== null}
+                            >
+                              {entry.verificationSentAt ? 'Resend' : 'Verify'}
+                            </Button>
+                          )}
+                        </XStack>
                       )}
-                      <Button
-                        size="$1"
-                        icon={Bell}
-                        onPress={() => {
-                          if (typeof window !== 'undefined') window.location.href = emailPreferencesUrl
-                        }}
-                      >
-                        Manage my Email Notifications
-                      </Button>
-                    </>
-                  )}
-                </XStack>
-              </YStack>
+
+                      {showMenu ? (
+                        <Popover
+                          size="$3"
+                          allowFlip
+                          open={openMenuId === entry.id}
+                          onOpenChange={(open) => setOpenMenuId(open ? entry.id : null)}
+                        >
+                          <Popover.Trigger asChild>
+                            <Button
+                              size="$2"
+                              circular
+                              chromeless
+                              icon={MoreHorizontal}
+                              aria-label="More actions"
+                            />
+                          </Popover.Trigger>
+                          <Popover.Content
+                            bordered
+                            elevate
+                            padding="$0"
+                            enterStyle={{ y: -6, opacity: 0 }}
+                            exitStyle={{ y: -6, opacity: 0 }}
+                            animation="quick"
+                          >
+                            <YStack minWidth={220}>
+                              {isPreferred ? null : (
+                                <Button
+                                  chromeless
+                                  justifyContent="flex-start"
+                                  borderRadius={0}
+                                  icon={Star}
+                                  onPress={() => {
+                                    setOpenMenuId(null)
+                                    void run(entry.id, () => onSetPreferred(entry.id))
+                                  }}
+                                >
+                                  Set as preferred
+                                </Button>
+                              )}
+                              {!isPreferred && canChangeLogin ? <Separator /> : null}
+                              {canChangeLogin ? (
+                                <Button
+                                  chromeless
+                                  justifyContent="flex-start"
+                                  borderRadius={0}
+                                  icon={Shield}
+                                  onPress={() => {
+                                    setOpenMenuId(null)
+                                    onSetLogin(entry.email)
+                                  }}
+                                >
+                                  Set as login
+                                </Button>
+                              ) : null}
+                            </YStack>
+                          </Popover.Content>
+                        </Popover>
+                      ) : null}
+
+                      {readOnly || isLogin ? null : (
+                        <Button
+                          size="$2"
+                          circular
+                          chromeless
+                          icon={rowBusy ? <Spinner size="small" /> : Trash2}
+                          color="$red10"
+                          aria-label="Delete this address"
+                          onPress={() => run(entry.id, () => onDeleteEmail(entry.id))}
+                          disabled={rowBusy}
+                        />
+                      )}
+                    </XStack>
+                  </XStack>
+                )}
+              </Card>
+            )
+          })}
+
+          {adding ? (
+            <Card padding="$3" backgroundColor="$backgroundHover">
+              <XStack gap="$2" alignItems="center" flexWrap="wrap">
+                <XStack width={GUTTER} />
+                <Input
+                  flex={1}
+                  minWidth={200}
+                  value={newEmail}
+                  onChangeText={setNewEmail}
+                  placeholder="email@example.com"
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                  autoFocus
+                />
+                <Button
+                  size="$2"
+                  variant="outlined"
+                  icon={X}
+                  onPress={() => { setAdding(false); setNewEmail('') }}
+                  disabled={busyId === '__add__'}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="$2"
+                  theme="blue"
+                  icon={busyId === '__add__' ? <Spinner size="small" /> : Check}
+                  onPress={submitAdd}
+                  disabled={busyId === '__add__' || !isValidEmail(newEmail.trim())}
+                >
+                  Add
+                </Button>
+              </XStack>
+              {newEmail && !isValidEmail(newEmail.trim()) ? (
+                <Text fontSize="$2" color="$red10" paddingTop="$2" paddingLeft={GUTTER + 8}>
+                  Enter a valid email address
+                </Text>
+              ) : null}
             </Card>
-          ))}
+          ) : null}
         </YStack>
-      )}
-
-      {emails.length > 1 && !readOnly && (
-        <Text fontSize="$2" theme="alt2" textAlign="center">
-          Drag to reorder. First email is your preferred contact.
-        </Text>
-      )}
-
-      {onSave && !readOnly && (
-        <Button
-          theme="blue"
-          onPress={onSave}
-          disabled={saving || emails.some(e => e.email && !isValidEmail(e.email))}
-          icon={saving ? <Spinner /> : undefined}
-        >
-          {saving ? 'Saving...' : 'Save Email Addresses'}
-        </Button>
       )}
     </YStack>
   )

--- a/packages/ui/src/profile/email-ordering.ts
+++ b/packages/ui/src/profile/email-ordering.ts
@@ -1,0 +1,16 @@
+/**
+ * Pure ordering helpers for the email list. Kept free of any Tamagui/React
+ * imports so it can be unit-tested in a plain node env.
+ *
+ * The model behind "Set as preferred": the preferred address is simply the
+ * item at index 0. Moving an address to the front and replacing the whole
+ * ordered set (PUT /api/user/emails) is how preference is persisted.
+ */
+export function moveEmailToFront<T extends { id: string }>(list: T[], id: string): T[] {
+  const idx = list.findIndex((e) => e.id === id)
+  if (idx <= 0) return list.slice()
+  const next = list.slice()
+  const [moved] = next.splice(idx, 1)
+  next.unshift(moved)
+  return next
+}


### PR DESCRIPTION
Tightens the Profile → Contact Info screen — the fix for the "accident waiting to happen" whitespace/edit-placement, built to an approved mockup.

## What changed
- **Name & Ecclesia:** edit pencil now sits in a consistent **left gutter** tight to the value; removed the far-right pencil stranded across the whitespace, and dropped the decorative type icons.
- **Email Addresses:** **every** address is shown as a row — left edit, Preferred/Login badges, a per-row **Verified** check or **Resend** button, **soft delete** (non-login), and a **⋯ menu** with **Set as preferred** and (flag-gated) **Set as login**.
- **Save-in-place:** removed the full-width "Save Email Addresses" button — each row hits the API immediately, then refetches.
- Removed the misleading "signed up to N emails" line — subscriptions move to their **own tab** (a later slice; not built here).
- **Change email, resolved two ways:** promote an already-verified address via ⋯ → *Set as login*, or change to a brand-new address via the login row's *Change login email* pencil — **both reuse the existing secure `ChangeEmailFlow`** (launched in a modal, pre-filled for a known address). No new backend.

## Safety / scope
- **Launch-dark preserved:** *Set as login* / *Change login email* only appear when `SECURE_EMAIL_CHANGE` is available to the session (`/api/user/email-change/available`). This PR ships the visual redesign + Set-as-preferred **live**; the identity-change path stays dark until you flip the flag.
- Every mutation routes a live `403 stepUpRequired` (the now-merged fresh-auth gate) through the existing `<Verify>` overlay + retry — edits don't just error for stale sessions.
- Cross-platform boundary kept: `EmailManager` stays Tamagui-only; next-auth stays in the Next page.

## Review fix (caught during oversight)
The inline-rename path deleted the old address even when the add was only **deferred** by a step-up (`handleAddEmail` resolves on a 403) — a data-loss window. `handleAddEmail` now reports whether the add actually landed, and rename drops the old address **only** when it did.

## Verification
Typecheck clean; `yarn build` reached "Compiled successfully"; `email-ordering` + `user-emails-route` tests green (10). Visual matches the approved mockup. (Not built: the Email Subscriptions tab; phone-manager left as-is.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)