### PR TITLE
Step-up modal: reorder + WCAG fix + show which email, and add Facebook login

### DIFF
--- a/EXTERNAL_CHANGES.md
+++ b/EXTERNAL_CHANGES.md
@@ -11,7 +11,25 @@ Changes in this file flag code modifications that require **matching manual upda
 
 ## Pending
 
-_(none)_
+### Meta / Facebook Login — OAuth provider for sign-in + step-up "Confirm it's you"
+- **Date**: 2026-08-10
+- **Branch**: `feat/verify-modal-and-facebook`
+- **Code change**: Added a conditional `FacebookProvider` to `apps/next/utils/auth.ts` (registered ONLY when both `FACEBOOK_CLIENT_ID` and `FACEBOOK_CLIENT_SECRET` are set) and a "Continue with Facebook" button in the `<Verify>` step-up modal (`apps/next/components/verify/verify.tsx`), gated on the client flag `NEXT_PUBLIC_FACEBOOK_ENABLED === 'true'`.
+- **Why it's safe today**: With the env vars unset the provider is not registered (no `/api/auth/callback/facebook` route, nothing to break at build or runtime) and the button stays hidden. Nothing ships to prod as a dead button.
+- **External action** (done by the site owner on the Meta side):
+  1. Create a Meta/Facebook app at https://developers.facebook.com → add the **Facebook Login** product.
+  2. Set **Valid OAuth Redirect URIs**:
+     - `https://tee-admin.com/api/auth/callback/facebook`
+     - `https://echadhub.org/api/auth/callback/facebook`
+     - Vercel preview pattern: `https://*.vercel.app/api/auth/callback/facebook` (Meta may not accept a wildcard — if so, add each preview URL you actively test, e.g. `https://tee-admin-<hash>-ken-eassons-projects.vercel.app/api/auth/callback/facebook`).
+  3. Copy the **App ID** and **App Secret** from Settings → Basic.
+  4. On **BOTH** Vercel projects (`tee-admin` and `echadhub`), set:
+     - `FACEBOOK_CLIENT_ID` = App ID
+     - `FACEBOOK_CLIENT_SECRET` = App Secret
+     - `NEXT_PUBLIC_FACEBOOK_ENABLED` = `true`
+     Then redeploy each project so the provider registers and the button appears.
+- **Impact if missed**: None until you finish setup — provider absent, button hidden. Once env vars are set, both the sign-in and step-up flows offer Facebook. Note the app must be taken **Live** (not Development mode) in the Meta dashboard for non-test users to sign in.
+- **Status**: PENDING
 
 ## Known Issues (not deploy-blocking)
 

--- a/apps/next/components/verify/verify.tsx
+++ b/apps/next/components/verify/verify.tsx
@@ -3,20 +3,24 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { signIn, useSession } from 'next-auth/react'
 import { useHydrated } from '@my/app/hooks/use-hydrated'
-import { YStack, XStack, Text, Heading, Button, Paragraph, Input, Separator } from '@my/ui'
+import { YStack, XStack, Text, Heading, Button, Paragraph, Input, Separator, Label } from '@my/ui'
+import { maskEmail } from '@/utils/mask-email'
 
 /**
  * <Verify> — the reusable step-up challenge (Epic #84, slice B).
  *
  * Elevates a `recognized` (or stale `authenticated`) viewer to a freshly-proven
  * `authenticated` session at the moment a sensitive action or page demands it.
- * Offers, in order of convenience:
- *   1. Google re-auth   — one tap if they're a Google account (redirects out and
- *      back; the return re-stamps `authTime`).
+ * Every method confirms the ONE on-file address (shown masked) — never a new
+ * address — so it's unambiguous which inbox/credentials are being proven.
+ * Offers, in order presented:
+ *   1. OTP              — "Email me a code" to the ON-FILE address only, FIRST.
+ *      This is the forward-safety anchor: a forwarder holding the email link can
+ *      VIEW, but only the true addressee receives the code, so only they can ACT.
  *   2. Password         — re-enter the on-file password (no redirect).
- *   3. OTP              — a 6-digit code to the ON-FILE address only. This is the
- *      forward-safety anchor: a forwarder holding the email link can VIEW, but
- *      only the true addressee receives the code, so only they can ACT.
+ *   3. Social re-auth   — Google / Facebook, one tap (redirects out and back;
+ *      the return re-stamps `authTime`). Facebook only appears once configured
+ *      (`NEXT_PUBLIC_FACEBOOK_ENABLED === 'true'`).
  *
  * On success the caller's `onVerified` fires — the caller then retries whatever
  * triggered the challenge. The server is the real boundary (`requireFreshAuth`);
@@ -88,12 +92,23 @@ export function Verify({
   const showGoogle = methods.includes('google')
   const showPassword = methods.includes('password')
   const showOtp = methods.includes('otp')
+  // Facebook is client-gated on a public flag so no dead button ships before the
+  // Meta app + Vercel env vars are configured (see EXTERNAL_CHANGES.md).
+  const showFacebook =
+    showGoogle && process.env.NEXT_PUBLIC_FACEBOOK_ENABLED === 'true'
+  const showSocial = showGoogle || showFacebook
+  const maskedEmail = targetEmail ? maskEmail(targetEmail) : ''
 
-  // --- Google re-auth: redirects out; the return re-stamps authTime. ---
+  // --- Social re-auth: redirects out; the return re-stamps authTime. ---
+  const socialCallbackUrl = () =>
+    returnTo ?? (typeof window !== 'undefined' ? window.location.href : '/')
+
   const handleGoogle = useCallback(() => {
-    const callbackUrl =
-      returnTo ?? (typeof window !== 'undefined' ? window.location.href : '/')
-    signIn('google', { callbackUrl })
+    signIn('google', { callbackUrl: socialCallbackUrl() })
+  }, [returnTo])
+
+  const handleFacebook = useCallback(() => {
+    signIn('facebook', { callbackUrl: socialCallbackUrl() })
   }, [returnTo])
 
   // --- Password re-entry: no redirect; onVerified on success. ---
@@ -199,7 +214,7 @@ export function Verify({
         <YStack gap="$2" alignItems="center">
           <Heading size="$7" color="$color12">Enter your code</Heading>
           <Paragraph color="$color11" textAlign="center">
-            We sent a 6-digit code to <Text fontWeight="bold" color="$color12">{targetEmail}</Text>.
+            We sent a code to <Text fontWeight="bold" color="$color12">{maskedEmail}</Text>.
           </Paragraph>
         </YStack>
 
@@ -284,60 +299,24 @@ export function Verify({
       <YStack gap="$2" alignItems="center">
         <Heading size="$7" color="$color12">Confirm it’s you</Heading>
         <Paragraph color="$color11" textAlign="center">
-          {reason ? `Please confirm your identity ${reason}.` : 'Please confirm your identity to continue.'}
+          To protect you, we need to confirm the email address we have on file
+          {reason ? ` ${reason}` : ''}.
         </Paragraph>
+        {maskedEmail ? (
+          <Text fontWeight="700" fontSize="$5" color="$color12">
+            {maskedEmail}
+          </Text>
+        ) : null}
       </YStack>
 
       <YStack gap="$4">
-        {showGoogle ? (
-          <Button
-            onPress={handleGoogle}
-            size="$4"
-            variant="outlined"
-            borderColor="$borderColor"
-            hoverStyle={{ backgroundColor: '$backgroundHover', borderColor: '$borderColor' }}
-          >
-            Continue with Google
-          </Button>
-        ) : null}
+        <Text fontSize="$2" color="$color11" textTransform="uppercase" letterSpacing={1}>
+          Pick one
+        </Text>
 
-        {showPassword ? (
-          <YStack gap="$2">
-            <Text fontWeight="600" color="$color12">Password</Text>
-            <Input
-              {...INPUT_STYLE}
-              value={password}
-              onChangeText={(val: string) => {
-                setPassword(val)
-                clearError()
-              }}
-              placeholder="Enter your password"
-              autoComplete="current-password"
-              secureTextEntry
-              size="$4"
-            />
-            <Button
-              onPress={handlePassword}
-              size="$4"
-              disabled={loading}
-              backgroundColor="$blue10"
-              color="white"
-              hoverStyle={{ backgroundColor: '$blue11' }}
-            >
-              {loading ? 'Confirming…' : 'Confirm with password'}
-            </Button>
-          </YStack>
-        ) : null}
-
+        {/* 1 — Email me a code (OTP), FIRST. Sends then reveals the code field. */}
         {showOtp ? (
-          <YStack gap="$4">
-            {showGoogle || showPassword ? (
-              <XStack alignItems="center" gap="$3">
-                <Separator flex={1} />
-                <Text fontSize="$2" color="$color11">OR</Text>
-                <Separator flex={1} />
-              </XStack>
-            ) : null}
+          <YStack gap="$1">
             <Button
               onPress={sendOtp}
               size="$4"
@@ -346,8 +325,83 @@ export function Verify({
               borderColor="$borderColor"
               hoverStyle={{ backgroundColor: '$backgroundHover', borderColor: '$borderColor' }}
             >
-              {loading ? 'Sending…' : 'Email me a 6-digit code'}
+              {loading ? 'Sending…' : 'Email me a code'}
             </Button>
+            {maskedEmail ? (
+              <Text fontSize="$2" color="$color11" textAlign="center">
+                sent to {maskedEmail}
+              </Text>
+            ) : null}
+          </YStack>
+        ) : null}
+
+        {/* 2 — Re-enter your password. Real <Label>-grade text, compact one-row input + Verify. */}
+        {showPassword ? (
+          <YStack gap="$2">
+            <Label htmlFor="verify-password" fontWeight="600" color="$color12">
+              Re-enter your password
+            </Label>
+            <XStack gap="$2" alignItems="center">
+              <Input
+                {...INPUT_STYLE}
+                flex={1}
+                id="verify-password"
+                value={password}
+                onChangeText={(val: string) => {
+                  setPassword(val)
+                  clearError()
+                }}
+                autoComplete="current-password"
+                secureTextEntry
+                size="$4"
+                onSubmitEditing={handlePassword}
+              />
+              <Button
+                onPress={handlePassword}
+                size="$4"
+                disabled={loading}
+                backgroundColor="$blue10"
+                color="white"
+                hoverStyle={{ backgroundColor: '$blue11' }}
+              >
+                {loading ? '…' : 'Verify'}
+              </Button>
+            </XStack>
+          </YStack>
+        ) : null}
+
+        {/* 3 — OR divider, then social buttons, LAST. */}
+        {showSocial ? (
+          <YStack gap="$3">
+            {showOtp || showPassword ? (
+              <XStack alignItems="center" gap="$3">
+                <Separator flex={1} />
+                <Text fontSize="$2" color="$color11">OR</Text>
+                <Separator flex={1} />
+              </XStack>
+            ) : null}
+            {showGoogle ? (
+              <Button
+                onPress={handleGoogle}
+                size="$4"
+                variant="outlined"
+                borderColor="$borderColor"
+                hoverStyle={{ backgroundColor: '$backgroundHover', borderColor: '$borderColor' }}
+              >
+                Continue with Google
+              </Button>
+            ) : null}
+            {showFacebook ? (
+              <Button
+                onPress={handleFacebook}
+                size="$4"
+                variant="outlined"
+                borderColor="$borderColor"
+                hoverStyle={{ backgroundColor: '$backgroundHover', borderColor: '$borderColor' }}
+              >
+                Continue with Facebook
+              </Button>
+            ) : null}
           </YStack>
         ) : null}
 

--- a/apps/next/utils/auth.ts
+++ b/apps/next/utils/auth.ts
@@ -4,6 +4,7 @@ import { DynamoDBDocument } from '@aws-sdk/lib-dynamodb'
 import NextAuth, { type NextAuthConfig, type User, type Session } from 'next-auth'
 import type { JWT } from 'next-auth/jwt'
 import GoogleProvider from 'next-auth/providers/google'
+import FacebookProvider from 'next-auth/providers/facebook'
 import CredentialsProvider from 'next-auth/providers/credentials'
 import { headers } from 'next/headers'
 import { jwtVerify } from 'jose'
@@ -45,16 +46,36 @@ const client = DynamoDBDocument.from(new DynamoDB(dbClientConfig), {
   },
 })
 
+// Providers are assembled here so optional OAuth providers can be added
+// conditionally — only when their credentials are actually configured. This
+// keeps builds and runtime healthy while a provider is un-provisioned.
+const authProviders: NextAuthConfig['providers'] = [
+  GoogleProvider({
+    clientId: process.env.GOOGLE_CLIENT_ID as string,
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+  }),
+]
+
+// Facebook — only registered when BOTH the App ID and App Secret are present.
+// Unconfigured, the provider is simply absent (no dead callback route), Google
+// has no `authorize` step so Facebook (also OAuth) resolves the PersonRecord via
+// the shared signIn/jwt callbacks and defaults to `assurance: 'authenticated'`.
+if (process.env.FACEBOOK_CLIENT_ID && process.env.FACEBOOK_CLIENT_SECRET) {
+  authProviders.push(
+    FacebookProvider({
+      clientId: process.env.FACEBOOK_CLIENT_ID,
+      clientSecret: process.env.FACEBOOK_CLIENT_SECRET,
+    })
+  )
+}
+
 export const authOptions: NextAuthConfig = {
   trustHost: true,
   session: {
     strategy: 'jwt' as const,
   },
   providers: [
-    GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID as string,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
-    }),
+    ...authProviders,
     CredentialsProvider({
       name: 'credentials',
       credentials: {


### PR DESCRIPTION
Reworks the 'Confirm it's you' step-up modal and adds Facebook as a login/step-up option.

## Modal (per feedback on the screenshot)
- **Says which email** — subtitle 'we need to confirm the email address we have on file' + the on-file address shown **masked**; it confirms your *current* login, not the new address you're adding.
- **Reordered** to ① **Email me a code** (dropped '6-digit'), ② **Re-enter your password**, ③ **OR** — [Continue with Google] [Continue with Facebook].
- **WCAG fix** — the password field's greyed placeholder-as-label is replaced with a real `<Label>` 'Re-enter your password'; input + Verify on one row.

## Facebook login
- Conditional `FacebookProvider` — registered **only** when `FACEBOOK_CLIENT_ID`+`FACEBOOK_CLIENT_SECRET` are set (build proven safe with them unset); button gated on `NEXT_PUBLIC_FACEBOOK_ENABLED`. Flows through the existing Google-style callbacks.
- **You must do the Meta side** — see `EXTERNAL_CHANGES.md`: create the Meta app + Facebook Login, set OAuth redirect URIs, and set the three env vars on both Vercel projects. Nothing breaks until then (button stays hidden).

## Note
Confirmed the step-up only fires for **stale** sessions — a fresh Google login already skips it (no change needed).

Typecheck clean; build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)