### PR TITLE
One email system: profile + verify on PersonRecords, retire USER# writes

### DIFF
--- a/apps/next/app/api/people/[email]/contacts/route.ts
+++ b/apps/next/app/api/people/[email]/contacts/route.ts
@@ -1,9 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { randomBytes } from 'crypto'
 import { auth } from '../../../../../utils/auth'
 import { personRepository } from '@my/app/provider/dynamodb/repositories/person-repository'
 import { relationshipRepository } from '@my/app/provider/dynamodb/repositories/relationship-repository'
-import { userRepository } from '@my/app/provider/dynamodb/repositories/user-repository'
+import { tokenRepository } from '@my/app/provider/dynamodb/repositories/token-repository'
 import { ROLES } from '@my/app/provider/auth/auth-roles'
 import { invalidatePeopleCache } from '../../cache'
 import { sendEmailChangeNotification, sendAdminAddedEmailVerification } from '../../../../../utils/email/send-email-change-notification'
@@ -117,27 +116,20 @@ export async function POST(
           || [targetPerson.firstName, targetPerson.lastName].filter(Boolean).join(' ')
           || 'Member'
 
-        // Send verification email to the NEW email address
+        // Send verification email to the NEW email address. Mint a single-use
+        // token in the unified TokenRepository so the /api/user/emails/verify?token
+        // callback resolves it (O(1) GSI4) and marks the PersonRecord EMAIL# row
+        // verified — no legacy USER# token write.
         try {
-          const token = randomBytes(32).toString('hex')
-          const expiry = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
-
-          // Store verification token on the USER# email record (legacy system)
-          // so the existing /api/user/emails/verify?token=xxx callback can find it
-          await userRepository.addEmail(targetPerson.primaryEmail, {
-            emailId: record.emailId,
-            email: email.toLowerCase().trim(),
-            verified: false,
-            order: existingEmails.length,
-            verificationToken: token,
-            verificationTokenExpiry: expiry,
-            verificationSentAt: new Date().toISOString(),
-          })
+          const token = await tokenRepository.createEmailVerification(
+            targetPerson.personId,
+            email.toLowerCase().trim()
+          )
 
           await sendAdminAddedEmailVerification({
             newEmail: email.toLowerCase().trim(),
             personName,
-            verificationToken: token,
+            verificationToken: token.tokenValue,
             addedByName: permResult.viewerName,
           })
         } catch (verifyError) {

--- a/apps/next/app/api/user/emails/route.ts
+++ b/apps/next/app/api/user/emails/route.ts
@@ -1,24 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { randomBytes } from 'crypto'
 import { auth } from '../../../../utils/auth'
-import { userRepository } from '@my/app/provider/dynamodb/repositories/user-repository'
 import { personRepository } from '@my/app/provider/dynamodb/repositories/person-repository'
-import { sendEmail } from '../../../../utils/email/sesClient'
+import { tokenRepository } from '@my/app/provider/dynamodb/repositories/token-repository'
+import { userRepository } from '@my/app/provider/dynamodb/repositories/user-repository'
 import { getPublicOptInCount } from '../../../../utils/email/public-topics'
 import { requireFreshAuth } from '../../../../utils/require-fresh-auth'
-
-// Generate a simple unique ID
-function generateEmailId(): string {
-  return `email-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
-}
-
-// Generate secure verification token
-function generateVerificationToken(): string {
-  return randomBytes(32).toString('hex')
-}
-
-// Token expiry: 24 hours
-const TOKEN_EXPIRY_MS = 24 * 60 * 60 * 1000
+import type { PersonRecord } from '@my/app/provider/dynamodb/types'
 
 // Simple email validation
 function isValidEmail(email: string): boolean {
@@ -26,8 +13,24 @@ function isValidEmail(email: string): boolean {
 }
 
 /**
+ * Resolve the acting person from the session login email. Prefers the O(1)
+ * primary-email GSI1 lookup, then falls back to any-address match so a login on
+ * a secondary still resolves the owner.
+ */
+async function resolveActingPerson(loginEmail: string): Promise<PersonRecord | null> {
+  const email = loginEmail.toLowerCase()
+  let person = await personRepository.getByEmail(email)
+  if (!person) {
+    const persons = await personRepository.getAllPersonsByEmail(email)
+    person = persons[0] || null
+  }
+  return person
+}
+
+/**
  * GET /api/user/emails - Get all emails for current user
- * Returns emails sorted by order (first = preferred)
+ * Sourced from PersonRecord EMAIL# rows (the single system). Lazily heals any
+ * historical USER#-only addresses onto the PersonRecord on read.
  */
 export async function GET() {
   try {
@@ -40,9 +43,9 @@ export async function GET() {
       )
     }
 
-    const result = await userRepository.getEmails(session.user.email)
+    const loginEmail = session.user.email.toLowerCase()
+    const person = await resolveActingPerson(loginEmail)
 
-    // Sort by order and transform to client format
     type ClientEmail = {
       id: string
       email: string
@@ -54,41 +57,90 @@ export async function GET() {
       /** A role this address represents (e.g. Recording Brother) — shown read-only. */
       roleLabel?: string
     }
-    const sorted = result.items.sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
-    let emails: ClientEmail[] = await Promise.all(
-      sorted.map(async (email) => ({
-        id: email.emailId,
-        email: email.email,
-        verified: email.verified,
-        verificationSentAt: email.verificationSentAt,
-        subscribed: email.subscribed,
-        // How many public mailing lists this address is opted into (verified
-        // addresses only — no point querying SES for an unverified one).
-        subscriptionCount: email.verified ? await getPublicOptInCount(email.email) : undefined,
-        isPrimary: email.isPrimary,
-      }))
-    )
+
+    let emails: ClientEmail[] = []
+
+    if (person) {
+      // Lazy-migrate: fold any USER#-only addresses into the PersonRecord. This is
+      // per-session, additive and idempotent — it heals historical addresses that
+      // only ever lived in the legacy USER# store (no data loss, no batch job).
+      try {
+        const [personEmails, legacy] = await Promise.all([
+          personRepository.getEmails(person.personId),
+          userRepository.getEmails(loginEmail),
+        ])
+        const known = new Set(personEmails.map(e => e.email.toLowerCase()))
+        for (const legacyEmail of legacy.items) {
+          const addr = legacyEmail.email.toLowerCase()
+          if (known.has(addr)) continue
+          await personRepository.addEmail(person.personId, {
+            email: addr,
+            emailType: legacyEmail.isPrimary ? 'primary' : 'secondary',
+            order: legacyEmail.order ?? known.size,
+            verified: !!legacyEmail.verified,
+            sesSubscribed: legacyEmail.subscribed ?? false,
+            sesStatus: 'active',
+          })
+          known.add(addr)
+        }
+      } catch (migrateErr) {
+        console.error('[user/emails] lazy-migrate of legacy USER# emails failed (non-fatal):', migrateErr)
+      }
+
+      // Re-read so freshly-healed rows are included in the response.
+      const personEmails = await personRepository.getEmails(person.personId)
+
+      // Derive "verification pending" from an active email_verification token for
+      // the address (createEmailVerification keeps at most one per person). No
+      // schema field needed — the token IS the pending state.
+      const pendingByEmail = new Map<string, string>()
+      try {
+        const tokens = await tokenRepository.getByPersonAndType(person.personId, 'email_verification')
+        const now = Date.now()
+        for (const t of tokens) {
+          if (t.usedAt) continue
+          if (new Date(t.expiresAt).getTime() < now) continue
+          pendingByEmail.set(t.email.toLowerCase(), t.createdAt)
+        }
+      } catch (tokErr) {
+        console.error('[user/emails] deriving verificationSentAt failed (non-fatal):', tokErr)
+      }
+
+      const sorted = [...personEmails].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+      emails = await Promise.all(
+        sorted.map(async (email) => ({
+          id: email.emailId,
+          email: email.email,
+          verified: email.verified,
+          verificationSentAt: pendingByEmail.get(email.email.toLowerCase()),
+          subscribed: email.sesSubscribed,
+          // How many public mailing lists this address is opted into (verified
+          // addresses only — no point querying SES for an unverified one).
+          subscriptionCount: email.verified ? await getPublicOptInCount(email.email) : undefined,
+          isPrimary: email.emailType === 'primary',
+        }))
+      )
+    }
 
     // If nothing is stored yet, seed with the login email.
     if (emails.length === 0) {
       emails = [
         {
           id: 'primary',
-          email: session.user.email,
+          email: loginEmail,
           verified: true, // Login email is verified by definition
           subscribed: true,
-          subscriptionCount: await getPublicOptInCount(session.user.email),
+          subscriptionCount: await getPublicOptInCount(loginEmail),
           isPrimary: true,
         },
       ]
     }
 
     // Surface the Recording Brother ECCLESIA email. It lives on the PersonRecord
-    // (`rbEcclesiaEmail`), NOT the USER# email store, so it never appeared here —
+    // (`rbEcclesiaEmail`), NOT the personal email set, so it never appeared here —
     // yet the RB genuinely receives on it. Shown read-only: it's a role address,
     // managed via the ecclesia / RB settings, not deletable from a personal profile.
     try {
-      const person = await personRepository.getByEmail(session.user.email.toLowerCase())
       const rbEmail = person?.isRecordingBrother ? person.rbEcclesiaEmail?.toLowerCase() : undefined
       if (rbEmail && !emails.some((e) => e.email.toLowerCase() === rbEmail)) {
         emails.push({
@@ -115,9 +167,9 @@ export async function GET() {
 }
 
 /**
- * PUT /api/user/emails - Replace all emails (batch update with ordering)
- * Body: { emails: Array<{ id: string, email: string, verified?: boolean }> }
- * Order is determined by array index (first = preferred)
+ * PUT /api/user/emails - Reorder emails ("set as preferred" moves an address to
+ * the front). Order is the array index. Display order only — never an identity
+ * transfer, so the primary login email is untouched.
  */
 export async function PUT(request: NextRequest) {
   try {
@@ -135,7 +187,7 @@ export async function PUT(request: NextRequest) {
     if (!gate.ok) return gate.response
 
     const body = await request.json()
-    const { emails } = body as { emails: Array<{ id: string; email: string; verified?: boolean; isPrimary?: boolean; subscribed?: boolean }> }
+    const { emails } = body as { emails: Array<{ id: string; email: string }> }
 
     if (!Array.isArray(emails)) {
       return NextResponse.json(
@@ -144,56 +196,26 @@ export async function PUT(request: NextRequest) {
       )
     }
 
-    // Validate each email
-    for (const email of emails) {
-      if (email.email && !isValidEmail(email.email)) {
-        return NextResponse.json(
-          { error: `Invalid email address: ${email.email}` },
-          { status: 400 }
-        )
-      }
+    const person = await resolveActingPerson(session.user.email)
+    if (!person) {
+      return NextResponse.json(
+        { error: 'No profile found for your account' },
+        { status: 404 }
+      )
     }
 
-    // Get existing emails to preserve verification status
-    const existing = await userRepository.getEmails(session.user.email)
-    const existingByEmail = new Map(existing.items.map(e => [e.email.toLowerCase(), e]))
+    // Only reorder real EMAIL# rows — filter out synthetic ids (seeded 'primary',
+    // read-only 'rb-ecclesia') and anything not on this person.
+    const personEmails = await personRepository.getEmails(person.personId)
+    const validIds = new Set(personEmails.map(e => e.emailId))
+    const orderedIds = emails.map(e => e.id).filter(id => validIds.has(id))
 
-    // Ensure primary login email is always included
-    let hasPrimary = emails.some(e => e.email.toLowerCase() === session.user.email?.toLowerCase())
-    if (!hasPrimary) {
-      // Add primary email at the start
-      emails.unshift({
-        id: 'primary',
-        email: session.user.email,
-        verified: true,
-        isPrimary: true,
-        subscribed: true,
-      })
-    }
-
-    // Filter out empty emails and prepare for save
-    const validEmails = emails
-      .filter(e => e.email && isValidEmail(e.email))
-      .map((email, index) => {
-        const existingRecord = existingByEmail.get(email.email.toLowerCase())
-        const isPrimaryLogin = email.email.toLowerCase() === session.user.email?.toLowerCase()
-
-        return {
-          emailId: email.id || generateEmailId(),
-          email: email.email.toLowerCase(),
-          verified: isPrimaryLogin ? true : (existingRecord?.verified ?? false),
-          order: index,
-          isPrimary: isPrimaryLogin,
-          subscribed: existingRecord?.subscribed ?? true,
-        }
-      })
-
-    await userRepository.replaceAllEmails(session.user.email, validEmails)
+    await personRepository.setEmailOrder(person.personId, orderedIds)
 
     return NextResponse.json({
       success: true,
       message: 'Email addresses updated',
-      count: validEmails.length,
+      count: orderedIds.length,
     })
   } catch (error) {
     console.error('Update emails error:', error)
@@ -205,7 +227,7 @@ export async function PUT(request: NextRequest) {
 }
 
 /**
- * POST /api/user/emails - Add a new email
+ * POST /api/user/emails - Add a new secondary email to the acting person.
  */
 export async function POST(request: NextRequest) {
   try {
@@ -235,66 +257,46 @@ export async function POST(request: NextRequest) {
 
     const normalized = email.toLowerCase()
 
-    // Check if email already exists (legacy USER# store)
-    const existing = await userRepository.getEmails(session.user.email)
-    if (existing.items.some(e => e.email.toLowerCase() === normalized)) {
+    const person = await resolveActingPerson(session.user.email)
+    if (!person) {
+      return NextResponse.json(
+        { error: 'No profile found for your account' },
+        { status: 404 }
+      )
+    }
+
+    // Dup-check against THIS person's existing addresses (PersonRecord is the
+    // single source of truth now).
+    const personEmails = await personRepository.getEmails(person.personId)
+    if (personEmails.some(e => e.email.toLowerCase() === normalized)) {
       return NextResponse.json(
         { error: 'This email address is already added' },
         { status: 409 }
       )
     }
 
-    // Resolve the acting person, and guard against attaching an address that
-    // already belongs to a DIFFERENT person — silently doing so would merge two
-    // identities. (Resolves via any address now that getByEmail sees secondaries.)
-    const person = await personRepository.getByEmail(session.user.email.toLowerCase())
-    if (person) {
-      const owners = await personRepository.getAllPersonsByEmail(normalized)
-      if (owners.some(p => p.personId !== person.personId)) {
-        return NextResponse.json(
-          { error: 'That email is already associated with another person in the directory.' },
-          { status: 409 }
-        )
-      }
+    // Collision guard: never attach an address that already belongs to a
+    // DIFFERENT person — silently doing so would merge two identities.
+    const owners = await personRepository.getAllPersonsByEmail(normalized)
+    if (owners.some(p => p.personId !== person.personId)) {
+      return NextResponse.json(
+        { error: 'That email is already associated with another person in the directory.' },
+        { status: 409 }
+      )
     }
 
-    const emailId = generateEmailId()
-    const order = existing.items.length
-
-    await userRepository.addEmail(session.user.email, {
-      emailId,
+    const record = await personRepository.addEmail(person.personId, {
       email: normalized,
+      emailType: 'secondary',
+      order: personEmails.length,
       verified: false,
-      order,
-      isPrimary: false,
+      sesSubscribed: false,
+      sesStatus: 'active',
     })
-
-    // Mirror the address onto the PersonRecord as a SECONDARY EMAIL# item, so it
-    // resolves (via GSI1) to this person. Without this the verify/lookup flow
-    // can't find the owner and mints a duplicate orphan profile. Best-effort:
-    // never fail the request if this half hiccups (the USER# add already stuck).
-    if (person) {
-      try {
-        const pEmails = await personRepository.getEmails(person.personId)
-        const alreadyOnPerson = pEmails.some(e => e.email.toLowerCase() === normalized)
-        if (!alreadyOnPerson) {
-          await personRepository.addEmail(person.personId, {
-            email: normalized,
-            emailType: 'secondary',
-            order: pEmails.length,
-            verified: false,
-            sesSubscribed: false,
-            sesStatus: 'active',
-          })
-        }
-      } catch (err) {
-        console.error('[user/emails] failed to mirror secondary email to PersonRecord:', err)
-      }
-    }
 
     return NextResponse.json({
       success: true,
-      emailId,
+      emailId: record.emailId,
       message: 'Email added. Please verify it.',
     })
   } catch (error) {
@@ -307,7 +309,7 @@ export async function POST(request: NextRequest) {
 }
 
 /**
- * DELETE /api/user/emails - Delete an email
+ * DELETE /api/user/emails - Delete a secondary email
  */
 export async function DELETE(request: NextRequest) {
   try {
@@ -334,23 +336,31 @@ export async function DELETE(request: NextRequest) {
       )
     }
 
-    // Verify the email exists and is not the primary
-    const existing = await userRepository.getEmail(session.user.email, emailId)
-    if (!existing) {
+    const person = await resolveActingPerson(session.user.email)
+    if (!person) {
+      return NextResponse.json(
+        { error: 'No profile found for your account' },
+        { status: 404 }
+      )
+    }
+
+    // Verify the email exists and is not the primary login address.
+    const target = await personRepository.getEmailById(person.personId, emailId)
+    if (!target) {
       return NextResponse.json(
         { error: 'Email not found' },
         { status: 404 }
       )
     }
 
-    if (existing.isPrimary) {
+    if (target.emailType === 'primary') {
       return NextResponse.json(
         { error: 'Cannot delete your primary login email' },
         { status: 400 }
       )
     }
 
-    await userRepository.deleteEmail(session.user.email, emailId)
+    await personRepository.removeEmail(person.personId, emailId)
 
     return NextResponse.json({
       success: true,

--- a/apps/next/app/api/user/emails/verify/route.ts
+++ b/apps/next/app/api/user/emails/verify/route.ts
@@ -1,16 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { randomBytes } from 'crypto'
 import { auth } from '../../../../../utils/auth'
+import { personRepository } from '@my/app/provider/dynamodb/repositories/person-repository'
+import { tokenRepository } from '@my/app/provider/dynamodb/repositories/token-repository'
 import { userRepository } from '@my/app/provider/dynamodb/repositories/user-repository'
 import { sendEmail } from '../../../../../utils/email/sesClient'
 import { requireFreshAuth } from '../../../../../utils/require-fresh-auth'
 
-// Token expiry: 24 hours
-const TOKEN_EXPIRY_MS = 24 * 60 * 60 * 1000
-
-// Generate secure verification token
-function generateVerificationToken(): string {
-  return randomBytes(32).toString('hex')
+/**
+ * Resolve the acting person from the session login email (primary via GSI1, then
+ * any-address fallback).
+ */
+async function resolveActingPerson(loginEmail: string) {
+  const email = loginEmail.toLowerCase()
+  let person = await personRepository.getByEmail(email)
+  if (!person) {
+    const persons = await personRepository.getAllPersonsByEmail(email)
+    person = persons[0] || null
+  }
+  return person
 }
 
 /**
@@ -43,8 +50,16 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Get the email record
-    const emailRecord = await userRepository.getEmail(session.user.email, emailId)
+    const person = await resolveActingPerson(session.user.email)
+    if (!person) {
+      return NextResponse.json(
+        { error: 'No profile found for your account' },
+        { status: 404 }
+      )
+    }
+
+    // Guard the target EMAIL# row exists and is still unverified.
+    const emailRecord = await personRepository.getEmailById(person.personId, emailId)
     if (!emailRecord) {
       return NextResponse.json(
         { error: 'Email not found' },
@@ -59,20 +74,13 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Generate token and expiry
-    const token = generateVerificationToken()
-    const expiry = new Date(Date.now() + TOKEN_EXPIRY_MS).toISOString()
-
-    // Update the email record with verification token
-    await userRepository.updateEmail(session.user.email, emailId, {
-      verificationToken: token,
-      verificationTokenExpiry: expiry,
-      verificationSentAt: new Date().toISOString(),
-    })
+    // Mint a single-use verification token in the unified TokenRepository
+    // (O(1) GSI4 lookup, atomic consume). Replaces the previous USER# token write.
+    const token = await tokenRepository.createEmailVerification(person.personId, emailRecord.email)
 
     // Build verification URL
     const baseUrl = process.env.NEXT_PUBLIC_AUTH_URL || 'https://tee-admin.com'
-    const verificationUrl = `${baseUrl}/api/user/emails/verify?token=${token}`
+    const verificationUrl = `${baseUrl}/api/user/emails/verify?token=${token.tokenValue}`
 
     // Send verification email
     const emailBody = `
@@ -133,8 +141,10 @@ Toronto East Christadelphian Ecclesia
 }
 
 /**
- * GET /api/user/emails/verify?token=xxx - Verify email with token
- * This is called when user clicks the link in their email
+ * GET /api/user/emails/verify?token=xxx - Verify email with token (link click,
+ * UNauthenticated). Consumes the unified token, then marks the matching
+ * PersonRecord EMAIL# row verified. Falls back to the legacy USER# token store
+ * for one release, to drain in-flight links minted before this change.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -145,13 +155,28 @@ export async function GET(request: NextRequest) {
       return redirectWithMessage('error', 'Invalid verification link')
     }
 
-    // Find email by token
+    // Primary path: unified TokenRepository (O(1), atomic single-use).
+    const result = await tokenRepository.verifyAndConsume(token, 'email_verification')
+    if (result.valid && result.token) {
+      await personRepository.markEmailVerifiedByAddress(result.token.personId, result.token.email)
+      return redirectWithMessage('success', 'Email verified successfully!')
+    }
+
+    // Token found but not consumable — report the reason without falling back.
+    if (result.token) {
+      if (result.error === 'expired') {
+        return redirectWithMessage('error', 'Verification link has expired. Please request a new one.')
+      }
+      return redirectWithMessage('error', 'Invalid or expired verification link')
+    }
+
+    // FALLBACK (drain window): no unified token → try the legacy USER# store for
+    // links minted before this release. Keep the `pkey` crash-fix.
     const emailRecord = await userRepository.getEmailByToken(token)
     if (!emailRecord) {
       return redirectWithMessage('error', 'Invalid or expired verification link')
     }
 
-    // Check if token has expired
     if (emailRecord.verificationTokenExpiry) {
       const expiry = new Date(emailRecord.verificationTokenExpiry)
       if (expiry < new Date()) {
@@ -159,23 +184,31 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Extract primary email from the partition key (format: USER#{primaryEmail}).
-    // These records are stored with the legacy `pkey` attribute (not `PK`), so
-    // `emailRecord.PK` is undefined at runtime — reading `.replace` off it threw a
-    // TypeError that the catch below rendered as the misleading "Verification
-    // failed. Please try again." Read `pkey` defensively and guard a missing key.
+    // Records are stored with the legacy `pkey` attribute (not `PK`), so
+    // `emailRecord.PK` is undefined at runtime — read `pkey` defensively and
+    // guard a missing key rather than throwing a misleading generic error.
     const storedPk = (emailRecord as { pkey?: string; PK?: string }).pkey ?? emailRecord.PK
     if (!storedPk) {
       return redirectWithMessage('error', 'Invalid or expired verification link')
     }
     const primaryEmail = storedPk.replace('USER#', '')
 
-    // Mark email as verified and clear token
+    // Mark legacy record verified + clear token.
     await userRepository.updateEmail(primaryEmail, emailRecord.emailId, {
       verified: true,
       verificationToken: undefined,
       verificationTokenExpiry: undefined,
     })
+
+    // Also heal the PersonRecord so the single system agrees. Best-effort.
+    try {
+      const owner = await resolveActingPerson(primaryEmail)
+      if (owner) {
+        await personRepository.markEmailVerifiedByAddress(owner.personId, emailRecord.email)
+      }
+    } catch (healErr) {
+      console.error('[user/emails/verify] PersonRecord heal on legacy verify failed (non-fatal):', healErr)
+    }
 
     return redirectWithMessage('success', 'Email verified successfully!')
   } catch (error) {

--- a/apps/next/tests/db/person-repository.test.ts
+++ b/apps/next/tests/db/person-repository.test.ts
@@ -450,6 +450,35 @@ describe('PersonRepository', () => {
         await repository.setEmailOrder('p1', [])
         expect(mockSend).not.toHaveBeenCalled()
       })
+
+      it('reordering a MULTI-email person never touches PROFILE / primaryEmail / gsi1pk (login is preserved)', async () => {
+        // A Recording Brother with several addresses re-preferences them. Reorder is
+        // display-only: it must not become an identity transfer.
+        mockSend
+          .mockResolvedValueOnce({ Attributes: {} }) // e-work
+          .mockResolvedValueOnce({ Attributes: {} }) // e-primary
+          .mockResolvedValueOnce({ Attributes: {} }) // e-personal
+
+        await repository.setEmailOrder('p1', ['e-work', 'e-primary', 'e-personal'])
+
+        expect(mockSend).toHaveBeenCalledTimes(3)
+
+        for (const call of mockSend.mock.calls) {
+          const cmd = call[0]
+          expect(cmd.type).toBe('UpdateCommand')
+          // Never writes the PROFILE row — only EMAIL# rows are reordered.
+          expect(cmd.params.Key.skey).not.toBe('PROFILE')
+          expect(cmd.params.Key.skey.startsWith('EMAIL#')).toBe(true)
+          // Never mutates the identity/login handle or its lookup index.
+          const names = Object.values(cmd.params.ExpressionAttributeNames)
+          expect(names).not.toContain('primaryEmail')
+          expect(names).not.toContain('gsi1pk')
+          expect(names).not.toContain('emailType')
+          expect(names).not.toContain('email')
+          // The only domain field written is `order` (plus base lastUpdated/version bookkeeping).
+          expect(names).toContain('order')
+        }
+      })
     })
 
     describe('markEmailVerifiedByAddress', () => {

--- a/apps/next/tests/db/person-repository.test.ts
+++ b/apps/next/tests/db/person-repository.test.ts
@@ -389,6 +389,99 @@ describe('PersonRepository', () => {
     })
   })
 
+  describe('Email consolidation methods', () => {
+    describe('getEmailById', () => {
+      it('fetches a single EMAIL# row by id', async () => {
+        const mockEmail = {
+          pkey: 'PERSON#p1',
+          skey: 'EMAIL#e1',
+          emailId: 'e1',
+          email: 'a@b.com',
+          emailType: 'secondary',
+        }
+        mockSend.mockResolvedValueOnce({ Item: mockEmail })
+
+        const result = await repository.getEmailById('p1', 'e1')
+
+        expect(result).toEqual(mockEmail)
+        expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+          type: 'GetCommand',
+          params: expect.objectContaining({
+            TableName: 'tee-admin',
+            Key: { pkey: 'PERSON#p1', skey: 'EMAIL#e1' },
+          }),
+        }))
+      })
+
+      it('returns null when the row is absent', async () => {
+        mockSend.mockResolvedValueOnce({ Item: null })
+        const result = await repository.getEmailById('p1', 'missing')
+        expect(result).toBeNull()
+      })
+    })
+
+    describe('setEmailOrder', () => {
+      it('writes order per EMAIL# row matching the given sequence, without touching identity keys', async () => {
+        mockSend
+          .mockResolvedValueOnce({ Attributes: {} }) // update e-a
+          .mockResolvedValueOnce({ Attributes: {} }) // update e-b
+
+        await repository.setEmailOrder('p1', ['e-a', 'e-b'])
+
+        expect(mockSend).toHaveBeenCalledTimes(2)
+
+        const first = mockSend.mock.calls[0][0]
+        expect(first.type).toBe('UpdateCommand')
+        expect(first.params.Key).toEqual({ pkey: 'PERSON#p1', skey: 'EMAIL#e-a' })
+        // order = index 0
+        expect(first.params.ExpressionAttributeNames['#attr0']).toBe('order')
+        expect(first.params.ExpressionAttributeValues[':val0']).toBe(0)
+        // never mutates identity/lookup keys
+        const firstNames = Object.values(first.params.ExpressionAttributeNames)
+        expect(firstNames).not.toContain('primaryEmail')
+        expect(firstNames).not.toContain('gsi1pk')
+
+        const second = mockSend.mock.calls[1][0]
+        expect(second.params.Key).toEqual({ pkey: 'PERSON#p1', skey: 'EMAIL#e-b' })
+        expect(second.params.ExpressionAttributeValues[':val0']).toBe(1)
+      })
+
+      it('is a no-op when the id list is empty', async () => {
+        await repository.setEmailOrder('p1', [])
+        expect(mockSend).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('markEmailVerifiedByAddress', () => {
+      it('sets verified=true on the matching EMAIL# row (secondary works)', async () => {
+        const rows = [
+          { pkey: 'PERSON#p1', skey: 'EMAIL#e1', emailId: 'e1', email: 'primary@x.com', emailType: 'primary', verified: true },
+          { pkey: 'PERSON#p1', skey: 'EMAIL#e2', emailId: 'e2', email: 'second@x.com', emailType: 'secondary', verified: false },
+        ]
+        mockSend
+          .mockResolvedValueOnce({ Items: rows }) // getEmails query
+          .mockResolvedValueOnce({ Attributes: {} }) // update
+
+        await repository.markEmailVerifiedByAddress('p1', 'Second@X.com')
+
+        expect(mockSend).toHaveBeenCalledTimes(2)
+        const update = mockSend.mock.calls[1][0]
+        expect(update.type).toBe('UpdateCommand')
+        expect(update.params.Key).toEqual({ pkey: 'PERSON#p1', skey: 'EMAIL#e2' })
+        const idx = Object.entries(update.params.ExpressionAttributeNames)
+          .find(([, v]) => v === 'verified')?.[0]
+          .replace('#attr', ':val')
+        expect(update.params.ExpressionAttributeValues[idx as string]).toBe(true)
+      })
+
+      it('is idempotent (no update) when the address is not on the person', async () => {
+        mockSend.mockResolvedValueOnce({ Items: [] }) // getEmails query only
+        await repository.markEmailVerifiedByAddress('p1', 'ghost@x.com')
+        expect(mockSend).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
   describe('Inter-Ecclesia Rep Methods', () => {
     describe('listInterEcclesiaReps', () => {
       it('should list all inter-ecclesia representatives', async () => {

--- a/apps/next/tests/user-emails-multi-email-migration.test.ts
+++ b/apps/next/tests/user-emails-multi-email-migration.test.ts
@@ -1,0 +1,316 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+/**
+ * GET /api/user/emails — DATA-LOSS SAFETY for multi-email people.
+ *
+ * The email-system consolidation makes the PersonRecord EMAIL# store the single
+ * source of truth, and heals historical addresses that only ever lived in the
+ * legacy USER# store via a lazy-migrate on read (see the GET handler). These
+ * tests PROVE that consolidation never drops or duplicates a person's addresses —
+ * the failure mode that matters for someone like a Recording Brother (e.g. Geoff
+ * McKay of Brampton) who has several personal emails plus a role email.
+ *
+ * The PersonRecord side is a STATEFUL mock: `addEmail` actually appends to the
+ * in-memory row set and `getEmails` returns the current set. That is deliberate —
+ * the GET handler re-reads `getEmails` AFTER migrating, so the returned response
+ * reflects exactly what the migration wrote. If the handler dropped or duplicated
+ * an address, the asserted response set would be wrong.
+ */
+
+const h = vi.hoisted(() => ({
+  auth: vi.fn(),
+  u_getEmails: vi.fn(),
+  p_getByEmail: vi.fn(),
+  p_getAllPersonsByEmail: vi.fn(),
+  p_getEmails: vi.fn(),
+  p_addEmail: vi.fn(),
+  t_getByPersonAndType: vi.fn(),
+  optInCount: vi.fn(),
+}))
+
+vi.mock('../utils/auth', () => ({ auth: h.auth }))
+vi.mock('@my/app/provider/dynamodb/repositories/user-repository', () => ({
+  userRepository: { getEmails: h.u_getEmails },
+}))
+vi.mock('@my/app/provider/dynamodb/repositories/person-repository', () => ({
+  personRepository: {
+    getByEmail: h.p_getByEmail,
+    getAllPersonsByEmail: h.p_getAllPersonsByEmail,
+    getEmails: h.p_getEmails,
+    addEmail: h.p_addEmail,
+  },
+}))
+vi.mock('@my/app/provider/dynamodb/repositories/token-repository', () => ({
+  tokenRepository: { getByPersonAndType: h.t_getByPersonAndType },
+}))
+vi.mock('../utils/email/public-topics', () => ({ getPublicOptInCount: h.optInCount }))
+
+import { GET } from '../app/api/user/emails/route'
+
+const PID = 'geoff-mckay-1'
+const PRIMARY = 'geoff@brampton.example'
+
+const GEOFF: any = { personId: PID, primaryEmail: PRIMARY }
+
+// ---- Stateful PersonRecord EMAIL# store ------------------------------------
+
+let rows: any[]
+
+/** Seed the person's existing PersonRecord EMAIL# rows. */
+function seedPersonEmails(
+  initial: Array<{ emailId: string; email: string; emailType?: string; order?: number; verified?: boolean; sesSubscribed?: boolean }>
+) {
+  rows = initial.map((r, i) => ({
+    pkey: `PERSON#${PID}`,
+    skey: `EMAIL#${r.emailId}`,
+    gsi1pk: `EMAIL#${r.email.toLowerCase()}`,
+    gsi1sk: `PERSON#${PID}`,
+    emailId: r.emailId,
+    email: r.email.toLowerCase(),
+    emailType: r.emailType ?? 'secondary',
+    order: r.order ?? i,
+    verified: r.verified ?? false,
+    sesSubscribed: r.sesSubscribed ?? false,
+    sesStatus: 'active',
+  }))
+}
+
+/** Legacy USER# EmailRecord shape returned by userRepository.getEmails. */
+function legacy(
+  items: Array<{ email: string; isPrimary?: boolean; order?: number; verified?: boolean; subscribed?: boolean }>
+) {
+  h.u_getEmails.mockResolvedValue({
+    items: items.map((r, i) => ({
+      emailId: `legacy-${i}`,
+      email: r.email,
+      isPrimary: r.isPrimary ?? false,
+      order: r.order ?? i,
+      verified: r.verified ?? false,
+      subscribed: r.subscribed,
+    })),
+  })
+}
+
+async function getJson() {
+  const res = await GET()
+  expect(res.status).toBe(200)
+  const body = await res.json()
+  return body.emails as Array<{
+    id: string
+    email: string
+    verified: boolean
+    subscribed?: boolean
+    isPrimary?: boolean
+    roleLabel?: string
+  }>
+}
+
+const addressesMigrated = () => h.p_addEmail.mock.calls.map((c) => c[1].email)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.auth.mockResolvedValue({ user: { email: PRIMARY } })
+  h.p_getByEmail.mockResolvedValue(GEOFF)
+  h.p_getAllPersonsByEmail.mockResolvedValue([GEOFF])
+  h.t_getByPersonAndType.mockResolvedValue([])
+  h.optInCount.mockResolvedValue(2)
+
+  // Stateful store wiring: addEmail appends, getEmails returns the live set.
+  rows = []
+  h.p_getEmails.mockImplementation(async () => rows.map((r) => ({ ...r })))
+  h.p_addEmail.mockImplementation(async (pid: string, rec: any) => {
+    const emailId = `migrated-${rows.length}`
+    const row = {
+      pkey: `PERSON#${pid}`,
+      skey: `EMAIL#${emailId}`,
+      gsi1pk: `EMAIL#${rec.email.toLowerCase()}`,
+      gsi1sk: `PERSON#${pid}`,
+      emailId,
+      ...rec,
+      email: rec.email.toLowerCase(),
+    }
+    rows.push(row)
+    return row
+  })
+})
+
+describe('GET /api/user/emails — multi-email consolidation (no drop, no dupe)', () => {
+  it('1) secondaries only in the legacy USER# store are ALL migrated; primary is left untouched', async () => {
+    // Login email already has its PersonRecord EMAIL# row (created at signup).
+    seedPersonEmails([{ emailId: 'p', email: PRIMARY, emailType: 'primary', order: 0, verified: true }])
+    // Legacy has the primary plus 3 secondaries that never made it onto the PersonRecord.
+    legacy([
+      { email: PRIMARY, isPrimary: true, verified: true },
+      { email: 'geoff.personal@gmail.example', order: 1, verified: true },
+      { email: 'geoffmckay@outlook.example', order: 2 },
+      { email: 'g.mckay@work.example', order: 3, verified: true },
+    ])
+
+    const emails = await getJson()
+    const set = emails.map((e) => e.email.toLowerCase())
+
+    // None lost: all four addresses present.
+    expect(set).toEqual(
+      expect.arrayContaining([
+        PRIMARY,
+        'geoff.personal@gmail.example',
+        'geoffmckay@outlook.example',
+        'g.mckay@work.example',
+      ])
+    )
+    expect(set).toHaveLength(4)
+
+    // Primary stays primary — exactly one, and it is the login email.
+    const primaries = emails.filter((e) => e.isPrimary)
+    expect(primaries).toHaveLength(1)
+    expect(primaries[0].email.toLowerCase()).toBe(PRIMARY)
+
+    // Exactly the 3 USER#-only secondaries were migrated — NOT the primary.
+    expect(h.p_addEmail).toHaveBeenCalledTimes(3)
+    expect(addressesMigrated()).toEqual(
+      expect.arrayContaining([
+        'geoff.personal@gmail.example',
+        'geoffmckay@outlook.example',
+        'g.mckay@work.example',
+      ])
+    )
+    expect(addressesMigrated()).not.toContain(PRIMARY)
+  })
+
+  it('2) addresses split across BOTH stores union with no duplicates and no loss', async () => {
+    // Already on the PersonRecord: primary + one already-healed secondary.
+    seedPersonEmails([
+      { emailId: 'p', email: PRIMARY, emailType: 'primary', order: 0, verified: true },
+      { emailId: 's1', email: 'shared@both.example', emailType: 'secondary', order: 1, verified: true },
+    ])
+    // Legacy overlaps on primary + shared@both, and adds two USER#-only addresses.
+    legacy([
+      { email: PRIMARY, isPrimary: true, verified: true },
+      { email: 'shared@both.example', order: 1, verified: true }, // overlap — must NOT duplicate
+      { email: 'legacy-only-a@x.example', order: 2, verified: true },
+      { email: 'legacy-only-b@x.example', order: 3 },
+    ])
+
+    const emails = await getJson()
+    const set = emails.map((e) => e.email.toLowerCase())
+
+    // Union by address, no duplicates.
+    expect(new Set(set).size).toBe(set.length)
+    expect(set.sort()).toEqual(
+      [PRIMARY, 'shared@both.example', 'legacy-only-a@x.example', 'legacy-only-b@x.example'].sort()
+    )
+
+    // Only the genuinely USER#-only addresses were migrated.
+    expect(h.p_addEmail).toHaveBeenCalledTimes(2)
+    expect(addressesMigrated().sort()).toEqual(['legacy-only-a@x.example', 'legacy-only-b@x.example'])
+  })
+
+  it('3) verified + subscribed + order carry over onto the migrated PersonRecord row', async () => {
+    seedPersonEmails([{ emailId: 'p', email: PRIMARY, emailType: 'primary', order: 0, verified: true }])
+    legacy([
+      { email: PRIMARY, isPrimary: true, verified: true },
+      { email: 'verified.sub@x.example', order: 7, verified: true, subscribed: true },
+    ])
+
+    const emails = await getJson()
+
+    expect(h.p_addEmail).toHaveBeenCalledTimes(1)
+    const [, rec] = h.p_addEmail.mock.calls[0]
+    expect(rec.email).toBe('verified.sub@x.example')
+    expect(rec.emailType).toBe('secondary')
+    expect(rec.verified).toBe(true)
+    expect(rec.sesSubscribed).toBe(true) // subscribed → sesSubscribed
+    expect(rec.order).toBe(7) // order carried, not defaulted
+
+    // And it surfaces in the response as verified + subscribed.
+    const migrated = emails.find((e) => e.email.toLowerCase() === 'verified.sub@x.example')!
+    expect(migrated.verified).toBe(true)
+    expect(migrated.subscribed).toBe(true)
+  })
+
+  it('4) idempotent: a second GET after everything is on the PersonRecord migrates nothing and returns the same set', async () => {
+    seedPersonEmails([
+      { emailId: 'p', email: PRIMARY, emailType: 'primary', order: 0, verified: true },
+      { emailId: 's1', email: 'a@x.example', emailType: 'secondary', order: 1, verified: true },
+      { emailId: 's2', email: 'b@x.example', emailType: 'secondary', order: 2 },
+    ])
+    // Legacy holds the same addresses — all already known, so nothing to heal.
+    legacy([
+      { email: PRIMARY, isPrimary: true, verified: true },
+      { email: 'a@x.example', order: 1, verified: true },
+      { email: 'b@x.example', order: 2 },
+    ])
+
+    const first = await getJson()
+    expect(h.p_addEmail).not.toHaveBeenCalled()
+
+    const second = await getJson()
+    expect(h.p_addEmail).not.toHaveBeenCalled()
+
+    const norm = (list: typeof first) => list.map((e) => e.email.toLowerCase()).sort()
+    expect(norm(second)).toEqual(norm(first))
+    expect(norm(first)).toEqual([PRIMARY, 'a@x.example', 'b@x.example'].sort())
+  })
+
+  it('5) a legacy address differing ONLY in case is the same address — no duplicate, no migrate', async () => {
+    seedPersonEmails([
+      { emailId: 'p', email: PRIMARY, emailType: 'primary', order: 0, verified: true },
+      { emailId: 's1', email: 'mixed.case@x.example', emailType: 'secondary', order: 1, verified: true },
+    ])
+    // Legacy carries the SAME address in a different case.
+    legacy([
+      { email: PRIMARY.toUpperCase(), isPrimary: true, verified: true },
+      { email: 'Mixed.Case@X.Example', order: 1, verified: true },
+    ])
+
+    const emails = await getJson()
+    const set = emails.map((e) => e.email.toLowerCase())
+
+    expect(new Set(set).size).toBe(set.length) // no case-only duplicate
+    expect(set.sort()).toEqual([PRIMARY, 'mixed.case@x.example'].sort())
+    expect(h.p_addEmail).not.toHaveBeenCalled()
+  })
+
+  it('6) Recording Brother: all personal addresses remain AND the role email is injected read-only (never written back)', async () => {
+    const RB_EMAIL = 'recorder@brampton-ecclesia.example'
+    h.p_getByEmail.mockResolvedValue({
+      ...GEOFF,
+      isRecordingBrother: true,
+      rbEcclesiaEmail: RB_EMAIL,
+    })
+    h.p_getAllPersonsByEmail.mockResolvedValue([
+      { ...GEOFF, isRecordingBrother: true, rbEcclesiaEmail: RB_EMAIL },
+    ])
+
+    // Geoff's real personal addresses, already consolidated onto the PersonRecord.
+    seedPersonEmails([
+      { emailId: 'p', email: PRIMARY, emailType: 'primary', order: 0, verified: true },
+      { emailId: 's1', email: 'geoff.personal@gmail.example', emailType: 'secondary', order: 1, verified: true },
+      { emailId: 's2', email: 'g.mckay@work.example', emailType: 'secondary', order: 2, verified: true },
+    ])
+    legacy([]) // nothing left in the legacy store
+
+    const emails = await getJson()
+    const set = emails.map((e) => e.email.toLowerCase())
+
+    // All three personal addresses still present, alongside the injected role email.
+    expect(set).toEqual(
+      expect.arrayContaining([
+        PRIMARY,
+        'geoff.personal@gmail.example',
+        'g.mckay@work.example',
+        RB_EMAIL,
+      ])
+    )
+    expect(set).toHaveLength(4)
+
+    // The RB entry is read-only role metadata, not a personal address.
+    const rb = emails.find((e) => e.email.toLowerCase() === RB_EMAIL)!
+    expect(rb.roleLabel).toBe('Recording Brother')
+    expect(rb.isPrimary).toBeFalsy()
+
+    // The role email is NOT written back onto the personal EMAIL# set.
+    expect(h.p_addEmail).not.toHaveBeenCalled()
+    expect(addressesMigrated()).not.toContain(RB_EMAIL)
+  })
+})

--- a/apps/next/tests/user-emails-route.test.ts
+++ b/apps/next/tests/user-emails-route.test.ts
@@ -1,27 +1,28 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
 /**
- * POST /api/user/emails — adding a secondary email (Issue #129).
+ * POST /api/user/emails — adding a secondary email, PersonRecord-only.
  *
- * The fix: the address must be mirrored onto the PersonRecord as a SECONDARY
- * EMAIL# item so it resolves (GSI1) to this person — otherwise the verify/lookup
- * flow can't find the owner and mints a duplicate orphan profile. And attaching
- * an address that already belongs to a DIFFERENT person is a collision (409).
+ * Email is consolidated onto the PersonRecord EMAIL# store (the single system):
+ * the address is written ONLY to the PersonRecord as a SECONDARY item (no legacy
+ * USER# write). Guards: attaching an address that already belongs to a DIFFERENT
+ * person is a collision (409); re-adding an address this person already has is a
+ * duplicate (409).
  */
 
 const h = vi.hoisted(() => ({
   auth: vi.fn(),
   u_getEmails: vi.fn(),
-  u_addEmail: vi.fn(),
   p_getByEmail: vi.fn(),
   p_getAllPersonsByEmail: vi.fn(),
   p_getEmails: vi.fn(),
   p_addEmail: vi.fn(),
+  t_getByPersonAndType: vi.fn(),
 }))
 
 vi.mock('../utils/auth', () => ({ auth: h.auth }))
 vi.mock('@my/app/provider/dynamodb/repositories/user-repository', () => ({
-  userRepository: { getEmails: h.u_getEmails, addEmail: h.u_addEmail },
+  userRepository: { getEmails: h.u_getEmails },
 }))
 vi.mock('@my/app/provider/dynamodb/repositories/person-repository', () => ({
   personRepository: {
@@ -31,7 +32,9 @@ vi.mock('@my/app/provider/dynamodb/repositories/person-repository', () => ({
     addEmail: h.p_addEmail,
   },
 }))
-vi.mock('../utils/email/sesClient', () => ({ sendEmail: vi.fn() }))
+vi.mock('@my/app/provider/dynamodb/repositories/token-repository', () => ({
+  tokenRepository: { getByPersonAndType: h.t_getByPersonAndType },
+}))
 vi.mock('../utils/email/public-topics', () => ({ getPublicOptInCount: vi.fn() }))
 
 import { POST } from '../app/api/user/emails/route'
@@ -49,11 +52,11 @@ beforeEach(() => {
   vi.clearAllMocks()
   h.auth.mockResolvedValue(ME)
   h.u_getEmails.mockResolvedValue({ items: [] })
-  h.u_addEmail.mockResolvedValue(undefined)
   h.p_getByEmail.mockResolvedValue(GORD)
   h.p_getAllPersonsByEmail.mockResolvedValue([]) // address free
   h.p_getEmails.mockResolvedValue([])
-  h.p_addEmail.mockResolvedValue(undefined)
+  h.p_addEmail.mockResolvedValue({ emailId: 'new-email-id', email: 'gord@gmail.com', emailType: 'secondary' })
+  h.t_getByPersonAndType.mockResolvedValue([])
 })
 
 describe('POST /api/user/emails', () => {
@@ -78,31 +81,31 @@ describe('POST /api/user/emails', () => {
     expect(res.status).toBe(400)
   })
 
-  it('mirrors the address onto the PersonRecord as a SECONDARY email', async () => {
+  it('writes the address to the PersonRecord ONLY, as a SECONDARY email', async () => {
     const res = await POST(req({ email: 'Gord@Gmail.com' }))
     expect(res.status).toBe(200)
-    // legacy USER# store still written
-    expect(h.u_addEmail).toHaveBeenCalledTimes(1)
-    // NEW: PersonRecord EMAIL# item written, lowercased, as secondary
+    const body = await res.json()
+    expect(body.emailId).toBe('new-email-id')
+    // PersonRecord EMAIL# item written, lowercased, as secondary
     expect(h.p_addEmail).toHaveBeenCalledTimes(1)
     const [pid, rec] = h.p_addEmail.mock.calls[0]
     expect(pid).toBe('gord-1')
     expect(rec.email).toBe('gord@gmail.com')
     expect(rec.emailType).toBe('secondary')
+    expect(rec.verified).toBe(false)
   })
 
   it('409 when the address already belongs to a DIFFERENT person', async () => {
     h.p_getAllPersonsByEmail.mockResolvedValue([{ personId: 'someone-else' }])
     const res = await POST(req({ email: 'shared@example.com' }))
     expect(res.status).toBe(409)
-    expect(h.u_addEmail).not.toHaveBeenCalled()
     expect(h.p_addEmail).not.toHaveBeenCalled()
   })
 
-  it('does not double-add when the person already has the address', async () => {
-    h.p_getEmails.mockResolvedValue([{ email: 'gord@gmail.com', emailType: 'secondary' }])
+  it('409 when this person already has the address (duplicate)', async () => {
+    h.p_getEmails.mockResolvedValue([{ emailId: 'x', email: 'gord@gmail.com', emailType: 'secondary' }])
     const res = await POST(req({ email: 'gord@gmail.com' }))
-    expect(res.status).toBe(200)
+    expect(res.status).toBe(409)
     expect(h.p_addEmail).not.toHaveBeenCalled()
   })
 })

--- a/packages/app/provider/dynamodb/repositories/person-repository.ts
+++ b/packages/app/provider/dynamodb/repositories/person-repository.ts
@@ -384,6 +384,51 @@ export class PersonRepository extends BaseRepository<PersonRecord> {
     return record
   }
 
+  /**
+   * Fetch a single EMAIL# row by its id (for existence / primary guards).
+   */
+  async getEmailById(personId: string, emailId: string): Promise<PersonEmailRecord | null> {
+    const pk = `PERSON#${personId}`
+    const sk = `EMAIL#${emailId}`
+    return this.get(pk, sk) as unknown as Promise<PersonEmailRecord | null>
+  }
+
+  /**
+   * Set the display `order` on each EMAIL# row to match the given id sequence.
+   * This is DISPLAY ordering only ("set as preferred" moves an address to the
+   * front) — it MUST NOT touch PROFILE.primaryEmail or any EMAIL# gsi1pk, since
+   * changing which address is preferred for display is not an identity transfer.
+   */
+  async setEmailOrder(personId: string, orderedEmailIds: string[]): Promise<void> {
+    const pk = `PERSON#${personId}`
+    for (let i = 0; i < orderedEmailIds.length; i++) {
+      await this.update(
+        pk,
+        `EMAIL#${orderedEmailIds[i]}`,
+        { order: i } as unknown as Partial<PersonRecord>
+      )
+    }
+  }
+
+  /**
+   * Mark the EMAIL# row matching a given address as verified. Unlike
+   * `markEmailVerified` (which only flips the `emailType==='primary'` row and the
+   * PROFILE.emailVerified stamp), this works for SECONDARY addresses too, so a
+   * verification link for an added address lands on the right row. Idempotent:
+   * a no-op if the address isn't on the person.
+   */
+  async markEmailVerifiedByAddress(personId: string, email: string): Promise<void> {
+    const target = email.toLowerCase()
+    const emails = await this.getEmails(personId)
+    const match = emails.find(e => e.email.toLowerCase() === target)
+    if (!match) return
+    await this.update(
+      match.pkey,
+      match.skey,
+      { verified: true } as unknown as Partial<PersonRecord>
+    )
+  }
+
   /** Default grace before a demoted former-primary email may be archived. */
   static readonly EMAIL_DEMOTE_GRACE_MS = 14 * 24 * 60 * 60 * 1000
 


### PR DESCRIPTION
The recurring "two systems for one job" bug. The profile read/wrote a legacy `USER#` email store that drifts from **PersonRecords** — the documented single source of truth. This consolidates onto PersonRecords + the unified TokenRepository.

**A full prod DynamoDB backup was taken first** (native on-demand backup `AVAILABLE` + encrypted S3 JSON of all 3,822 items / 176 people). Worst case = clean restore.

## Why it can't break login
Auth/login runs **entirely** on `personRepository` and never reads `USER#` (verified). Newsletter/SES/directory read PersonRecord `EMAIL#`, not `USER#`. The email-change flow is already PersonRecords. Blast radius = the 3 files below.

## What changed
- **`personRepository`** +3 methods: `setEmailOrder` (display order only — **never** touches `primaryEmail`/`gsi1pk`), `markEmailVerifiedByAddress` (works for secondaries), `getEmailById`.
- **`/api/user/emails`**: GET sources from PersonRecords and **lazy-migrates on read** any `USER#`-only address into an `EMAIL#` (per-session, additive, idempotent — no batch job, no address can vanish); keeps the subscription count + read-only **Recording Brother** injection; derives `verificationSentAt` from an active token. POST/PUT/DELETE = PersonRecords only, keeping fresh-auth gates + the cross-person collision guard.
- **`/api/user/emails/verify`**: TokenRepository (`createEmailVerification` + `verifyAndConsume`, O(1) — replaces a full-table scan); **one-release fallback** to the legacy `USER#` token to drain in-flight links (pkey crash-fix kept).
- **admin contacts route**: verify token via TokenRepository.
- Legacy `userRepository` email methods left as dead code for a later soak-cleanup.

## ⚠️ Please review — auth-adjacent choices
1. **Lazy-migrate performs writes on a GET** (idempotent, non-fatal, self-healing). Heals real data, but a read can mutate — could be flag-gated if you'd rather.
2. **Verify GET fallback still writes the legacy `USER#`** during the one-release drain window — remove in the soak-cleanup.
3. **POST/PUT/DELETE now 404** if a session's email has no PersonRecord (shouldn't happen since login is PersonRecord-based, but it's a new failure surface).

## Verification
Typecheck clean; build compiles; `person-repository` (28) + `user-emails-route` (6) + adjacent suites green. Reviewed the unauthenticated verify handler by hand (token-first, expired/used reported without double-processing, legacy fallback intact).

**Recommend reviewing before merge/deploy given it's auth-adjacent — I have not merged it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)