### PR TITLE
fix(profile): cap Contact Info width + surface the Recording Brother email

### DIFF
--- a/apps/next/app/api/user/emails/route.ts
+++ b/apps/next/app/api/user/emails/route.ts
@@ -43,9 +43,19 @@ export async function GET() {
     const result = await userRepository.getEmails(session.user.email)
 
     // Sort by order and transform to client format
-    // Always include the primary login email
+    type ClientEmail = {
+      id: string
+      email: string
+      verified: boolean
+      verificationSentAt?: string
+      subscribed?: boolean
+      subscriptionCount?: number
+      isPrimary?: boolean
+      /** A role this address represents (e.g. Recording Brother) — shown read-only. */
+      roleLabel?: string
+    }
     const sorted = result.items.sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
-    const emails = await Promise.all(
+    let emails: ClientEmail[] = await Promise.all(
       sorted.map(async (email) => ({
         id: email.emailId,
         email: email.email,
@@ -59,26 +69,42 @@ export async function GET() {
       }))
     )
 
-    // If no emails stored, create entry for primary login email
+    // If nothing is stored yet, seed with the login email.
     if (emails.length === 0) {
-      const primaryEmail = {
-        id: 'primary',
-        email: session.user.email,
-        verified: true, // Login email is verified by definition
-        subscribed: true, // Assume subscribed by default
-        subscriptionCount: await getPublicOptInCount(session.user.email),
-        isPrimary: true,
-      }
-      return NextResponse.json({
-        success: true,
-        emails: [primaryEmail],
-      })
+      emails = [
+        {
+          id: 'primary',
+          email: session.user.email,
+          verified: true, // Login email is verified by definition
+          subscribed: true,
+          subscriptionCount: await getPublicOptInCount(session.user.email),
+          isPrimary: true,
+        },
+      ]
     }
 
-    return NextResponse.json({
-      success: true,
-      emails,
-    })
+    // Surface the Recording Brother ECCLESIA email. It lives on the PersonRecord
+    // (`rbEcclesiaEmail`), NOT the USER# email store, so it never appeared here —
+    // yet the RB genuinely receives on it. Shown read-only: it's a role address,
+    // managed via the ecclesia / RB settings, not deletable from a personal profile.
+    try {
+      const person = await personRepository.getByEmail(session.user.email.toLowerCase())
+      const rbEmail = person?.isRecordingBrother ? person.rbEcclesiaEmail?.toLowerCase() : undefined
+      if (rbEmail && !emails.some((e) => e.email.toLowerCase() === rbEmail)) {
+        emails.push({
+          id: 'rb-ecclesia',
+          email: rbEmail,
+          verified: true,
+          isPrimary: false,
+          subscriptionCount: await getPublicOptInCount(rbEmail),
+          roleLabel: 'Recording Brother',
+        })
+      }
+    } catch (rbErr) {
+      console.error('Surface RB ecclesia email failed (non-fatal):', rbErr)
+    }
+
+    return NextResponse.json({ success: true, emails })
   } catch (error) {
     console.error('Get emails error:', error)
     return NextResponse.json(

--- a/packages/app/features/profile/user-profile.tsx
+++ b/packages/app/features/profile/user-profile.tsx
@@ -678,7 +678,11 @@ export const UserProfile: React.FC<UserProfileProps> = ({
             </Tabs.List>
 
             <Tabs.Content value="contact">
-              <YStack gap="$6" paddingTop="$4" paddingBottom="$8">
+              {/* Tight vertical rhythm — the sections were $6 (~24px) apart, which
+                  read as miles of empty space between rows. */}
+              <YStack gap="$3" paddingTop="$3" paddingBottom="$5">
+                {/* Name + ecclesia grouped tight (they're one identity block). */}
+                <YStack gap="$2">
                 {/* Name */}
                 <YStack gap="$3">
                   {editingName ? (
@@ -832,6 +836,7 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                       </XStack>
                     </Card>
                   )}
+                </YStack>
                 </YStack>
 
                 <Separator />

--- a/packages/app/features/profile/user-profile.tsx
+++ b/packages/app/features/profile/user-profile.tsx
@@ -326,12 +326,17 @@ export const UserProfile: React.FC<UserProfileProps> = ({
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        emails: reordered.map(e => ({
-          id: e.id,
-          email: e.email,
-          verified: e.verified,
-          isPrimary: e.isPrimary,
-        })),
+        // Role entries (e.g. the Recording Brother ecclesia email) are surfaced
+        // read-only from the PersonRecord — they must NOT be written back into the
+        // USER# email store, so exclude them from the replace-all payload.
+        emails: reordered
+          .filter(e => !e.roleLabel)
+          .map(e => ({
+            id: e.id,
+            email: e.email,
+            verified: e.verified,
+            isPrimary: e.isPrimary,
+          })),
       }),
     })
     if (res.ok) {
@@ -626,7 +631,9 @@ export const UserProfile: React.FC<UserProfileProps> = ({
   return (
     <Wrapper>
       <Section gap={'$4'}>
-        <YStack gap="$4">
+        {/* Cap the settings column so rows don't stretch edge-to-edge on wide
+            viewports (the far-apart controls read as disconnected otherwise). */}
+        <YStack gap="$4" width="100%" maxWidth={880} alignSelf="center">
           {/* Header */}
           <YStack gap="$2">
             <Heading size={5}>My Profile</Heading>

--- a/packages/ui/src/profile/email-manager.tsx
+++ b/packages/ui/src/profile/email-manager.tsx
@@ -24,6 +24,9 @@ export interface EmailEntry {
   verified: boolean
   verificationSentAt?: string
   isPrimary?: boolean // Primary login email (cannot be removed)
+  /** A role this address represents (e.g. "Recording Brother"). Rendered read-only
+   *  with a badge — it's managed elsewhere (ecclesia/RB settings), not editable here. */
+  roleLabel?: string
   // NOTE: `subscribed`/`subscriptionCount` used to render here; subscriptions now
   // live in their own tab. Kept optional so the API payload still type-checks.
   subscribed?: boolean
@@ -156,11 +159,12 @@ export const EmailManager: React.FC<EmailManagerProps> = ({
         <YStack gap="$2">
           {emails.map((entry, index) => {
             const isLogin = !!entry.isPrimary
-            const isPreferred = index === 0
+            const isRole = !!entry.roleLabel // e.g. Recording Brother — read-only
+            const isPreferred = index === 0 && !isRole
             const isEditing = editingId === entry.id
             const rowBusy = busyId === entry.id
-            const showMenu = !readOnly && entry.verified && !isLogin
-            const canRename = !readOnly && !isLogin
+            const showMenu = !readOnly && entry.verified && !isLogin && !isRole
+            const canRename = !readOnly && !isLogin && !isRole
 
             return (
               <Card
@@ -206,7 +210,7 @@ export const EmailManager: React.FC<EmailManagerProps> = ({
                   <XStack gap="$2" alignItems="flex-start">
                     {/* Left edit gutter — consistent on every row */}
                     <XStack width={GUTTER} alignItems="center" justifyContent="flex-start">
-                      {readOnly ? null : isLogin ? (
+                      {readOnly || isRole ? null : isLogin ? (
                         canChangeLogin ? (
                           <Button
                             size="$2"
@@ -244,6 +248,11 @@ export const EmailManager: React.FC<EmailManagerProps> = ({
                         {isLogin ? (
                           <Card paddingHorizontal="$2" paddingVertical="$1" backgroundColor="$gray4">
                             <Text fontSize="$1" color="$gray11">Login</Text>
+                          </Card>
+                        ) : null}
+                        {isRole ? (
+                          <Card paddingHorizontal="$2" paddingVertical="$1" backgroundColor="$color4">
+                            <Text fontSize="$1" color="$color11">{entry.roleLabel}</Text>
                           </Card>
                         ) : null}
                       </XStack>
@@ -335,7 +344,7 @@ export const EmailManager: React.FC<EmailManagerProps> = ({
                         </Popover>
                       ) : null}
 
-                      {readOnly || isLogin ? null : (
+                      {readOnly || isLogin || isRole ? null : (
                         <Button
                           size="$2"
                           circular


### PR DESCRIPTION
Two follow-ups on the live Profile → Contact Info (after #147).

## 1. Too much horizontal space
`Tabs.Content` was a plain full-width `YStack` — nothing capped it, so on a wide viewport the row controls stretched apart into whitespace (the very thing the redesign was meant to fix; it only *looked* right in the max-width mockup). **Fix:** cap the settings column at **880px, centered** — the app's existing `maxWidth` convention (e.g. daily-readings), using our UI primitives, no inline hacks.

## 2. The Recording Brother email was missing
The address list was built **only** from the legacy `USER#` store (`userRepository.getEmails`), which never holds `rbEcclesiaEmail` (`teerecbro@gmail.com`) — that lives on the **PersonRecord** and drives every RB nomination/confirmation flow. The RB genuinely receives on it, so it's now surfaced from the PersonRecord and shown **read-only** with a **"Recording Brother"** badge (a role address, managed in ecclesia settings — no edit/delete/⋯). It's excluded from the set-preferred replace-all write so it can never be persisted into the `USER#` store.

## Visual
Approved mockup updated with both (capped column + the read-only RB row): the same design link from the session.

## Verification
Typecheck clean; `user-emails-route` + `email-ordering` tests green (10). Cross-platform boundary kept (EmailManager stays Tamagui-only). 

Note: this is the focused fix. The deeper "source the whole profile email list from PersonRecords instead of the USER# store" is the standing legacy-store disconnect (tracked separately) — not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)